### PR TITLE
Configure live Supabase env via config file.

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "eepvxhmgmtasvfzwlrbh"
+project_id = "boardwalk"
 
 [api]
 enabled = true

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -276,3 +276,29 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+# CONFIGS FOR PERSISTENT BRANCHES BELLOW:
+# Settings above are applied to local enviroment and hosted preview environments (feature branches) that are ephemeral.
+# For persitent branches like `master` we need to use [remotes]. See the docs here
+# https://supabase.com/docs/guides/deployment/branching?queryGroups=platform&platform=existing#branch-configuration-with-remotes
+
+# Master configs (live enviroment):
+# we are only specifying overriden defaults here for now
+[remotes.master]
+project_id = "eepvxhmgmtasvfzwlrbh"
+
+#[remotes.master.api]
+## Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+## endpoints. `public` and `graphql_public` schemas are included by default.
+#schemas = ["wallet"]
+## Extra schemas to add to the search_path of every request.
+#extra_search_path = ["public", "extensions"]
+#
+#[remotes.master.auth]
+#enabled = false
+## Allow/disallow new user signups to your project.
+#enable_signup = false
+#
+#[remotes.master.auth.email]
+## Allow/disallow new user signups via email to your project.
+#enable_signup = false


### PR DESCRIPTION
config.toml settings are not applied to master env after all. see screenshot:

![Screenshot 2025-01-22 at 11 58 06](https://github.com/user-attachments/assets/d363b0ef-9e32-4834-9c11-a46b3ce7d401)

My initial understanding that for persistent branches we need to configure [remotes] might have been correct. Testing that here