### PR TITLE
convert decoded nsec from Uint8Array

### DIFF
--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -1,5 +1,5 @@
 import { NostrError } from '@/types';
-import { hexToBytes } from '@noble/curves/abstract/utils';
+import { bytesToHex, hexToBytes } from '@noble/curves/abstract/utils';
 import NDK, {
    NDKEvent,
    NDKKind,
@@ -37,7 +37,8 @@ const initializeNDK = async (relays = defaultRelays) => {
       privkey = process.env.BOARDWALK_NOSTR_PRIVKEY;
    }
    if (privkey?.startsWith('nsec1')) {
-      privkey = nip19.decode(privkey).data as string;
+      privkey = nip19.decode(privkey).data as Uint8Array;
+      privkey = bytesToHex(privkey);
    }
    if (!privkey) {
       throw new Error('Boardwalk Nostr private key not found');

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -37,7 +37,7 @@ const initializeNDK = async (relays = defaultRelays) => {
       privkey = process.env.BOARDWALK_NOSTR_PRIVKEY;
    }
    if (privkey?.startsWith('nsec1')) {
-      privkey = nip19.decode(privkey).data as Uint8Array;
+      privkey = nip19.decode<'nsec'>(privkey as `nsec1${string}`).data;
       privkey = bytesToHex(privkey);
    }
    if (!privkey) {


### PR DESCRIPTION
nostr-tools got updated and made this breaking change. nip19.decode used to return a string, now it returns a Uint8Array when the data is an nsec