### PR TITLE
allow toggle if `nwcIsMain`

### DIFF
--- a/src/components/ToggleCurrencyDropdown.tsx
+++ b/src/components/ToggleCurrencyDropdown.tsx
@@ -10,14 +10,11 @@ import Tooltip from './utility/Tooltip';
 import RadioButton from './buttons/RadioButton';
 
 const ToggleCurrencyDrawer = () => {
-   const { activeUnit, setActiveUnit, defaultWallets } = useCashuContext();
+   const { activeUnit, setActiveUnit, defaultWallets, nwcIsMain } = useCashuContext();
    const { satBalance, usdBalance, satBalanceInUsd } = useBalance();
    const [isOpen, setIsOpen] = useState(false);
 
    const handleToggle = (unit: Currency) => {
-      if (!defaultWallets.has(unit)) {
-         return;
-      }
       setActiveUnit(unit);
       setIsOpen(false);
    };
@@ -45,7 +42,7 @@ const ToggleCurrencyDrawer = () => {
                         balance={formatSats(satBalance || 0)}
                         subBalance={formatCents(satBalanceInUsd || 0)}
                         isSelected={activeUnit === Currency.SAT}
-                        isAvailable={defaultWallets.has(Currency.SAT)}
+                        isAvailable={defaultWallets.has(Currency.SAT) || nwcIsMain}
                         onSelect={handleToggle}
                      />
                   </div>

--- a/src/hooks/contexts/cashuContext.tsx
+++ b/src/hooks/contexts/cashuContext.tsx
@@ -389,22 +389,21 @@ export const CashuProvider: React.FC<{ children: React.ReactNode }> = ({ childre
    };
 
    const setUnit = (unit: Currency) => {
+      if (!defaultWallets.has(unit) && !nwcIsMain) {
+         return;
+      }
       const defaultWallet = defaultWallets.get(unit);
-      console.log('setting unit to ', unit);
       const inMintlessMode = user.sendMode === 'mintless' && user.receiveMode === 'mintless';
       if (inMintlessMode || nwcIsMain) {
          if (unit === Currency.USD) {
-            console.log('disabling mintless mode');
             toggleMintlessMode(false);
             if (!defaultWallet) throw new Error('No default wallet found for USD');
             setToMain(defaultWallet.keys.id);
          } else if (unit === Currency.SAT && nwcIsMain) {
-            console.log('enabling mintless mode');
             toggleMintlessMode(true);
          }
       }
       if (defaultWallet) {
-         console.log('default wallet found for unit', defaultWallet);
          setToMain(defaultWallet.keys.id);
       }
       setActiveUnit(unit);


### PR DESCRIPTION
Fixes a bug where if the user's main sat account is their NWC, then `defaultWallets.has(Currency.SAT)` returns false and does not let the user toggle to BTC mode.

