### PR TITLE
add class sorting to biome config

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '~/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -75,6 +75,15 @@
         "noUnsafeNegation": "error",
         "useGetterReturn": "error",
         "useValidTypeof": "error"
+      },
+      "nursery": {
+        "useSortedClasses": {
+          "options": {
+            "functions": ["cva", "clsx"]
+          },
+          "level": "error",
+          "fix": "safe"
+        }
       }
     }
   },


### PR DESCRIPTION
Use useSortedClasses to improve readability of tailwind class lists. Adapted the [tailwind recommend IDE setup](https://tailwindcss.com/docs/editor-setup) to use biome instead of prettier

Please see [the biome docs](https://biomejs.dev/linter/rules/use-sorted-classes/). They say this is considered an "unsafe" feature. I marked it as safe in our biome config so that it gets auto-fixed. I assume it's unsafe just because it's still "in the nursery" ie. beta, but let me know what you think about auto-fixing based on what they say in the docs about it. All that it does is reorder classes lists based on some heuristic

