### PR TITLE
Fix green lightning sends

### DIFF
--- a/src/components/modals/SendModal.tsx
+++ b/src/components/modals/SendModal.tsx
@@ -126,7 +126,7 @@ export const SendModal = ({ isSendModalOpen, setIsSendModalOpen }: SendModalProp
                   addTransaction({
                      type: 'lightning',
                      transaction: {
-                        amount: meltQuote!.amount,
+                        amount: -meltQuote!.amount,
                         unit: 'usd',
                         mint: activeWallet.url,
                         status: TxStatus.PAID,


### PR DESCRIPTION
- added pwa configuration (#35)
- add qrcode scanner for sending to bolt11 (#37)
- update pwa loga & change manifest name (#39)
- add qr codes back to sendecashmodal (#40)
- change pwa name
- process invoice right after scan
- More pwa updates (#42)
- change theme color
- bug fix: get proofs only for active wallet keyset
- Scan QR to receive tokens (#44)
- add transaction history + ability to reclaim unspent tokens (#45)
- .
- lightning send amount should be negative
