### PR TITLE
fix padding for mobile on setup page

### DIFF
--- a/src/pages/setup.tsx
+++ b/src/pages/setup.tsx
@@ -45,7 +45,7 @@ const FirstPage = ({ nextPage }: { nextPage: (pgNum: number) => void }) => {
 const WarningPage = ({ nextPage }: { nextPage: (pgNum: number) => void }) => {
    return (
       <main className='flex flex-col md:flex-row items-center justify-center mx-auto min-h-screen'>
-         <div className='w-full md:w-1/2 space-y-4 p-5'>
+         <div className='w-full md:w-1/2 space-y-4 px-5 pt-10 pb-32'>
             <h2 className='underline text-2xl'>Warning!</h2>
             <p>
                Boardwalk Cash is a self-custodial wallet that enables you to manage payments on your


### PR DESCRIPTION
Depending on the browser, sometimes the continue button at the bottom of the warning page would not show up. This ensures there is plenty of padding below so that the user can scroll all the way down and click continue﻿
