### PR TITLE
Don't try to mint tokens if failed to pay payment request invoice

### DIFF
--- a/src/hooks/cashu/useCashu.ts
+++ b/src/hooks/cashu/useCashu.ts
@@ -555,7 +555,7 @@ export const useCashu = () => {
       invoice: string,
       meltQuote?: MeltQuoteResponse,
       wallet?: CashuWallet,
-   ): Promise<PayInvoiceResponse> => {
+   ): Promise<PayInvoiceResponse | undefined> => {
       if (!wallet) {
          if (!activeWallet) {
             throw new Error('No active wallet set');

--- a/src/hooks/cashu/usePaymentRequests.ts
+++ b/src/hooks/cashu/usePaymentRequests.ts
@@ -111,13 +111,17 @@ export const usePaymentRequests = () => {
       } else {
          const quote = await wallet.createMintQuote(amount);
 
-         let res: PayInvoiceResponse;
+         let res: PayInvoiceResponse | undefined;
          if (isMintless) {
             res = await nwcPayInvoice(quote.request);
          } else if (activeWallet) {
             res = await cashuPayInvoice(quote.request);
          } else {
             throw new Error('No active wallet found');
+         }
+
+         if (!res) {
+            throw new Error('Failed to pay invoice');
          }
 
          const { proofs } = await wallet.mintTokens(amount, quote.quote);


### PR DESCRIPTION
If paying the invoice failed, then we would still try to mint tokens which would throw an error and then the error messages were confusing. Now we just fail as soon as paying the invoice fails