### PR TITLE
Adding PWA RefreshButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before you begin, ensure you have the following tools installed and running:
 3. Update .env.example -> .env
 
    ```bash
-   cp .env.example -> .env
+   cp .env.example .env
    ```
 
 4. Use Docker Compose to build and run the containers:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Before you begin, ensure you have the following tools installed and running:
 
    ```
 
-3. Use Docker Compose to build and run the containers:
+3. Update .env.example -> .env
+
+   ```bash
+   cp .env.example -> .env
+   ```
+
+4. Use Docker Compose to build and run the containers:
 
    ```bash
    docker-compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+# version: '3' --docker-compose.yml: `version` is obsolete 
 services:
    db:
       container_name: quick-cashu-db

--- a/src/components/EcashTapButton.tsx
+++ b/src/components/EcashTapButton.tsx
@@ -1,0 +1,100 @@
+import { useCashu } from '@/hooks/useCashu';
+import { useToast } from '@/hooks/useToast';
+import { useWallet } from '@/hooks/useWallet';
+import { RootState } from '@/redux/store';
+import { Modal } from 'flowbite-react';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import SendEcashModalBody from './modals/SendEcashModalBody';
+
+export const BanknoteIcon = ({ className }: { className?: string }) => (
+   <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox='0 0 24 24'
+      strokeWidth={1.5}
+      stroke='currentColor'
+      className={className}
+   >
+      <path
+         strokeLinecap='round'
+         strokeLinejoin='round'
+         d='M2.25 18.75a60.07 60.07 0 0 1 15.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 0 1 3 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 0 0-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 0 1-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 0 0 3 15h-.75M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm3 0h.008v.008H18V10.5Zm-12 0h.008v.008H6V10.5Z'
+      />
+   </svg>
+);
+
+interface EcashTapButtonProps {
+   isMobile: boolean;
+}
+
+const EcashTapButton = ({ isMobile }: EcashTapButtonProps) => {
+   const [creatingToken, setCreatingToken] = useState(false);
+   const [tokenToSend, setTokenToSend] = useState<string | null>(null);
+
+   const { createSendableEcashToken } = useCashu();
+   const { ecashTapsEnabled, defaultTapAmount } = useSelector((state: RootState) => state.settings);
+
+   const { getActiveWallet } = useWallet();
+   const { addToast } = useToast();
+
+   if (!ecashTapsEnabled) return null;
+
+   const handleEcashTapClicked = async () => {
+      try {
+         const wallet = getActiveWallet();
+
+         setCreatingToken(true);
+
+         const token = await createSendableEcashToken(defaultTapAmount, wallet);
+
+         if (!token) {
+            addToast('Error creating tap token', 'error');
+            return;
+         }
+
+         if (isMobile) {
+            console.log('Sending token to mobile');
+            setTokenToSend(token);
+         } else {
+            navigator.clipboard
+               .writeText(
+                  `${window.location.protocol}//${window.location.host}/wallet?token=${token}`,
+               )
+               .then(() =>
+                  addToast(
+                     `$${(defaultTapAmount / 100).toFixed(2)} copied to clipboard`,
+                     'success',
+                  ),
+               )
+               .catch(e => addToast('Error copying token to clipboard' + e.message, 'error'));
+         }
+      } catch (e: any) {
+         addToast(`Error creating tap token: ${e.message && e.message}`, 'error');
+      } finally {
+         setCreatingToken(false);
+      }
+   };
+
+   return (
+      <>
+         <button
+            disabled={creatingToken}
+            onClick={handleEcashTapClicked}
+            className='fixed left-0 top-0 m-4 p-2 z-10'
+         >
+            <BanknoteIcon className='size-6' />
+         </button>
+         {tokenToSend && (
+            <Modal show={tokenToSend ? true : false} onClose={() => setTokenToSend(null)}>
+               <Modal.Header>
+                  <h2>Send Ecash</h2>
+               </Modal.Header>
+               <SendEcashModalBody token={tokenToSend} onClose={() => setTokenToSend(null)} />
+            </Modal>
+         )}
+      </>
+   );
+};
+
+export default EcashTapButton;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import React, { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+   children: ReactNode;
+   fallback: ReactNode;
+}
+
+interface ErrorBoundaryState {
+   hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+   constructor(props: ErrorBoundaryProps) {
+      super(props);
+      this.state = { hasError: false };
+   }
+
+   static getDerivedStateFromError(): ErrorBoundaryState {
+      // Update state to indicate an error occurred
+      return { hasError: true };
+   }
+
+   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+      // Log the error to an error reporting service if needed
+      console.error('ErrorBoundary caught an error', error, errorInfo);
+   }
+
+   render() {
+      if (this.state.hasError) {
+         // Render the fallback UI
+         return this.props.fallback;
+      }
+
+      // Render children if no error
+      return this.props.children;
+   }
+}
+
+export default ErrorBoundary;

