### PR TITLE
Patch/cross mint swap

### DIFF
--- a/src/hooks/cashu/useCashu.ts
+++ b/src/hooks/cashu/useCashu.ts
@@ -553,10 +553,6 @@ export const useCashu = () => {
          },
          { privkey },
       );
-      console.log(
-         'recoverme',
-         getEncodedTokenV4({ token: [{ proofs: newProofs, mint: wallet.mint.mintUrl }] }),
-      );
       return newProofs;
    };
 

--- a/src/hooks/cashu/useCashu.ts
+++ b/src/hooks/cashu/useCashu.ts
@@ -108,10 +108,11 @@ export const useCashu = () => {
             console.log('Found valid quotes');
             return { mintQuote, meltQuote, amountToMint };
          }
-         amountToMint = amountToMint - meltQuote.fee_reserve - 1;
+         const difference = meltQuote.amount + meltQuote.fee_reserve - totalProofsAmount;
+         amountToMint = amountToMint - difference;
       }
 
-      throw new Error('Failed to find valid quotes after maximum attempts');
+      throw new Error('Failed to find valid quotes after maximum attempts. ');
    };
 
    /**


### PR DESCRIPTION
There were two issues here.

One is that if we want to claim locked ecash by melting to another mint, cashu-ts does not currently support unlocking in the melt operation so if the lightning payment fails, then we already had swapped to unlock and the original proofs are now spent.
- Fixed by claiming the swapped proofs and prompting the user to add the source mint

The other issue was with a discrepancy in exchange rates between mints, and my `getCrossMinttQuotes` function was exceeding its max attempts to find valid mint/melt quotes to melt all the proofs.
- Fixed by subtracting the difference in quotes rather than `amountToMint = amountToMint - meltQuote.fee_reserve - 1;`