### PR TITLE
poll reusable payment requests

### DIFF
--- a/src/components/buttons/Receive/ReceiveFlow.tsx
+++ b/src/components/buttons/Receive/ReceiveFlow.tsx
@@ -276,7 +276,9 @@ const ReceiveFlow = ({ onClose }: ReceiveFlowProps) => {
          {state.step === 'QRScanner' && (
             <QRScanner onCancel={() => setState(defaultState)} onScan={handlePaste} />
          )}
-         {state.step === 'reusablePaymentRequest' && <ViewReusablePaymentRequest />}
+         {state.step === 'reusablePaymentRequest' && (
+            <ViewReusablePaymentRequest onSuccess={onClose} />
+         )}
       </div>
    );
 };

--- a/src/components/views/ViewReusablePaymentRequest.tsx
+++ b/src/components/views/ViewReusablePaymentRequest.tsx
@@ -1,6 +1,6 @@
 import { usePaymentRequests } from '@/hooks/cashu/usePaymentRequests';
 import QRCode from 'qrcode.react';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import ClipboardButton from '../buttons/utility/ClipboardButton';
 import { useCashuContext } from '@/hooks/contexts/cashuContext';
 import { decodePaymentRequest } from '@cashu/cashu-ts';
@@ -8,14 +8,18 @@ import useMintlessMode from '@/hooks/boardwalk/useMintlessMode';
 import { Spinner } from 'flowbite-react';
 import { usePolling } from '@/hooks/util/usePolling';
 import { useCashu } from '@/hooks/cashu/useCashu';
