### PR TITLE
fix bug when calculating invoice expiry

### DIFF
--- a/src/lib/mintQuoteModels.ts
+++ b/src/lib/mintQuoteModels.ts
@@ -20,7 +20,7 @@ export const createMintQuote = async (
          request,
          pubkey,
          amount: amountUnit ? amountUnit : amount, // this is a hack to get the amount in the correct unit
-         expiryUnix: expiry,
+         expiryUnix: expiry || Infinity,
          paid: false,
          mintKeysetId: keysetId,
       },

--- a/src/utils/bolt11.ts
+++ b/src/utils/bolt11.ts
@@ -18,11 +18,12 @@ export const decodeBolt11 = (invoice: string) => {
    const amountSection = findSection(decoded.sections, 'amount');
    const amountSat = amountSection?.value ? Number(amountSection.value) / 1000 : undefined;
 
+   const expirySection = findSection(decoded.sections, 'expiry');
    const timestampSection = findSection(decoded.sections, 'timestamp');
 
    let expiryUnixSec: number | undefined = undefined;
-   if (decoded.expiry && timestampSection) {
-      expiryUnixSec = timestampSection.value + decoded.expiry;
+   if (expirySection && timestampSection) {
+      expiryUnixSec = timestampSection.value + expirySection.value;
    }
 
    const expiryUnixMs = expiryUnixSec ? expiryUnixSec * 1000 : undefined;

--- a/src/utils/bolt11.ts
+++ b/src/utils/bolt11.ts
@@ -10,7 +10,7 @@ const findSection = <T extends Section['name']>(
 /**
  * Decodes a BOLT11 invoice
  * @param invoice invoice to decode
- * @returns decoded invoice data
+ * @returns invoice `amountSat` and `expiryUnixMs`. `expiryUnixMs` is undefined if the invoice does not have an expiry
  */
 export const decodeBolt11 = (invoice: string) => {
    const decoded = bolt11Decoder.decode(invoice);

--- a/src/utils/bolt11.ts
+++ b/src/utils/bolt11.ts
@@ -18,16 +18,14 @@ export const decodeBolt11 = (invoice: string) => {
    const amountSection = findSection(decoded.sections, 'amount');
    const amountSat = amountSection?.value ? Number(amountSection.value) / 1000 : undefined;
 
-   const expirySection = findSection(decoded.sections, 'expiry');
    const timestampSection = findSection(decoded.sections, 'timestamp');
 
-   /* infinity if no expiry is defined */
-   let expiryUnixSec = Infinity;
-   if (expirySection && timestampSection) {
-      expiryUnixSec = timestampSection.value + expirySection.value;
-   } else if (decoded.expiry && timestampSection) {
+   let expiryUnixSec: number | undefined = undefined;
+   if (decoded.expiry && timestampSection) {
       expiryUnixSec = timestampSection.value + decoded.expiry;
    }
 
-   return { amountSat, expiryUnixMs: expiryUnixSec * 1000 };
+   const expiryUnixMs = expiryUnixSec ? expiryUnixSec * 1000 : undefined;
+
+   return { amountSat, expiryUnixMs };
 };

--- a/src/utils/bolt11.ts
+++ b/src/utils/bolt11.ts
@@ -18,8 +18,16 @@ export const decodeBolt11 = (invoice: string) => {
    const amountSection = findSection(decoded.sections, 'amount');
    const amountSat = amountSection?.value ? Number(amountSection.value) / 1000 : undefined;
 
-   const expiryUnixSeconds = decoded.expiry;
-   const expiryUnixMs = decoded.expiry * 1000;
+   const expirySection = findSection(decoded.sections, 'expiry');
+   const timestampSection = findSection(decoded.sections, 'timestamp');
 
-   return { amountSat, expiryUnixMs };
+   /* infinity if no expiry is defined */
+   let expiryUnixSec = Infinity;
+   if (expirySection && timestampSection) {
+      expiryUnixSec = timestampSection.value + expirySection.value;
+   } else if (decoded.expiry && timestampSection) {
+      expiryUnixSec = timestampSection.value + decoded.expiry;
+   }
+
+   return { amountSat, expiryUnixMs: expiryUnixSec * 1000 };
 };

--- a/src/utils/cashu.ts
+++ b/src/utils/cashu.ts
@@ -443,7 +443,7 @@ export const isMintQuoteExpired = (quote: MintQuoteResponse) => {
    const now = Math.floor(Date.now()) - 15;
 
    const quoteExpired = quote.expiry && quote.expiry * 1000 < now;
-   const invoiceExpired = invoiceExpiry < now;
+   const invoiceExpired = invoiceExpiry ? invoiceExpiry < now : false;
 
    return quoteExpired || invoiceExpired;
 };


### PR DESCRIPTION
I assumed that the expiry on the invoice was the absolute timestamp, but its actually relative to the timestamp. To correctly get the expiry we add it to the timestamp of the invoice﻿
