### PR TITLE
make sure keysets get created for new mints

### DIFF
--- a/src/hooks/contexts/cashuContext.tsx
+++ b/src/hooks/contexts/cashuContext.tsx
@@ -345,7 +345,7 @@ export const CashuProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             if (active) {
                setDefaultWallets(new Map(defaultWallets.set(k.unit as Currency, wallet)));
                if (k.unit === activeUnit) {
-                  setActiveWallet(wallet);
+                  setToMain(k.id);
                }
             }
             if (!defaultWallets.has(k.unit as Currency)) {

--- a/src/lib/mintModels.ts
+++ b/src/lib/mintModels.ts
@@ -45,8 +45,11 @@ export async function findOrCreateMint(
          const newMint = await prisma.mint.create({
             data: {
                url: mintUrl,
-               // keysets: {
-               // },
+               keysets: {
+                  createMany: {
+                     data: mintKeysetData,
+                  },
+               },
             },
             include: {
                keysets: true,


### PR DESCRIPTION
This should solve the problem of the mint keyset not being found when a mint that hasn't been seen before is added. 

To test, clear your local database and your browser storage, then refresh and add a mint. Now try to mint some ecash and it should work without toggling mints.