### PR TITLE
Use docker image with Playwright already installed when running Playwright github workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,9 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.49.1-noble
+      options: --user 1001
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -19,9 +22,9 @@ jobs:
 
     - name: Install dependencies
       run: bun install --frozen-lockfile
-
-    - name: Install Playwright Browsers
-      run: bunx playwright install --with-deps
+#
+#    - name: Install Playwright Browsers
+#      run: bunx playwright install --with-deps
 
     - name: Run Playwright tests
       run: bun run test:e2e


### PR DESCRIPTION
Testing if this will be faster than installing the playwright and the browsers