### PR TITLE
simple presentational money display component

### DIFF
--- a/app/components/money-display.tsx
+++ b/app/components/money-display.tsx
@@ -7,7 +7,6 @@ export interface MoneyInputDisplayProps {
   inputValue: string;
   currency: Currency;
   unit: CurrencyUnit<Currency>;
-  className?: string;
   locale?: string;
 }
 
@@ -16,7 +15,6 @@ export function MoneyInputDisplay({
   currency,
   unit,
   locale,
-  className,
 }: MoneyInputDisplayProps) {
   const money = new Money({ amount: inputValue, currency, unit });
   const {
@@ -46,14 +44,12 @@ export function MoneyInputDisplay({
     ? '0'.repeat(numberOfDecimals - inputDecimals.length)
     : '';
 
-  const symbol = (
-    <span className="font-bold text-[3.45rem]">{currencySymbol}</span>
-  );
+  const symbol = <span className="text-[3.45rem]">{currencySymbol}</span>;
 
   return (
-    <div className={cn('inline-flex w-fit items-center', className)}>
+    <span className="font-bold">
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className="pt-2 font-bold font-numeric text-6xl">
+      <span className="pt-2 font-numeric text-6xl">
         {integer}
         {(inputDecimals || needsPaddedZeros) && (
           <>
@@ -66,7 +62,7 @@ export function MoneyInputDisplay({
         )}
       </span>
       {currencySymbolPosition === 'suffix' && symbol}
-    </div>
+    </span>
   );
 }
 
@@ -75,6 +71,7 @@ type MoneyDisplayProps = {
   locale?: string;
   unit?: CurrencyUnit<Currency>;
   size?: 'sm' | 'default';
+  className?: string;
 };
 
 const sizes = {
@@ -93,6 +90,7 @@ export function MoneyDisplay({
   locale,
   unit,
   size = 'default',
+  className,
 }: MoneyDisplayProps) {
   const {
     currencySymbol,
@@ -102,25 +100,17 @@ export function MoneyDisplay({
     fraction,
   } = money.toLocalizedStringParts({ locale, unit });
 
+  const value = `${integer}${decimalSeparator}${fraction}`;
+
   const symbol = (
-    <span className={cn('font-bold', sizes[size].symbol)}>
-      {currencySymbol}
-    </span>
+    <span className={cn(sizes[size].symbol)}>{currencySymbol}</span>
   );
 
   return (
-    <div className={cn('inline-flex w-fit items-center')}>
+    <span className={cn('font-bold', className)}>
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className={cn('font-bold font-numeric', sizes[size].value)}>
-        {integer}
-        {fraction && (
-          <>
-            <span>{decimalSeparator}</span>
-            <span>{fraction}</span>
-          </>
-        )}
-      </span>
+      <span className={cn('font-numeric', sizes[size].value)}>{value}</span>
       {currencySymbolPosition === 'suffix' && symbol}
-    </div>
+    </span>
   );
 }

--- a/app/components/money-display.tsx
+++ b/app/components/money-display.tsx
@@ -2,24 +2,12 @@ import type { Currency, CurrencyUnit } from '~/lib/money';
 import { Money } from '~/lib/money';
 import { cn } from '~/lib/utils';
 
-const sizes = {
-  sm: {
-    symbol: 'text-[1.2rem]',
-    value: 'text-2xl pt-1',
-  },
-  default: {
-    symbol: 'text-[3.45rem]',
-    value: 'text-6xl pt-2',
-  },
-} as const;
-
 export interface MoneyInputDisplayProps {
   /** Raw input value from user (e.g., "1", "1.", "1.0") */
   inputValue: string;
   currency: Currency;
   unit: CurrencyUnit<Currency>;
   className?: string;
-  size?: 'sm' | 'default';
   locale?: string;
 }
 
@@ -28,7 +16,6 @@ export function MoneyInputDisplay({
   currency,
   unit,
   locale,
-  size = 'default',
   className,
 }: MoneyInputDisplayProps) {
   const money = new Money({ amount: inputValue, currency, unit });
@@ -60,15 +47,13 @@ export function MoneyInputDisplay({
     : '';
 
   const symbol = (
-    <span className={cn('font-bold', sizes[size].symbol)}>
-      {currencySymbol}
-    </span>
+    <span className="font-bold text-[3.45rem]">{currencySymbol}</span>
   );
 
   return (
     <div className={cn('inline-flex w-fit items-center', className)}>
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className={cn('font-bold font-numeric', sizes[size].value)}>
+      <span className="pt-2 font-bold font-numeric text-6xl">
         {integer}
         {(inputDecimals || needsPaddedZeros) && (
           <>
@@ -77,6 +62,61 @@ export function MoneyInputDisplay({
             {paddedZeros && (
               <span className="text-gray-400">{paddedZeros}</span>
             )}
+          </>
+        )}
+      </span>
+      {currencySymbolPosition === 'suffix' && symbol}
+    </div>
+  );
+}
+
+type MoneyDisplayProps = {
+  money: Money<Currency>;
+  locale?: string;
+  unit?: CurrencyUnit<Currency>;
+  size?: 'sm' | 'default';
+};
+
+const sizes = {
+  sm: {
+    symbol: 'text-[1.2rem]',
+    value: 'text-2xl pt-1',
+  },
+  default: {
+    symbol: 'text-[3.45rem]',
+    value: 'text-6xl pt-2',
+  },
+} as const;
+
+export function MoneyDisplay({
+  money,
+  locale,
+  unit,
+  size = 'default',
+}: MoneyDisplayProps) {
+  const {
+    currencySymbol,
+    currencySymbolPosition,
+    integer,
+    decimalSeparator,
+    fraction,
+  } = money.toLocalizedStringParts({ locale, unit });
+
+  const symbol = (
+    <span className={cn('font-bold', sizes[size].symbol)}>
+      {currencySymbol}
+    </span>
+  );
+
+  return (
+    <div className={cn('inline-flex w-fit items-center')}>
+      {currencySymbolPosition === 'prefix' && symbol}
+      <span className={cn('font-bold font-numeric', sizes[size].value)}>
+        {integer}
+        {fraction && (
+          <>
+            <span>{decimalSeparator}</span>
+            <span>{fraction}</span>
           </>
         )}
       </span>

--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -4,6 +4,7 @@ import Big from 'big.js';
 import { Cog } from 'lucide-react';
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import {
+  MoneyDisplay,
   MoneyInputDisplay,
   type MoneyInputDisplayProps,
 } from '~/components/money-display';
@@ -25,7 +26,7 @@ import { useAuthActions } from '~/features/user/auth';
 import { useUserStore } from '~/features/user/user-provider';
 import { toast } from '~/hooks/use-toast';
 import type { Rates } from '~/lib/exchange-rate/providers/types';
-import { Money } from '~/lib/money';
+import { type Currency, Money } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { buildEmailValidator } from '~/lib/validation';
 
@@ -43,7 +44,6 @@ const testMoneys: Record<string, MoneyInputDisplayProps> = {
     inputValue: '1432',
     currency: 'BTC',
     unit: 'btc',
-    size: 'sm',
   },
   '1,432.35 btc unit': {
     inputValue: '1432.35',
@@ -188,6 +188,13 @@ export default function Index() {
             </div>
           );
         })}
+      </div>
+      <br />
+      <div>
+        Basic money display:
+        <MoneyDisplay
+          money={new Money({ amount: 1, currency: 'USD' }) as Money<Currency>}
+        />
       </div>
 
       <br />


### PR DESCRIPTION
Here I added a `MoneyDisplay` component that is used just for display `Money` without doing any padding of zeros.

I also removed the sizes form the MoneyInputDisplay to your point [in this comment](https://github.com/MakePrisms/boardwalkcash/pull/257/files#r1901362945)