--- a/src/components/buttons/utility/RefreshButton.tsx
+++ b/src/components/buttons/utility/RefreshButton.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+const RefreshSVG = () => (
+   <svg
+      xmlns='http://www.w3.org/2000/svg'
+      fill='none'
+      viewBox="0 0 26 26"
+      strokeWidth={1}
+      stroke='currentColor'
+      className='w-5 h-5'
+   >
+      <path d="M7 9h-7v-7h1v5.2c1.853-4.237 6.083-7.2 11-7.2 6.623 0 12 5.377 12 12s-5.377 12-12 12c-6.286 0-11.45-4.844-11.959-11h1.004c.506 5.603 5.221 10 10.955 10 6.071 0 11-4.929 11-11s-4.929-11-11-11c-4.66 0-8.647 2.904-10.249 7h5.249v1z"/>
+   </svg>
+);
+
+export const RefreshButton = () => {
+    const [hidden, setHidden] = useState(true);
+
+    function refreshPage(){ 
+        setHidden(!hidden);
+        window.location.reload();
+    }
+
+    return (
+        <>
+            <div className={`${hidden ? '' : hidden}`}>
+            <button className='fixed right-24 top-1 m-4 p-2 z-10' onClick={ () => {refreshPage()} }>
+                {hidden && <RefreshSVG />}
+            </button>
+            </div>
+        </>
+    );
+};
+
+export default RefreshButton;

