### PR TITLE
move 'keydown' event listener to `Amount` component

### DIFF
--- a/src/components/buttons/Receive/ReceiveButtonContent.tsx
+++ b/src/components/buttons/Receive/ReceiveButtonContent.tsx
@@ -54,11 +54,12 @@ const ReceiveButtonContent = ({ isMobile, closeParentComponent }: ReceiveButtonC
    const { activeUnit, activeKeysetId } = useCashuContext();
    const userPubkey = useSelector((state: RootState) => state.user.pubkey);
    const {
-      numpadValue,
+      handleNumpadBackspace,
       numpadValueIsEmpty,
       handleNumpadInput,
-      handleNumpadBackspace,
       clearNumpadInput,
+      setNumpadValue,
+      numpadValue,
    } = useNumpad({
       activeUnit,
    });
@@ -167,6 +168,7 @@ const ReceiveButtonContent = ({ isMobile, closeParentComponent }: ReceiveButtonC
                <div className='flex-grow flex flex-col items-center justify-center'>
                   <Amount
                      value={numpadValue}
+                     setValue={setNumpadValue}
                      unit={activeUnit}
                      className='font-teko text-6xl font-bold text-black'
                      isDollarAmount={true}

--- a/src/components/buttons/Send/SendButtonContent.tsx
+++ b/src/components/buttons/Send/SendButtonContent.tsx
@@ -73,6 +73,7 @@ const SendButtonContent = ({
       numpadValueIsEmpty,
       handleNumpadInput,
       clearNumpadInput,
+      setNumpadValue,
       numpadAmount,
       numpadValue,
    } = useNumpad({
@@ -263,6 +264,7 @@ const SendButtonContent = ({
                      <Amount
                         value={numpadValue}
                         unit={activeUnit}
+                        setValue={setNumpadValue}
                         className='font-teko text-6xl font-bold text-black'
                         isDollarAmount={true}
                      />

--- a/src/hooks/util/useNumpad.tsx
+++ b/src/hooks/util/useNumpad.tsx
@@ -8,24 +8,6 @@ interface UseNumpadProps {
 export const useNumpad = ({ activeUnit }: UseNumpadProps = {}) => {
    const [inputValue, setInputValue] = useState('');
 
-   useEffect(() => {
-      const handleKeyPress = (e: KeyboardEvent) => {
-         const numbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9'];
-         const showDecimal = activeUnit === Currency.USD;
-
-         if (numbers.includes(e.key) || e.key === '0') {
-            handleNumpadInput(e.key);
-         } else if (e.key === '.' && showDecimal) {
-            handleNumpadInput('.');
-         } else if (e.key === 'Backspace') {
-            handleNumpadBackspace();
-         }
-      };
-
-      window.addEventListener('keydown', handleKeyPress);
-      return () => window.removeEventListener('keydown', handleKeyPress);
-   }, [activeUnit]);
-
    const handleNumpadInput = (input: string) => {
       if (input === '.') {
          /* Only add decimal if one doesn't exist yet and we're in USD mode */
@@ -64,6 +46,7 @@ export const useNumpad = ({ activeUnit }: UseNumpadProps = {}) => {
 
    return {
       numpadValue: inputValue,
+      setNumpadValue: setInputValue,
       numpadAmount,
       numpadValueIsEmpty,
       setInputValue,


### PR DESCRIPTION
# Fixes: " when you start typing, there is a line that appears around the box, but we should remove the line." from workspace

## Description 

I moved the event listener from `useNumpad` into the `Amount` component and made `setValue` an optional prop that if set will set the numpad value when valid keys are pressed. Now that the event listener is only be used within the Amount input the outline Bob talked about is gone.

## Question

I'm wondering if this is the right approach for a custom keyboard/amount input because its starting to feel like a hack. We are also missing some accessibility features by not having a real input. This works, but @jbojcic1 if you have any better approaches let me know. The only idea that I have is to make 