### PR TITLE
set loading false if user not setup boardwalk

### DIFF
--- a/src/pages/wallet.tsx
+++ b/src/pages/wallet.tsx
@@ -61,6 +61,8 @@ export default function Home({ token }: { token?: string }) {
    useEffect(() => {
       if (user.status === 'failed') {
          setLoadingState(false);
+      } else if (user.status === 'idle' && !loadingExchangeRate && !loadingBalance) {
+         setLoadingState(false);
       } else if (user.status !== 'succeeded' || loadingExchangeRate || loadingBalance) {
          setLoadingState(true);
       } else if (user.status === 'succeeded' && !loadingExchangeRate && !loadingBalance) {


### PR DESCRIPTION
initializeUser is not called﻿ when the user has not set up boardwalk and they are viewing a gift link, so we need to check if the user.status is 'idle' to setLoading(false) otherwise the page will say 'Loading...' forever when a user that has never visited boardwalk clicks on a sharable link