--- a/src/components/buttons/utility/RefreshButton.tsx
+++ b/src/components/buttons/utility/RefreshButton.tsx
@@ -4,7 +4,7 @@ const RefreshSVG = () => (
    <svg
       xmlns='http://www.w3.org/2000/svg'
       fill='none'
-      viewBox="0 0 26 26"
+      viewBox="0 0 26 25"
       strokeWidth={1}
       stroke='currentColor'
       className='w-5 h-5'
@@ -24,7 +24,7 @@ export const RefreshButton = () => {
     return (
         <>
             <div className={`${hidden ? '' : hidden}`}>
-            <button className='fixed right-24 top-1 m-4 p-2 z-10' onClick={ () => {refreshPage()} }>
+            <button className='fixed right-24 top-1 m-4 p-2 z-10' style={{ padding: '0.45rem' }} onClick={ () => {refreshPage()} }>
                 {hidden && <RefreshSVG />}
             </button>
             </div>

--- a/src/components/modals/SendEcashModalBody.tsx
+++ b/src/components/modals/SendEcashModalBody.tsx
@@ -1,168 +1,79 @@
-import { useCashu } from '@/hooks/useCashu';
-import { useToast } from '@/hooks/useToast';
-import {
-   CashuWallet,
-   Proof,
-   Token,
-   TokenEntry,
-   getDecodedToken,
-   getEncodedToken,
-} from '@cashu/cashu-ts';
-import { Modal, Spinner } from 'flowbite-react';
+import { Modal } from 'flowbite-react';
 import React, { useEffect, useState } from 'react';
 import AnimatedQRCode from '../AnimatedQR';
 import ClipboardButton from '../buttons/utility/ClipboardButton';
 import QRCode from 'qrcode.react';
 import CustomCarousel from '../Carousel/CustomCarousel';
-import { useDispatch } from 'react-redux';
-import { TxStatus, addTransaction } from '@/redux/slices/HistorySlice';
+import ErrorBoundary from '../ErrorBoundary';
 
 interface SendEcashModalBodyProps {
-   amountUsd: number;
+   token: string;
    onClose: () => void;
 }
 
-const SendEcashModalBody = ({ amountUsd, onClose }: SendEcashModalBodyProps) => {
-   const [sending, setSending] = useState(false);
-   const [sendAmount, setSendAmount] = useState('');
-   const [tokenEntryData, setTokenEntryData] = useState<{
-      proofs: Proof[];
-      wallet: CashuWallet;
-   } | null>(null);
-   const [encodedToken, setEncodedToken] = useState<string | null>(null);
+const SendEcashModalBody = ({ onClose, token }: SendEcashModalBodyProps) => {
    const [carouselSlides, setCarouselSlides] = useState<React.ReactNode[]>([]);
-
-   const dispatch = useDispatch();
-
-   const { addToast } = useToast();
-   const { swapToSend } = useCashu();
+   const [qrError, setQrError] = useState(false);
 
    useEffect(() => {
-      if (!tokenEntryData) return;
+      if (!token) return;
 
-      const token: Token = {
-         token: [
-            {
-               proofs: tokenEntryData.proofs,
-               mint: tokenEntryData.wallet.mint.mintUrl,
-            } as TokenEntry,
-         ],
-         unit: 'usd',
-      };
+      try {
+         const qrCodeValue = `${window.location.protocol}//${window.location.host}/wallet?token=${token}`;
 
-      const encodedToken = getEncodedToken(token);
+         setCarouselSlides([
+            <div className='text-black text-center space-y-2 ml-3' key='1'>
+               <ErrorBoundary
+                  fallback={
+                     <p className='text-red-500'>
+                        Failed to load QR. Link too long. Go to transaction history to reclaim your
+                        tokens and try again, or just copy the link by clicking the button below.{' '}
+                     </p>
+                  }
+               >
+                  <h2 className='text-xl'>Shareable Boardwalk Cash Link</h2>
+                  <QRCode value={qrCodeValue} size={window.innerWidth < 768 ? 275 : 400} />
+                  <p> Link: {`boardwalkcash.com...`}</p>
+               </ErrorBoundary>
+            </div>,
+            <div className='text-black text-center space-y-2' key='2'>
+               <h2 className='text-xl'>Ecash Token</h2>
+               <ErrorBoundary
+                  fallback={<p className='text-red-500'>Failed to load QR. Token too long</p>}
+               >
+                  <AnimatedQRCode encodedToken={`${token}`} />
+               </ErrorBoundary>
+               <p> Token: {`${token.slice(0, 12)}...${token.slice(-5)}`}</p>
+            </div>,
+         ]);
+      } catch (error) {
+         console.error(error);
+         setQrError(true);
+      }
 
-      console.log('Encoded Token', encodedToken);
-
-      console.log('DECODED', getDecodedToken(encodedToken));
-
-      setEncodedToken(encodedToken.replace('Token:', ''));
-      setSending(false);
-
-      dispatch(
-         addTransaction({
-            type: 'ecash',
-            transaction: {
-               token: encodedToken,
-               amount: -amountUsd,
-               unit: 'usd',
-               mint: tokenEntryData.wallet.mint.mintUrl,
-               status: TxStatus.PENDING,
-               date: new Date().toLocaleString(),
-            },
-         }),
-      );
-   }, [tokenEntryData]);
-
-   useEffect(() => {
-      const handleSendEcash = async () => {
-         console.log('Send Ecash', amountUsd);
-         if (amountUsd <= 0) {
-            addToast('Enter an amount to send', 'error');
-            return;
-         }
-         setSending(true);
-
-         console.log(
-            'TOtal balance. About to send',
-            (JSON.parse(window.localStorage.getItem('proofs') || '[]') as Proof[]).reduce(
-               (a, b) => a + b.amount,
-               0,
-            ),
-         );
-
-         const { proofs: newProofs, wallet } = await swapToSend(amountUsd);
-
-         console.log(
-            'Balance after sending',
-            (JSON.parse(window.localStorage.getItem('proofs') || '[]') as Proof[]).reduce(
-               (a, b) => a + b.amount,
-               0,
-            ),
-         );
-
-         console.log('Send Ecash', newProofs);
-
-         if (!newProofs) {
-            return;
-         }
-
-         setTokenEntryData({ proofs: newProofs, wallet });
-      };
-      handleSendEcash().finally(() => setSending(false));
-   }, [amountUsd]);
-
-   useEffect(() => {
-      if (!encodedToken) return;
-      setCarouselSlides([
-         <div className='text-black text-center space-y-2 ml-2' key='1'>
-            <h2 className='text-xl'>Shareable Boardwalk Cash Link</h2>
-            <QRCode
-               value={`${window.location.protocol}//${window.location.host}/wallet?token=${encodedToken}`}
-               size={window.innerWidth < 768 ? 275 : 400}
-            />
-            <p> Link: {`boardwalkcash.com...`}</p>
-         </div>,
-         <div className='text-black text-center space-y-2' key='2'>
-            <h2 className='text-xl'>Ecash Token</h2>
-            <AnimatedQRCode encodedToken={`${encodedToken}`} />
-            <p> Token: {`${encodedToken.slice(0, 12)}...${encodedToken.slice(-5)}`}</p>
-         </div>,
-      ]);
       return () => {};
-   }, [encodedToken]);
+   }, [token]);
 
    return (
       <>
          <Modal.Body>
-            {sending ? (
-               <div className='flex flex-col space-y-4 justify-center items-center'>
-                  <Spinner size='xl' />
-                  <div className='text-black'>Creating sendable tokens...</div>
-               </div>
-            ) : (
-               <div className='flex flex-col justify-center items-center text-black space-y-3'>
-                  {encodedToken && (
-                     <>
-                        <div className='max-w-full'>
-                           <CustomCarousel slides={carouselSlides} />
-                        </div>
-                        <div className='flex space-x-3'>
-                           <ClipboardButton
-                              toCopy={`${window.location.protocol}//${window.location.host}/wallet?token=${encodedToken}`}
-                              toShow={`Link`}
-                              onClick={onClose}
-                           />
-                           <ClipboardButton
-                              toCopy={`${encodedToken}`}
-                              toShow={`Token`}
-                              onClick={onClose}
-                           />
-                        </div>
-                     </>
-                  )}
-               </div>
-            )}
+            <div className='flex flex-col justify-center items-center text-black space-y-3'>
+               {token && (
+                  <>
+                     <div className='max-w-full'>
+                        <CustomCarousel slides={carouselSlides} />
+                     </div>
+                     <div className='flex space-x-3'>
+                        <ClipboardButton
+                           toCopy={`${window.location.protocol}//${window.location.host}/wallet?token=${token}`}
+                           toShow={`Link`}
+                           onClick={onClose}
+                        />
+                        <ClipboardButton toCopy={`${token}`} toShow={`Token`} onClick={onClose} />
+                     </div>
+                  </>
+               )}
+            </div>
          </Modal.Body>
       </>
    );

--- a/src/components/sidebar/EcashTapsSettings.tsx
+++ b/src/components/sidebar/EcashTapsSettings.tsx
@@ -1,0 +1,46 @@
+import { setDefaultTapAmount, setEcashTapsEnabled } from '@/redux/slices/SettingsSlice';
+import { RootState } from '@/redux/store';
+import { Badge } from 'flowbite-react';
+import { useDispatch, useSelector } from 'react-redux';
+
+const EcashTapsSettings = () => {
+   const { ecashTapsEnabled, defaultTapAmount } = useSelector((state: RootState) => state.settings);
+
+   const dispatch = useDispatch();
+
+   const handleSetTapAmount = (amount: number) => {
+      if (amount === defaultTapAmount) return;
+      if (amount === 0) {
+         dispatch(setEcashTapsEnabled(false));
+      } else if (!ecashTapsEnabled) {
+         dispatch(setEcashTapsEnabled(true));
+      }
+
+      dispatch(setDefaultTapAmount(amount));
+   };
+
+   const tapAmounts = [
+      { name: 'off', value: 0 },
+      { name: '1 ¢', value: 1 },
+      { name: '5 ¢', value: 5 },
+      { name: '25 ¢', value: 25 },
+      { name: '$1', value: 100 },
+   ];
+
+   return (
+      <div>
+         <div className='text-lg mb-9'>Create one-tap sharable ecash</div>
+         <div className='flex justify-around mb-4'>
+            {tapAmounts.map((tap, idx) => (
+               <button key={idx} onClick={() => handleSetTapAmount(tap.value)}>
+                  <Badge color={`${defaultTapAmount === tap.value ? 'success' : 'dark'}`}>
+                     {tap.name}
+                  </Badge>
+               </button>
+            ))}
+         </div>
+      </div>
+   );
+};
+
+export default EcashTapsSettings;

--- a/src/components/sidebar/SettingsSidebar.tsx
+++ b/src/components/sidebar/SettingsSidebar.tsx
@@ -10,6 +10,8 @@ import ClipboardButton from '../buttons/utility/ClipboardButton';
 import { customDrawerTheme } from '@/themes/drawerTheme';
 import DrawerCollapse from '../DrawerCollapse';
 import { BuildingLibraryIcon, LinkIcon, XMarkIcon } from '@heroicons/react/20/solid';
+import { BanknoteIcon } from '../EcashTapButton';
+import EcashTapsSettings from './EcashTapsSettings';
 
 const SettingsCog = () => (
    <svg
@@ -70,7 +72,7 @@ export const SettingsSidebar = () => {
                      </div>
                   </DrawerCollapse>
                </div>
-               <div className='mb-12 mt-1 space-y-3 border-b pt-4 first:mt-0 first:border-b-0 first:pt-0 border-gray-300'>
+               <div className='mt-1 space-y-3 border-b pt-4 first:mt-0 first:border-b-0 first:pt-0 border-gray-300'>
                   <DrawerCollapse label='Connections' icon={<LinkIcon className='size-4' />}>
                      {nwcState.allPubkeys.map((pubkey, idx) => (
                         <NwcSidebarItem connection={nwcState.connections[pubkey]} key={idx} />
@@ -82,6 +84,11 @@ export const SettingsSidebar = () => {
                            setNwcUri={setNwcUri}
                         />
                      </div>
+                  </DrawerCollapse>
+               </div>
+               <div className='mb-12 mt-1 space-y-3  pt-4 first:mt-0 first:pt-0 '>
+                  <DrawerCollapse label='Cash Taps' icon={<BanknoteIcon className='size-4' />}>
+                     <EcashTapsSettings />
                   </DrawerCollapse>
                </div>
             </Drawer.Items>

--- a/src/hooks/useCashu.ts
+++ b/src/hooks/useCashu.ts
@@ -18,12 +18,14 @@ import {
    MintQuoteResponse,
    Proof,
    getDecodedToken,
+   getEncodedToken,
 } from '@cashu/cashu-ts';
 import { useToast } from './useToast';
 import { CashuWallet, CashuMint, SendResponse } from '@cashu/cashu-ts';
 import { getNeededProofs, addBalance, customMintQuoteRequest } from '@/utils/cashu';
 import { RootState } from '@/redux/store';
 import { useExchangeRate } from './useExchangeRate';
+import { TxStatus, addTransaction } from '@/redux/slices/HistorySlice';
 
 export const useCashu = () => {
    const dispatch = useDispatch();
@@ -254,6 +256,68 @@ export const useCashu = () => {
       }
    };
 
+   const createSendableEcashToken = async (amount: number, wallet: CashuWallet) => {
+      console.log('Send Ecash', amount);
+      if (amount <= 0) {
+         addToast('Enter an amount to send', 'error');
+         return;
+      }
+
+      console.log(
+         'TOtal balance. About to send',
+         (JSON.parse(window.localStorage.getItem('proofs') || '[]') as Proof[]).reduce(
+            (a, b) => a + b.amount,
+            0,
+         ),
+      );
+
+      // TODO: make is so that I can use CashuWallet directly
+      const keyset: Wallet = {
+         id: wallet.keys.id,
+         url: wallet.mint.mintUrl,
+         proofs: [],
+         keys: wallet.keys,
+         active: true,
+      };
+
+      const { proofs: newProofs } = await swapToSend(amount, keyset);
+
+      console.log(
+         'Balance after sending',
+         (JSON.parse(window.localStorage.getItem('proofs') || '[]') as Proof[]).reduce(
+            (a, b) => a + b.amount,
+            0,
+         ),
+      );
+
+      console.log('Send Ecash', newProofs);
+
+      if (!newProofs) {
+         return;
+      }
+
+      const token = getEncodedToken({
+         token: [{ proofs: newProofs, mint: keyset.url }],
+         unit: 'usd',
+      });
+
+      dispatch(
+         addTransaction({
+            type: 'ecash',
+            transaction: {
+               token: token,
+               amount: -amount,
+               unit: 'usd',
+               mint: keyset.url,
+               status: TxStatus.PENDING,
+               date: new Date().toLocaleString(),
+            },
+         }),
+      );
+
+      return token;
+   };
+
    const swapToMain = async (
       keyset: { id: string; url: string; unit: string; keys?: MintKeys },
       proofs?: Proof[],
@@ -409,7 +473,7 @@ export const useCashu = () => {
       console.log('swapToSend.proofs', proofs);
 
       if (proofs.length === 0) {
-         addToast('Insufficient balance', 'warning');
+         addToast('Insufficient balance in active mint', 'warning');
          throw new Error('Insufficient balance');
       }
 
@@ -522,5 +586,6 @@ export const useCashu = () => {
       updateProofsAndBalance,
       checkProofsValid,
       payInvoice,
+      createSendableEcashToken,
    };
 };

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,23 @@
+import { RootState } from '@/redux/store';
+import { CashuMint, CashuWallet } from '@cashu/cashu-ts';
+import { useSelector } from 'react-redux';
+import { useToast } from './useToast';
+
+export const useWallet = () => {
+   const wallet = useSelector((state: RootState) => state.wallet);
+   const { addToast } = useToast();
+   const getActiveWallet = () => {
+      const activeKeyset = Object.values(wallet.keysets).find(wallet => wallet.active);
+
+      if (!activeKeyset) {
+         addToast('Unexpected error: no active wallet found', 'error');
+         throw new Error('No active wallet found');
+      }
+
+      const activeWallet = new CashuWallet(new CashuMint(activeKeyset?.url), activeKeyset);
+
+      return activeWallet;
+   };
+
+   return { getActiveWallet };
+};

--- a/src/pages/wallet.tsx
+++ b/src/pages/wallet.tsx
@@ -20,8 +20,10 @@ import { useToast } from '@/hooks/useToast';
 import ProcessingSwapModal from '@/components/sidebar/ProcessingSwapModal';
 import ConfirmEcashReceiveModal from '@/components/modals/ConfirmEcashReceiveModal';
 import TransactionHistoryDrawer from '@/components/transactionHistory/TransactionHistoryDrawer';
+import EcashTapButton from '@/components/EcashTapButton';
+import { GetServerSideProps } from 'next';
 
-export default function Home() {
+export default function Home({ isMobile }: { isMobile: boolean }) {
    const newUser = useRef(false);
    const [swapping, setSwapping] = useState(false);
    const [tokenDecoded, setTokenDecoded] = useState<Token | null>(null);
@@ -32,7 +34,6 @@ export default function Home() {
    const wallets = useSelector((state: RootState) => state.wallet.keysets);
    const user = useSelector((state: RootState) => state.user);
    const { addToast } = useToast();
-
    const { updateProofsAndBalance, checkProofsValid, swapToMain } = useCashu();
 
    useEffect(() => {
@@ -152,6 +153,7 @@ export default function Home() {
          </main>
          <SettingsSidebar />
          <TransactionHistoryDrawer />
+         <EcashTapButton isMobile={isMobile} />
          <ProcessingSwapModal isSwapping={swapping} />
          {tokenDecoded && !newUser.current && ecashReceiveModalOpen && (
             <ConfirmEcashReceiveModal
@@ -167,3 +169,14 @@ export default function Home() {
       </>
    );
 }
+
+export const getServerSideProps: GetServerSideProps = async ({ req }: any) => {
+   const userAgent = req.headers['user-agent'];
+   const isMobile = /mobile/i.test(userAgent);
+
+   return {
+      props: {
+         isMobile,
+      },
+   };
+};

--- a/src/pages/wallet.tsx
+++ b/src/pages/wallet.tsx
@@ -13,6 +13,7 @@ import Disclaimer from '@/components/Disclaimer';
 import ActivityIndicator from '@/components/ActivityIndicator';
 import { setSuccess } from '@/redux/slices/ActivitySlice';
 import SettingsSidebar from '@/components/sidebar/SettingsSidebar';
+import RefreshButton from '@/components/buttons/utility/RefreshButton';
 import { CashuMint, CashuWallet, Token, getDecodedToken } from '@cashu/cashu-ts';
 import useNwc2 from '@/hooks/useNwc2';
 import { useRouter } from 'next/router';
@@ -153,6 +154,7 @@ export default function Home({ isMobile }: { isMobile: boolean }) {
          </main>
          <SettingsSidebar />
          <TransactionHistoryDrawer />
+         <RefreshButton />
          <EcashTapButton isMobile={isMobile} />
          <ProcessingSwapModal isSwapping={swapping} />
          {tokenDecoded && !newUser.current && ecashReceiveModalOpen && (

--- a/src/redux/slices/SettingsSlice.ts
+++ b/src/redux/slices/SettingsSlice.ts
@@ -1,0 +1,28 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+interface SettingsState {
+   ecashTapsEnabled: boolean;
+   defaultTapAmount: number;
+}
+
+const initialState: SettingsState = {
+   ecashTapsEnabled: false,
+   defaultTapAmount: 0,
+};
+
+const SettingsSlice = createSlice({
+   name: 'settings',
+   initialState,
+   reducers: {
+      setEcashTapsEnabled: (state, action: PayloadAction<boolean>) => {
+         state.ecashTapsEnabled = action.payload;
+      },
+      setDefaultTapAmount: (state, action: PayloadAction<number>) => {
+         state.defaultTapAmount = action.payload;
+      },
+   },
+});
+
+export const { setEcashTapsEnabled, setDefaultTapAmount } = SettingsSlice.actions;
+
+export default SettingsSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -8,6 +8,7 @@ import walletReducer from '@/redux/slices/Wallet.slice';
 import userReducer from '@/redux/slices/UserSlice';
 import nwcReducer from '@/redux/slices/NwcSlice';
 import historyReducer from '@/redux/slices/HistorySlice';
+import settingsReducer from '@/redux/slices/SettingsSlice';
 
 const rootReducer = combineReducers({
    wallet: walletReducer,
@@ -15,12 +16,13 @@ const rootReducer = combineReducers({
    user: userReducer,
    nwc: nwcReducer,
    history: historyReducer,
+   settings: settingsReducer,
 });
 
 const persistConfig = {
    key: 'root',
    storage,
-   whitelist: ['nwc', 'history'],
+   whitelist: ['nwc', 'history', 'settings'],
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
## Description
Adds a refresh button next to the Activity Icon and Settings icon on the homepage. This helps with mobile refresh and PWA (Progressive Web Apps) homescreen apps, specifically on iphone. 

- Updates README.md for step 3 with .env setup.
- Removes version from docker-compose file as it is now [deprecated](https://github.com/mailcow/mailcow-dockerized/issues/5797). 
- RefreshButton Component.

Mobile:
<img width="207" alt="Screenshot 2024-07-20 at 10 50 19 PM" src="https://github.com/user-attachments/assets/12269c8e-91aa-4080-bff2-83b07e0ad590">

Desktop:
<img width="1241" alt="Screenshot 2024-07-20 at 10 48 35 PM" src="https://github.com/user-attachments/assets/3b96f7a8-0bd9-4826-9636-5805aa58af8d">

