### PR TITLE
patch/payment-request-amounts

### DIFF
--- a/src/components/buttons/Send/SendFlow.tsx
+++ b/src/components/buttons/Send/SendFlow.tsx
@@ -59,7 +59,7 @@ type SendFlowState = {
    | {
         step: 'confirmPaymentRequest';
         paymentRequest: PaymentRequest;
-        amount: number;
+        displayAmount: number;
         amountToPay: number;
      }
    | {
@@ -115,7 +115,7 @@ const SendFlow = ({ onClose }: SendFlowProps) => {
             ...state,
             step: 'confirmPaymentRequest',
             paymentRequest,
-            amount: input,
+            displayAmount: input,
             amountToPay,
          }));
       } else if (state.activeTab === 'ecash') {
@@ -228,12 +228,12 @@ const SendFlow = ({ onClose }: SendFlowProps) => {
                ...state,
                step: 'confirmPaymentRequest',
                paymentRequest: decoded,
-               amount: numpadAmount,
+               displayAmount: numpadAmount,
                amountToPay,
             });
          }
       } else {
-         const amount = await convertToUnit(
+         const displayAmount = await convertToUnit(
             decoded.amount,
             (decoded.unit as Currency) || Currency.SAT,
             activeUnit,
@@ -242,7 +242,7 @@ const SendFlow = ({ onClose }: SendFlowProps) => {
             ...state,
             step: 'confirmPaymentRequest',
             paymentRequest: decoded,
-            amount,
+            displayAmount,
             amountToPay: decoded.amount,
             isProcessing: false,
          });
@@ -356,9 +356,9 @@ const SendFlow = ({ onClose }: SendFlowProps) => {
          {state.step === 'confirmPaymentRequest' && (
             <ConfirmAndPayPaymentRequest
                paymentRequest={state.paymentRequest}
-               requestAmount={state.amountToPay}
+               amountToPay={state.amountToPay}
+               displayAmount={state.displayAmount}
                onClose={onClose}
-               displayAmount={state.amount}
             />
          )}
          {state.step === 'shareEcash' && (

--- a/src/components/views/ConfirmAndPayPaymentRequest.tsx
+++ b/src/components/views/ConfirmAndPayPaymentRequest.tsx
@@ -9,16 +9,16 @@ import { useCashuContext } from '@/hooks/contexts/cashuContext';
 
 interface MyProps {
    paymentRequest: PaymentRequest;
-   requestAmount: number;
+   amountToPay: number;
    displayAmount: number;
    onClose: () => void;
 }
 
 const ConfirmAndPayPaymentRequest = ({
    paymentRequest,
-   requestAmount,
-   onClose,
+   amountToPay,
    displayAmount,
+   onClose,
 }: MyProps) => {
    const [isProcessing, setIsProcessing] = useState(false);
 
@@ -34,7 +34,7 @@ const ConfirmAndPayPaymentRequest = ({
    const handleSendPaymentRequest = async () => {
       try {
          setIsProcessing(true);
-         const res = await payPaymentRequest(paymentRequest, requestAmount);
+         const res = await payPaymentRequest(paymentRequest, amountToPay);
          if (res === true) {
             addToast('Payment request paid!', 'success');
          } else {

--- a/src/components/views/ConfirmAndPayPaymentRequest.tsx
+++ b/src/components/views/ConfirmAndPayPaymentRequest.tsx
@@ -3,20 +3,27 @@ import PaymentConfirmationDetails from './PaymentConfirmationDetails';
 import { PaymentRequest } from '@cashu/cashu-ts';
 import { useToast } from '@/hooks/util/useToast';
 import { Button } from 'flowbite-react';
-import { Currency } from '@/types';
 import { useState } from 'react';
 import { getMsgFromUnknownError } from '@/utils/error';
+import { useCashuContext } from '@/hooks/contexts/cashuContext';
 
 interface MyProps {
    paymentRequest: PaymentRequest;
    requestAmount: number;
+   displayAmount: number;
    onClose: () => void;
 }
 
-const ConfirmAndPayPaymentRequest = ({ paymentRequest, requestAmount, onClose }: MyProps) => {
+const ConfirmAndPayPaymentRequest = ({
+   paymentRequest,
+   requestAmount,
+   onClose,
+   displayAmount,
+}: MyProps) => {
    const [isProcessing, setIsProcessing] = useState(false);
 
    const { payPaymentRequest } = usePaymentRequests();
+   const { activeUnit } = useCashuContext();
    const { addToast } = useToast();
 
    const handleClose = () => {
@@ -44,8 +51,8 @@ const ConfirmAndPayPaymentRequest = ({ paymentRequest, requestAmount, onClose }:
    return (
       <div className='text-black flex flex-col items-center justify-between h-full'>
          <PaymentConfirmationDetails
-            amount={requestAmount}
-            unit={(paymentRequest?.unit as Currency) || Currency.SAT}
+            amount={displayAmount}
+            unit={activeUnit}
             destination={paymentRequest?.toEncodedRequest()}
          />
          <Button


### PR DESCRIPTION
This fixes an issues with a difference in activeUnit and the payment request's unit. We would always pay the request as if it was our active unit which would result in something like trying to pay 5 cents, but actually paying 5 sats. 

To fix it, I differentiate between amountToPay and displayAmount`where displayAmount matches the user's activeUnit

I could not come up with a more intuitive way to achieve this. What I do is every time the payment request amount is set, I convert the amountToPay from the input amount to the amount in the unit of the payment request. If the request already has an amount, then I convert the payment request amount to the user's activeUnit for the displayAmount