### PR TITLE
fix bad error message when failed to create ecash token

### DIFF
--- a/src/hooks/boardwalk/useWallet.tsx
+++ b/src/hooks/boardwalk/useWallet.tsx
@@ -89,7 +89,8 @@ const useWallet = () => {
          }
 
          if (!token) {
-            throw new Error('Failed to create ecash token');
+            /* failed to create token is handled in the token creation functions */
+            return;
          }
 
          let txid: string | undefined;


### PR DESCRIPTION
Right now all errors are handled inside the functions that create ecash, so we just return from `sendEcash` instead of throwing. In the future I would like to make it more clear which functions throw and which handle errors internally.﻿