+import { useLocalStorage } from 'usehooks-ts';
 
 interface ViewReusablePaymentRequestProps {
    onSuccess?: () => void;
 }
 
 const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestProps) => {
+   const [paymentRequest, setPaymentRequest] = useLocalStorage<{ pr: string; id: string } | null>(
+      'reusablePaymentRequest',
+      null,
+   );
    const { fetchPaymentRequest, lookupLastPaid } = usePaymentRequests();
-   const [paymentRequest, setPaymentRequest] = useState<{ pr: string; id: string } | null>(null);
    const [lastPaid, setLastPaid] = useState<string | null>(null);
    const { activeWallet, activeUnit } = useCashuContext();
    const { handleClaimToSourceMint } = useCashu();
@@ -48,11 +52,9 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
    useEffect(() => {
       if (!activeWallet) return;
       if (!activeUnit) return;
-      const storedPaymentRequest = localStorage.getItem('paymentRequest');
-      const storedRequestId = localStorage.getItem('paymentRequestId');
-      if (storedPaymentRequest && storedRequestId) {
-         console.log('payment request found', storedPaymentRequest);
-         const { mints, unit } = decodePaymentRequest(storedPaymentRequest);
+
+      if (paymentRequest) {
+         const { mints, unit } = decodePaymentRequest(paymentRequest.pr);
          if (
             mints &&
             mints.length > 0 &&
@@ -60,20 +62,14 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
          ) {
             fetchPaymentRequest(undefined, true).then(({ pr, id }) => {
                setPaymentRequest({ pr, id });
-               localStorage.setItem('paymentRequest', pr);
-               localStorage.setItem('paymentRequestId', id);
             });
-         } else {
-            setPaymentRequest({ pr: storedPaymentRequest, id: storedRequestId });
          }
       } else {
          fetchPaymentRequest(undefined, true).then(({ pr, id }) => {
             setPaymentRequest({ pr, id });
-            localStorage.setItem('paymentRequest', pr);
-            localStorage.setItem('paymentRequestId', id);
          });
       }
-   }, [activeWallet, activeUnit, fetchPaymentRequest]);
+   }, [activeWallet, activeUnit, fetchPaymentRequest, paymentRequest, setPaymentRequest]);
 
    return (
       <div className='text-black flex flex-col justify-around items-center gap-6 h-full'>
@@ -86,7 +82,6 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
             <Spinner size='xl' />
          ) : (
             <>
-               fetchingPaymentRequest
                <div className='flex flex-col  gap-6 items-center'>
                   <QRCode value={paymentRequest.pr} size={256} />
                   <p className=' text-center text-sm'>

--- a/src/components/views/ViewReusablePaymentRequest.tsx
+++ b/src/components/views/ViewReusablePaymentRequest.tsx
@@ -21,7 +21,7 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
    const { handleClaimToSourceMint } = useCashu();
    const { isMintless } = useMintlessMode();
 
-   const pollPaymentRequest = useCallback(async () => {
+   const pollPaymentRequest = async () => {
       if (!paymentRequest?.id) return;
 
       try {
@@ -41,7 +41,7 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
       } catch (e) {
          console.warn('Failed to poll payment request:', e);
       }
-   }, [paymentRequest?.id, lastPaid, lookupLastPaid, handleClaimToSourceMint, onSuccess]);
+   };
 
    usePolling(pollPaymentRequest, 1000);
 

--- a/src/components/views/ViewReusablePaymentRequest.tsx
+++ b/src/components/views/ViewReusablePaymentRequest.tsx
@@ -1,23 +1,56 @@
 import { usePaymentRequests } from '@/hooks/cashu/usePaymentRequests';
 import QRCode from 'qrcode.react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import ClipboardButton from '../buttons/utility/ClipboardButton';
 import { useCashuContext } from '@/hooks/contexts/cashuContext';
 import { decodePaymentRequest } from '@cashu/cashu-ts';
 import useMintlessMode from '@/hooks/boardwalk/useMintlessMode';
 import { Spinner } from 'flowbite-react';
+import { usePolling } from '@/hooks/util/usePolling';
+import { useCashu } from '@/hooks/cashu/useCashu';
 
-const ViewReusablePaymentRequest = () => {
-   const [paymentRequest, setPaymentRequest] = useState('');
-   const { fetchPaymentRequest, fetchingPaymentRequest } = usePaymentRequests();
+interface ViewReusablePaymentRequestProps {
+   onSuccess?: () => void;
+}
+
+const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestProps) => {
+   const { fetchPaymentRequest, fetchingPaymentRequest, lookupLastPaid } = usePaymentRequests();
+   const [paymentRequest, setPaymentRequest] = useState<{ pr: string; id: string } | null>(null);
+   const [lastPaid, setLastPaid] = useState<string | null>(null);
    const { activeWallet, activeUnit } = useCashuContext();
+   const { handleClaimToSourceMint } = useCashu();
    const { isMintless } = useMintlessMode();
+
+   const pollPaymentRequest = useCallback(async () => {
+      if (!paymentRequest?.id) return;
+
+      try {
+         const res = await lookupLastPaid(paymentRequest.id);
+
+         if (!lastPaid) {
+            /* First time checking - initialize lastPaid */
+            setLastPaid(res.lastPaid || new Date(0).toISOString());
+            return;
+         }
+
+         if (res.lastPaid && res.lastPaid > lastPaid) {
+            /* payment request was paid since this component has been open */
+            handleClaimToSourceMint(res.token);
+            onSuccess?.();
+         }
+      } catch (e) {
+         console.warn('Failed to poll payment request:', e);
+      }
+   }, [paymentRequest?.id, lastPaid, lookupLastPaid, handleClaimToSourceMint, onSuccess]);
+
+   usePolling(pollPaymentRequest, 1000);
 
    useEffect(() => {
       if (!activeWallet) return;
       if (!activeUnit) return;
       const storedPaymentRequest = localStorage.getItem('paymentRequest');
-      if (storedPaymentRequest) {
+      const storedRequestId = localStorage.getItem('paymentRequestId');
+      if (storedPaymentRequest && storedRequestId) {
          console.log('payment request found', storedPaymentRequest);
          const { mints, unit } = decodePaymentRequest(storedPaymentRequest);
          if (
@@ -25,20 +58,22 @@ const ViewReusablePaymentRequest = () => {
             mints.length > 0 &&
             (!mints?.some(url => url === activeWallet?.mint.mintUrl) || unit !== activeUnit)
          ) {
-            fetchPaymentRequest(undefined, true).then(({ pr }) => {
-               setPaymentRequest(pr);
+            fetchPaymentRequest(undefined, true).then(({ pr, id }) => {
+               setPaymentRequest({ pr, id });
                localStorage.setItem('paymentRequest', pr);
+               localStorage.setItem('paymentRequestId', id);
             });
          } else {
-            setPaymentRequest(storedPaymentRequest);
+            setPaymentRequest({ pr: storedPaymentRequest, id: storedRequestId });
          }
       } else {
-         fetchPaymentRequest(undefined, true).then(({ pr }) => {
-            setPaymentRequest(pr);
+         fetchPaymentRequest(undefined, true).then(({ pr, id }) => {
+            setPaymentRequest({ pr, id });
             localStorage.setItem('paymentRequest', pr);
+            localStorage.setItem('paymentRequestId', id);
          });
       }
-   }, [activeWallet, activeUnit]);
+   }, [activeWallet, activeUnit, fetchPaymentRequest]);
 
    return (
       <div className='text-black flex flex-col justify-around items-center gap-6 h-full'>
@@ -52,13 +87,13 @@ const ViewReusablePaymentRequest = () => {
          ) : (
             <>
                <div className='flex flex-col  gap-6 items-center'>
-                  <QRCode value={paymentRequest} size={256} />
+                  <QRCode value={paymentRequest?.pr || ''} size={256} />
                   <p className=' text-center text-sm'>
                      Scan with any cashu wallet that supports payment requests
                   </p>
                </div>
                <ClipboardButton
-                  toCopy={paymentRequest}
+                  toCopy={paymentRequest?.pr || ''}
                   toShow={'Copy Request'}
                   className='btn-primary hover:!bg-[var(--btn-primary-bg)]'
                />

--- a/src/components/views/ViewReusablePaymentRequest.tsx
+++ b/src/components/views/ViewReusablePaymentRequest.tsx
@@ -14,7 +14,7 @@ interface ViewReusablePaymentRequestProps {
 }
 
 const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestProps) => {
-   const { fetchPaymentRequest, fetchingPaymentRequest, lookupLastPaid } = usePaymentRequests();
+   const { fetchPaymentRequest, lookupLastPaid } = usePaymentRequests();
    const [paymentRequest, setPaymentRequest] = useState<{ pr: string; id: string } | null>(null);
    const [lastPaid, setLastPaid] = useState<string | null>(null);
    const { activeWallet, activeUnit } = useCashuContext();
@@ -82,18 +82,19 @@ const ViewReusablePaymentRequest = ({ onSuccess }: ViewReusablePaymentRequestPro
                You currently have a Lightning Wallet set as your main account. Select an eCash mint
                as your main account to generate an eCash request.
             </p>
-         ) : fetchingPaymentRequest ? (
+         ) : paymentRequest === null ? (
             <Spinner size='xl' />
          ) : (
             <>
+               fetchingPaymentRequest
                <div className='flex flex-col  gap-6 items-center'>
-                  <QRCode value={paymentRequest?.pr || ''} size={256} />
+                  <QRCode value={paymentRequest.pr} size={256} />
                   <p className=' text-center text-sm'>
                      Scan with any cashu wallet that supports payment requests
                   </p>
                </div>
                <ClipboardButton
-                  toCopy={paymentRequest?.pr || ''}
+                  toCopy={paymentRequest.pr}
                   toShow={'Copy Request'}
                   className='btn-primary hover:!bg-[var(--btn-primary-bg)]'
                />

--- a/src/hooks/cashu/usePaymentRequests.ts
+++ b/src/hooks/cashu/usePaymentRequests.ts
@@ -1,6 +1,7 @@
 import {
    CheckPaymentRequestResponse,
    Currency,
+   GetCashuPRLastPaidResponse,
    GetPaymentRequestResponse,
    PayInvoiceResponse,
 } from '@/types';
@@ -22,7 +23,7 @@ import { useProofStorage } from './useProofStorage';
 import { useAppDispatch } from '@/redux/store';
 import { addTransaction, TxStatus } from '@/redux/slices/HistorySlice';
 import useMintlessMode from '@/hooks/boardwalk/useMintlessMode';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export const usePaymentRequests = () => {
    const [fetchingPaymentRequest, setFetchingPaymentRequest] = useState(false);
@@ -34,7 +35,7 @@ export const usePaymentRequests = () => {
 
    const dispatch = useAppDispatch();
 
-   const fetchPaymentRequest = async (amount?: number, reusable?: boolean) => {
+   const fetchPaymentRequest = useCallback(async (amount?: number, reusable?: boolean) => {
       setFetchingPaymentRequest(true);
       const params = new URLSearchParams();
       if (amount !== undefined) params.append('amount', amount.toString());
@@ -48,7 +49,7 @@ export const usePaymentRequests = () => {
       setFetchingPaymentRequest(false);
 
       return res;
-   };
+   }, []);
 
    const checkPaymentRequest = async (id: string) => {
       return await authenticatedRequest<CheckPaymentRequestResponse>(
@@ -57,6 +58,14 @@ export const usePaymentRequests = () => {
          undefined,
       );
    };
+
+   const lookupLastPaid = useCallback(async (id: string) => {
+      return await authenticatedRequest<GetCashuPRLastPaidResponse>(
+         `/api/token/pr/${id}/last-paid`,
+         'GET',
+         undefined,
+      );
+   }, []);
 
    const createPayload = async (request: PaymentRequest): Promise<PaymentRequestPayload> => {
       if (!request.amount) {
@@ -252,5 +261,11 @@ export const usePaymentRequests = () => {
          throw e;
       }
    };
-   return { fetchPaymentRequest, checkPaymentRequest, payPaymentRequest, fetchingPaymentRequest };
+   return {
+      fetchPaymentRequest,
+      checkPaymentRequest,
+      payPaymentRequest,
+      lookupLastPaid,
+      fetchingPaymentRequest,
+   };
 };

--- a/src/hooks/util/usePolling.ts
+++ b/src/hooks/util/usePolling.ts
@@ -9,8 +9,8 @@ import { useInterval, useTimeout } from 'react-use';
 export const usePolling = (callback: Function, delay?: number | null, timeout?: number) => {
    const [hasTimedOut, _, restart] = useTimeout(timeout);
 
-   /* hasTimedOut returns true if the timeout has been reached  or null if timeout is undefind*/
-   const pollingPeriod = hasTimedOut === null ? delay : !hasTimedOut() ? delay : null;
+   /* hasTimedOut returns true if the timeout has been reached */
+   const pollingPeriod = timeout === undefined || !hasTimedOut() ? delay : null;
 
    useInterval(callback, pollingPeriod);
 

--- a/src/hooks/util/usePolling.ts
+++ b/src/hooks/util/usePolling.ts
@@ -10,7 +10,7 @@ export const usePolling = (callback: Function, delay?: number | null, timeout?: 
    const [hasTimedOut, _, restart] = useTimeout(timeout);
 
    /* hasTimedOut returns true if the timeout has been reached */
-   const pollingPeriod = !hasTimedOut() ? delay : null;
+   const pollingPeriod = timeout === undefined || !hasTimedOut() ? delay : null;
 
    useInterval(callback, pollingPeriod);
 

--- a/src/hooks/util/usePolling.ts
+++ b/src/hooks/util/usePolling.ts
@@ -9,8 +9,8 @@ import { useInterval, useTimeout } from 'react-use';
 export const usePolling = (callback: Function, delay?: number | null, timeout?: number) => {
    const [hasTimedOut, _, restart] = useTimeout(timeout);
 
-   /* hasTimedOut returns true if the timeout has been reached */
-   const pollingPeriod = timeout === undefined || !hasTimedOut() ? delay : null;
+   /* hasTimedOut returns true if the timeout has been reached  or null if timeout is undefind*/
+   const pollingPeriod = hasTimedOut === null ? delay : !hasTimedOut() ? delay : null;
 
    useInterval(callback, pollingPeriod);
 

--- a/src/lib/paymentRequestModels.ts
+++ b/src/lib/paymentRequestModels.ts
@@ -33,3 +33,17 @@ export const markPaymentRequestAsPaid = async (id: string, token: string) => {
       include: { tokens: true },
    });
 };
+
+export const addTokenToPaymentRequest = async (id: string, token: string) => {
+   return await prisma.paymentRequest.update({
+      where: { id },
+      data: {
+         tokens: {
+            create: {
+               id: computeTxId(token),
+               token,
+            },
+         },
+      },
+   });
+};

--- a/src/pages/api/token/pr/[id]/index.ts
+++ b/src/pages/api/token/pr/[id]/index.ts
@@ -2,7 +2,7 @@ import { AuthenticatedRequest, CheckPaymentRequestResponse, NotificationType } f
 import { getEncodedTokenV4, PaymentRequestPayload } from '@cashu/cashu-ts';
 import { computeTxId, initializeWallet } from '@/utils/cashu';
 import { createNotification } from '@/lib/notificationModels';
-import { runAuthMiddleware } from '@/utils/middleware';
+import { corsMiddleware, runAuthMiddleware, runMiddleware } from '@/utils/middleware';
 import { NextApiResponse } from 'next';
 import {
    getPaymentRequestByIdIncludeToken,
@@ -15,6 +15,8 @@ export default async function handler(
    req: AuthenticatedRequest,
    res: NextApiResponse<CheckPaymentRequestResponse | { error: string }>,
 ) {
+   await runMiddleware(req, res, corsMiddleware);
+
    if (req.method === 'GET') {
       await runAuthMiddleware(req, res);
 

--- a/src/pages/api/token/pr/[id]/index.ts
+++ b/src/pages/api/token/pr/[id]/index.ts
@@ -3,12 +3,12 @@ import { getEncodedTokenV4, PaymentRequestPayload } from '@cashu/cashu-ts';
 import { computeTxId, initializeWallet } from '@/utils/cashu';
 import { createNotification } from '@/lib/notificationModels';
 import { runAuthMiddleware } from '@/utils/middleware';
-import { createTokenInDb } from '@/lib/tokenModels';
 import { NextApiResponse } from 'next';
 import {
    getPaymentRequestByIdIncludeToken,
    markPaymentRequestAsPaid,
    getPaymentRequestById,
+   addTokenToPaymentRequest,
 } from '@/lib/paymentRequestModels';
 
 export default async function handler(
@@ -109,22 +109,16 @@ export default async function handler(
 
       const txid = computeTxId(token);
       if (request.reusable) {
-         await createTokenInDb({ token, giftId: null }, txid);
-         await createNotification(
-            request.userPubkey,
-            NotificationType.Token,
-            JSON.stringify({ token }),
-            txid,
-         );
+         await addTokenToPaymentRequest(request.id, token);
       } else {
          await markPaymentRequestAsPaid(payment.id, token);
-         await createNotification(
-            request.userPubkey,
-            NotificationType.Token,
-            JSON.stringify({ token }),
-            txid,
-         );
       }
+      await createNotification(
+         request.userPubkey,
+         NotificationType.Token,
+         JSON.stringify({ token }),
+         txid,
+      );
       return res.status(200).end();
    } else {
       res.setHeader('Allow', ['GET', 'POST']);

--- a/src/pages/api/token/pr/[id]/last-paid.ts
+++ b/src/pages/api/token/pr/[id]/last-paid.ts
@@ -19,12 +19,12 @@ export default async function handler(
       try {
          const paymentRequest = await getPaymentRequestByIdIncludeToken(id);
 
-         if (!paymentRequest) {
-            return res.status(404).json({ error: 'Payment request not found' });
+         if (paymentRequest?.userPubkey !== req.authenticatedPubkey) {
+            return res.status(403).json({ error: 'Unauthorized' });
          }
 
-         if (paymentRequest.userPubkey !== req.authenticatedPubkey) {
-            return res.status(403).json({ error: 'Unauthorized' });
+         if (!paymentRequest) {
+            return res.status(404).json({ error: 'Payment request not found' });
          }
 
          /* get most recent token by createdAt timestamp */

--- a/src/pages/api/token/pr/[id]/last-paid.ts
+++ b/src/pages/api/token/pr/[id]/last-paid.ts
@@ -1,0 +1,54 @@
+import { AuthenticatedRequest, GetCashuPRLastPaidResponse } from '@/types';
+import { NextApiResponse } from 'next';
+import { getPaymentRequestByIdIncludeToken } from '@/lib/paymentRequestModels';
+import { runAuthMiddleware } from '@/utils/middleware';
+
+export default async function handler(
+   req: AuthenticatedRequest,
+   res: NextApiResponse<GetCashuPRLastPaidResponse | { error: string }>,
+) {
+   if (req.method === 'GET') {
+      await runAuthMiddleware(req, res);
+
+      const { id } = req.query;
+
+      if (!id || typeof id !== 'string') {
+         return res.status(400).json({ error: 'Invalid payment request ID' });
+      }
+
+      try {
+         const paymentRequest = await getPaymentRequestByIdIncludeToken(id);
+
+         if (!paymentRequest) {
+            return res.status(404).json({ error: 'Payment request not found' });
+         }
+
+         if (paymentRequest.userPubkey !== req.authenticatedPubkey) {
+            return res.status(403).json({ error: 'Unauthorized' });
+         }
+
+         /* get most recent token by createdAt timestamp */
+         const latestToken =
+            paymentRequest.tokens.length > 0
+               ? paymentRequest.tokens.reduce((latest, token) =>
+                    token.createdAt > latest.createdAt ? token : latest,
+                 )
+               : null;
+
+         if (!latestToken) {
+            return res.status(200).json({ token: null, lastPaid: null });
+         }
+
+         return res.status(200).json({
+            lastPaid: latestToken.createdAt.toISOString(),
+            token: latestToken.token,
+         });
+      } catch (error) {
+         console.error('Error fetching last paid timestamp:', error);
+         return res.status(500).json({ error: 'Internal server error' });
+      }
+   } else {
+      res.setHeader('Allow', ['GET']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+   }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,3 +412,13 @@ export type CheckPaymentRequestResponse = {
 export type PendingMintQuote = MintQuoteResponse & { amount: number; keysetId: string };
 
 export type MintQuoteStateExt = MintQuoteState | 'EXPIRED';
+
+export type GetCashuPRLastPaidResponse =
+   | {
+        lastPaid: string;
+        token: string;
+     }
+   | {
+        lastPaid: null;
+        token: null;
+     };


### PR DESCRIPTION
When the ViewReusablePaymentRequest view is open it will poll the /pr/[id]/last-paid endpoint. This endpoint returns the token that was most recently sent to that payment request.

When the view opens, we store the most recent request in `lastPaid`. If a token is created after that time and the view is still open then we claim the token and close the view.

In use polling I added a check for `timeout`. If `timeout` is undefined it will poll until unmounted.