### PR TITLE
revert to  swapping before melting

### DIFF
--- a/src/hooks/cashu/useCashu.ts
+++ b/src/hooks/cashu/useCashu.ts
@@ -590,9 +590,9 @@ export const useCashu = () => {
       dispatch(setSending('Sending...'));
 
       try {
-         const proofsToSend = getProofsByAmount(
+         const proofsToSend = await getProofsToSend(
             meltQuote.amount + meltQuote.fee_reserve,
-            wallet.keys.id,
+            wallet,
          );
 
          if (!proofsToSend || proofsToSend.length === 0) {


### PR DESCRIPTION
I had wrongly assumed that cashu-ts would create change outputs for any overpaid amount put into the library. What the library actually does is create outputs only for fees (see attached pic). To fix it I reverted a change I had made in #123 that removed what I thought was an unnecessary swap. Now we will swap for the exact amount of ecash before melting. This creates an unnecessary swap, but prevents loss of funds. It looks like in cashu-ts V2 this is fixed (see [here](https://github.com/cashubtc/cashu-ts/blob/development/src/CashuWallet.ts#L755))

![image](https://github.com/user-attachments/assets/7305154f-0574-4b39-842b-30346ff82079)
