### PR TITLE
conver mint urls to lowercase

### DIFF
--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -3,9 +3,9 @@ export const normalizeUrl = (url: string): string => {
    url = url.replace(/\/+$/, '');
 
    if (url.startsWith('http://') || url.startsWith('https://')) {
-      return url;
+      return url.toLocaleLowerCase();
    } else {
-      return 'https://' + url;
+      return ('https://' + url).toLocaleLowerCase();
    }
 };
 


### PR DESCRIPTION
if the user typed in a url with uppercase then this would break fetching the mint info