### PR TITLE
set base path for open graph requests

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -21,6 +21,7 @@ interface CustomPageProps {
    pageTitle?: string;
    pageDescription?: string;
    giftPath?: string;
+   baseRequestUrl?: string;
 }
 
 const defaultPageDescription = 'The easiest way to send and receive cash.';
@@ -28,11 +29,11 @@ const defaultPageTitle = 'Boardwalk Cash';
 
 type CustomAppProps = AppProps<CustomPageProps>;
 export default function App({ Component, pageProps }: CustomAppProps) {
-   const { pageTitle, pageDescription, giftPath } = pageProps;
+   const { pageTitle, pageDescription, giftPath, baseRequestUrl } = pageProps;
    useViewportHeight();
    const router = useRouter();
 
-   const previewImg = `${typeof window !== 'undefined' ? window.location.origin : 'https://boardwalkcash.com'}${giftPath || '/logo-url-preview.png'}`;
+   const previewImg = `${baseRequestUrl || 'https://boardwalkcash.com'}${giftPath || '/logo-url-preview.png'}`;
 
    useEffect(() => {
       const checkAdminAccess = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next/types';
+import { getRequestedDomainFromRequest } from '@/utils/url';
 
 export default function Home() {
    const router = useRouter();
@@ -16,3 +18,15 @@ export default function Home() {
 
    return;
 }
+
+export const getServerSideProps: GetServerSideProps = async (
+   context: GetServerSidePropsContext,
+) => {
+   const baseRequestUrl = getRequestedDomainFromRequest(context.req);
+
+   return {
+      props: {
+         baseRequestUrl,
+      },
+   };
+};

--- a/src/pages/wallet.tsx
+++ b/src/pages/wallet.tsx
@@ -23,7 +23,7 @@ import { useCashuContext } from '@/hooks/contexts/cashuContext';
 import { PublicContact, TokenProps, GiftAsset, Currency } from '@/types';
 import { findContactByPubkey, isContactsTrustedMint } from '@/lib/contactModels';
 import { proofsLockedTo } from '@/utils/cashu';
-import { formatUrl } from '@/utils/url';
+import { formatUrl, getRequestedDomainFromRequest } from '@/utils/url';
 import NotificationDrawer from '@/components/notifications/NotificationDrawer';
 import { formatTokenAmount } from '@/utils/formatting';
 import { findTokenByTxId } from '@/lib/tokenModels';
@@ -292,6 +292,8 @@ export const getServerSideProps: GetServerSideProps = async (
    let gift: GiftAsset | undefined = undefined;
    const txid = context.query.txid as string;
 
+   const baseRequestUrl = getRequestedDomainFromRequest(context.req);
+
    if (txid && !token) {
       const tokenEntry = await findTokenByTxId(txid);
       if (tokenEntry) {
@@ -338,6 +340,7 @@ export const getServerSideProps: GetServerSideProps = async (
          pageTitle: pageTitle(tokenData) || null,
          pageDescription: pageDescription(tokenData) || null,
          giftPath,
+         baseRequestUrl,
       },
    };
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage } from 'http';
 import { NextApiRequest } from 'next';
 export const normalizeUrl = (url: string): string => {
    url = url.trim();
@@ -20,5 +21,14 @@ export const formatUrl = (url: string, maxLength: number = 20): string => {
 export const getBaseURLFromRequest = (req: NextApiRequest) => {
    const host = req.headers.host;
    const protocol = req.headers.referer?.split('://')[0] || 'https';
+   return `${protocol}://${host}`;
+};
+
+export const getRequestedDomainFromRequest = (req: IncomingMessage) => {
+   const host = req.headers.host;
+   let protocol = req.headers.referer?.split('://')[0] || 'https';
+   if (host?.includes('localhost') || host?.includes('127.0.0.1')) {
+      protocol = 'http';
+   }
    return `${protocol}://${host}`;
 };


### PR DESCRIPTION
Get the domain of the requested app so that the gifts and preview image urls resolve to the deployment being used.

Falls back to https://boardwalkcash.com 
