### PR TITLE
Only show successful lightning txes in history

### DIFF
--- a/src/components/buttons/lightning/Receive.tsx
+++ b/src/components/buttons/lightning/Receive.tsx
@@ -113,20 +113,6 @@ const Receive = () => {
             mintUrl: activeWallet.url,
          });
 
-         // Add transaction to history as pending
-         dispatch(
-            addTransaction({
-               type: 'lightning',
-               transaction: {
-                  amount: amountUsdCents,
-                  date: new Date().toLocaleString(),
-                  status: TxStatus.PENDING,
-                  mint: activeWallet.url,
-                  quote,
-               },
-            }),
-         );
-
          const pollingResponse = await axios.post(
             `${process.env.NEXT_PUBLIC_PROJECT_URL}/api/invoice/polling/${quote}`,
             {
@@ -143,7 +129,18 @@ const Receive = () => {
             setInvoiceToPay('');
             setAmount('');
             // dispatch(setSuccess(`Received $${Number(amount).toFixed(2)}!`));
-            dispatch(updateTransactionStatus({ type: 'lightning', quote, status: TxStatus.PAID })); // TODO: move this to updateProofsAndBalance logic
+            dispatch(
+               addTransaction({
+                  type: 'lightning',
+                  transaction: {
+                     amount: amountUsdCents,
+                     date: new Date().toLocaleString(),
+                     status: TxStatus.PAID,
+                     mint: activeWallet.url,
+                     quote,
+                  },
+               }),
+            );
          }
       } catch (error) {
          console.error('Error receiving ', error);

--- a/src/components/icons/ClockIcon.tsx
+++ b/src/components/icons/ClockIcon.tsx
@@ -1,0 +1,20 @@
+const ClockIcon = () => {
+   return (
+      <svg
+         xmlns='http://www.w3.org/2000/svg'
+         fill='none'
+         viewBox='0 0 24 24'
+         strokeWidth={1.5}
+         stroke='currentColor'
+         className='w-6 h-6'
+      >
+         <path
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            d='M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'
+         />
+      </svg>
+   );
+};
+
+export default ClockIcon;

--- a/src/components/icons/XMarkIcon.tsx
+++ b/src/components/icons/XMarkIcon.tsx
@@ -1,0 +1,3 @@
+import { XMarkIcon } from '@heroicons/react/20/solid';
+
+export default XMarkIcon;

--- a/src/components/modals/SendModal.tsx
+++ b/src/components/modals/SendModal.tsx
@@ -78,7 +78,6 @@ export const SendModal = ({ isSendModalOpen, setIsSendModalOpen }: SendModalProp
 
          setAmountSat((quote.amount / 100).toFixed(2));
          setEstimatedFee(quote.fee_reserve);
-         addToast(`Estimated fee: ${quote.fee_reserve} sats`, 'info');
          setCurrentTab(Tabs.Fee);
       } catch (error) {
          console.error(error);
@@ -102,20 +101,22 @@ export const SendModal = ({ isSendModalOpen, setIsSendModalOpen }: SendModalProp
       console.log('using active wallet', activeWallet);
 
       try {
-         await payInvoice(invoice, meltQuote).then(() => {
-            dispatch(
-               addTransaction({
-                  type: 'lightning',
-                  transaction: {
-                     amount: -meltQuote!.amount,
-                     unit: 'usd',
-                     mint: activeWallet.url,
-                     status: TxStatus.PAID,
-                     date: new Date().toLocaleString(),
-                     quote: meltQuote!.quote,
-                  },
-               }),
-            );
+         await payInvoice(invoice, meltQuote).then(res => {
+            if (res) {
+               dispatch(
+                  addTransaction({
+                     type: 'lightning',
+                     transaction: {
+                        amount: -meltQuote!.amount,
+                        unit: 'usd',
+                        mint: activeWallet.url,
+                        status: TxStatus.PAID,
+                        date: new Date().toLocaleString(),
+                        quote: meltQuote!.quote,
+                     },
+                  }),
+               );
+            }
          });
       } catch (error) {
          console.error(error);
@@ -273,9 +274,10 @@ export const SendModal = ({ isSendModalOpen, setIsSendModalOpen }: SendModalProp
             return (
                <Modal.Body>
                   <div className=' text-sm text-black mb-4'>
-                     Estimated Fee: ${estimatedFee}
+                     Estimated Fee: ${(estimatedFee! / 100).toFixed(2)}
                      <br />
-                     Total amount to pay: ${parseFloat(amountSat) + estimatedFee!}
+                     Total amount to pay: $
+                     {(parseFloat(amountSat) + estimatedFee! / 100).toFixed(2)}
                   </div>
                   <div className='flex justify-around'>
                      <Button color='failure' onClick={handleBackClick}>

--- a/src/components/transactionHistory/TransactionHistoryDrawer.tsx
+++ b/src/components/transactionHistory/TransactionHistoryDrawer.tsx
@@ -12,29 +12,11 @@ import HistoryTable from './HistoryTable';
 import { CashuMint, CashuWallet, Proof, getDecodedToken } from '@cashu/cashu-ts';
 import { customDrawerTheme } from '@/themes/drawerTheme';
 import { XMarkIcon } from '@heroicons/react/20/solid';
+import ClockIcon from '@/components/icons/ClockIcon';
 
 type NewType = FC<ComponentProps<'svg'>>;
 
 const NoIcon: NewType = () => null;
-
-const ClockIcon = () => {
-   return (
-      <svg
-         xmlns='http://www.w3.org/2000/svg'
-         fill='none'
-         viewBox='0 0 24 24'
-         strokeWidth={1.5}
-         stroke='currentColor'
-         className='w-6 h-6'
-      >
-         <path
-            strokeLinecap='round'
-            strokeLinejoin='round'
-            d='M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z'
-         />
-      </svg>
-   );
-};
 
 const TransactionHistoryDrawer = () => {
    const [hidden, setHidden] = useState(true);

--- a/src/components/transactionHistory/TransactionHistoryDrawer.tsx
+++ b/src/components/transactionHistory/TransactionHistoryDrawer.tsx
@@ -11,7 +11,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import HistoryTable from './HistoryTable';
 import { CashuMint, CashuWallet, Proof, getDecodedToken } from '@cashu/cashu-ts';
 import { customDrawerTheme } from '@/themes/drawerTheme';
-import { XMarkIcon } from '@heroicons/react/20/solid';
+import XMarkIcon from '@/components/icons/XMarkIcon';
 import ClockIcon from '@/components/icons/ClockIcon';
 
 type NewType = FC<ComponentProps<'svg'>>;


### PR DESCRIPTION
Before, lgithning transactions were getting added as pending, and then if they ailed, the pending payments still looked liked a success. Now, the lightining payments only get added to tx history when they are completed