### PR TITLE
add transaction IDs

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
 declare global {
-   // var prisma: PrismaClient;
+   var prisma: PrismaClient | undefined;
 }
 
 export {};


### PR DESCRIPTION
Adds a function to `computeTxId` that creates a unique identifier for token, no matter the order of the proofs.
- NOTE: this is not part of the nuts

Stores tokens in the database by txid

Lookup tokens (including from a sharable link) by txid