### PR TITLE
POST token to Boardwalk username

### DIFF
--- a/src/pages/api/users/username/[username]/index.ts
+++ b/src/pages/api/users/username/[username]/index.ts
@@ -2,19 +2,16 @@ import { findContactByUsername } from '@/lib/contactModels';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-   const { slug } = req.query;
+   const { username } = req.query;
 
-   if (!slug || typeof slug !== 'string') {
+   if (!username || typeof username !== 'string') {
       return res.status(400).json({ message: 'Invalid slug' });
    }
-
-   console.log('slug:', slug);
 
    switch (req.method) {
       case 'GET':
          try {
-            console.log('Looking for user with username:', slug.toString());
-            const user = await findContactByUsername(slug.toString());
+            const user = await findContactByUsername(username.toString());
             if (user) {
                return res.status(200).json(user);
             } else {

--- a/src/pages/api/users/username/[username]/token.ts
+++ b/src/pages/api/users/username/[username]/token.ts
@@ -1,0 +1,117 @@
+import { getMsgFromUnknownError, TokenAlreadySpentError } from '@/utils/error';
+import { corsMiddleware, runMiddleware } from '@/utils/middleware';
+import { notifyTokenReceived } from '@/lib/notificationModels';
+import { findContactByUsername } from '@/lib/contactModels';
+import { getEncodedTokenV4, Proof } from '@cashu/cashu-ts';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { createTokenInDb } from '@/lib/tokenModels';
+import {
+   computeTxId,
+   dissectToken,
+   getCrossMintQuotes,
+   getUnspentProofs,
+   initializeWallet,
+} from '@/utils/cashu';
+import { convertToUnit } from '@/utils/convertToUnit';
+import { Currency } from '@/types';
+
+/* This endpoint is used for sending a token directly to a user's wallet. */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+   await runMiddleware(req, res, corsMiddleware);
+
+   const { username } = req.query;
+
+   if (!username || typeof username !== 'string') {
+      return res.status(400).json({ error: 'Invalid username' });
+   }
+
+   if (req.method === 'POST') {
+      const { token } = req.body;
+
+      if (!token || typeof token !== 'string') {
+         return res.status(400).json({ error: 'Invalid token' });
+      }
+
+      try {
+         const user = await findContactByUsername(username);
+         if (!user) {
+            return res.status(404).json({ error: 'User not found' });
+         }
+
+         if (!user.defaultMintUrl || !user.defaultUnit) {
+            return res.status(400).json({ error: 'User has no default mint url or unit' });
+         }
+
+         /* create new CashuWallet to receive the token */
+         const wallet = await initializeWallet(user.defaultMintUrl, { unit: user.defaultUnit });
+
+         const { proofs, mintUrl, unit } = dissectToken(token);
+
+         let newProofs: Proof[] = [];
+         let changeToken: string | undefined;
+         let amountClaimedSats: number;
+
+         if (mintUrl === user.defaultMintUrl && unit === user.defaultUnit) {
+            /* swap */
+            const unspentProofs = await getUnspentProofs(wallet, proofs);
+
+            newProofs = await wallet.receive({
+               token: [{ proofs: unspentProofs, mint: mintUrl }],
+               unit,
+            });
+
+            const proofAmt = newProofs.reduce((acc, p) => acc + p.amount, 0);
+            amountClaimedSats = await convertToUnit(proofAmt, unit, Currency.SAT);
+         } else {
+            /* melt proofs then mint into user's default wallet */
+            const meltWallet = await initializeWallet(mintUrl, { unit });
+
+            const unspentProofs = await getUnspentProofs(meltWallet, proofs);
+
+            const { mintQuote, meltQuote, amountToMint } = await getCrossMintQuotes(
+               meltWallet,
+               wallet,
+               unspentProofs.reduce((acc, p) => acc + p.amount, 0),
+            );
+
+            const { change } = await meltWallet.meltTokens(meltQuote, unspentProofs);
+            if (change.length > 0) {
+               changeToken = getEncodedTokenV4({
+                  token: [{ proofs: change, mint: meltWallet.mint.mintUrl }],
+                  unit: meltWallet.keys.unit,
+               });
+            }
+
+            const { proofs: mintedProofs } = await wallet.mintTokens(amountToMint, mintQuote.quote);
+            newProofs = mintedProofs;
+            amountClaimedSats = await convertToUnit(amountToMint, wallet.unit, Currency.SAT);
+         }
+
+         const newToken = getEncodedTokenV4({
+            token: [{ proofs: newProofs, mint: wallet.mint.mintUrl }],
+            unit: wallet.keys.unit,
+         });
+
+         const txid = computeTxId(newToken);
+         await createTokenInDb({ token }, txid);
+         await notifyTokenReceived(user.pubkey, JSON.stringify({ token: newToken }), txid);
+
+         return res.status(200).json({
+            status: 'success',
+            txid,
+            amountSats: amountClaimedSats,
+            changeToken,
+         });
+      } catch (error) {
+         if (error instanceof TokenAlreadySpentError) {
+            return res.status(400).json({ error: 'Token already spent' });
+         }
+         return res
+            .status(500)
+            .json({ error: getMsgFromUnknownError(error, 'internal server error') });
+      }
+   } else {
+      res.setHeader('Allow', ['POST', 'OPTIONS']);
+      return res.status(405).end(`Method ${req.method} Not Allowed`);
+   }
+}

--- a/src/utils/cashu.ts
+++ b/src/utils/cashu.ts
@@ -11,8 +11,10 @@ import { hashToCurve } from '@cashu/crypto/modules/common';
 import { bytesToHex } from '@noble/curves/abstract/utils';
 import { sha256 } from '@noble/hashes/sha256';
 import { getTokenFromDb } from './appApiRequests';
-import { Currency } from '@/types';
+import { CrossMintQuoteResult, Currency } from '@/types';
+import { convertToUnit } from './convertToUnit';
 import { decodeBolt11 } from './bolt11';
+import { TokenAlreadySpentError } from './error';
 
 /**
  * Only takes needed proofs and puts the rest back to local storage.
@@ -446,4 +448,59 @@ export const isMintQuoteExpired = (quote: MintQuoteResponse) => {
    const invoiceExpired = invoiceExpiry < now;
 
    return quoteExpired || invoiceExpired;
+};
+
+export const getCrossMintQuotes = async (
+   fromWallet: CashuWallet,
+   toWallet: CashuWallet,
+   totalProofsAmount: number,
+   maxAttempts = 5,
+): Promise<CrossMintQuoteResult> => {
+   let attempts = 0;
+   let amountToMint = totalProofsAmount;
+
+   while (attempts < maxAttempts) {
+      attempts++;
+
+      /* convert amount to mint to toWallet's unit */
+      const convertedAmountToMint = await convertToUnit(
+         amountToMint,
+         fromWallet.keys.unit,
+         toWallet.keys.unit,
+      );
+
+      if (convertedAmountToMint < 1) {
+         throw new Error('Token is too small to melt');
+      }
+
+      const mintQuote = await toWallet.createMintQuote(convertedAmountToMint);
+      const meltQuote = await fromWallet.createMeltQuote(mintQuote.request);
+
+      if (meltQuote.amount + meltQuote.fee_reserve <= totalProofsAmount) {
+         console.log('Found valid quotes');
+         return { mintQuote, meltQuote, amountToMint: convertedAmountToMint };
+      }
+      const difference = meltQuote.amount + meltQuote.fee_reserve - totalProofsAmount;
+      amountToMint = amountToMint - difference;
+   }
+
+   throw new Error('Failed to find valid quotes after maximum attempts.');
+};
+
+/**
+ * Returns unspent proofs or throws error if all proofs are spent
+ * @param wallet CashuWallet that the proofs are from
+ * @param proofs Proofs to check
+ * @returns Unspent proofs
+ * @throws Error if all proofs are spent
+ */
+export const getUnspentProofs = async (wallet: CashuWallet, proofs: Proof[]): Promise<Proof[]> => {
+   const alreadySpent = await wallet.checkProofsSpent(proofs);
+   const unspentProofs = proofs.filter(p => !alreadySpent.some(s => s.secret === p.secret));
+
+   if (unspentProofs.length === 0) {
+      throw new TokenAlreadySpentError();
+   }
+
+   return unspentProofs;
 };

--- a/src/utils/convertToUnit.ts
+++ b/src/utils/convertToUnit.ts
@@ -1,4 +1,4 @@
-const DEFAULT_USD_BTC_RATE = 65000;
+const DEFAULT_USD_BTC_RATE = 90_000;
 
 const getUsdToSatRate = async (): Promise<number> => {
    try {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -11,3 +11,10 @@ export const getMsgFromUnknownError = (
    }
    return errMsg;
 };
+
+export class TokenAlreadySpentError extends Error {
+   constructor(message?: string) {
+      super(message);
+      this.name = 'TokenAlreadySpentError';
+   }
+}


### PR DESCRIPTION
I added a new endpoint: `/api/users/username/[username]/token.ts`. 

## Use Case

I'm making it so that OpenTollGate (the wifi router you pay with ecash) can accept tokens and pay to a Boardwalk user.

Now anyone can send a token directly to a Boardwalk user without directly supporting cashu using a script like this:

```bash
#!/bin/sh

# Take any token as input and sendi it to a boardwalk user
# Usage: send_token_to_boardwalk.sh <token> <boardwalk_username>

BOARDWALK_ENDPOINT="https://boardwalk-git-feat-post-token-makeprisms.vercel.app"

token=$1
boardwalk_username=$2

response=$(curl -s -w "%{http_code}" -X POST -H "Content-Type: application/json" -d "{\"token\": \"$token\"}" "$BOARDWALK_ENDPOINT/api/users/username/$boardwalk_username/token")

echo "$response"

http_code=$(echo "$response" | tail -c 4)
body=$(echo "$response" | head -c -4)

if [ "$http_code" != "200" ]; then
    # Simple grep and sed to extract error message between quotes after "error":
    error_msg=$(echo "$body" | grep -o '"error":"[^"]*"' | sed 's/"error":"\(.*\)"/\1/')
    if [ -z "$error_msg" ]; then
        error_msg="Unknown error"
    fi
    echo "Error: HTTP status code $http_code - $error_msg"
    exit 1
fi

# Extract amount_sats using grep and sed to find number after "amountSats":
amount_sats=$(echo "$body" | grep -o '"amountSats":[0-9]*' | sed 's/"amountSats":\([0-9]*\)/\1/')
echo ""
echo "=========================================================="
echo "Successfully sent $amount_sats sats to $boardwalk_username"
echo "============================================================"

```