### PR TITLE
add username and make it editable

### DIFF
--- a/app/animations.css
+++ b/app/animations.css
@@ -1,0 +1,55 @@
+.animate-shake {
+  animation: shake 0.4s ease-out both;
+  transform-origin: center;
+  display: inline-block;
+}
+
+.animate-slam {
+  animation: slam 0.4s ease-out both;
+  transform-origin: center;
+  display: inline-block;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  75% {
+    transform: translateX(-5px);
+  }
+}
+
+@keyframes slam {
+  0% {
+    transform: scale(1);
+    letter-spacing: normal;
+    opacity: 1;
+  }
+  25% {
+    transform: scale(1.05);
+    letter-spacing: 0.05em;
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(0.98);
+    letter-spacing: -0.02em;
+    opacity: 0.95;
+  }
+  75% {
+    transform: scale(1.02);
+    letter-spacing: 0.02em;
+    opacity: 0.98;
+  }
+  100% {
+    transform: scale(1);
+    letter-spacing: normal;
+    opacity: 1;
+  }
+}

--- a/app/features/settings/profile/edit-profile.tsx
+++ b/app/features/settings/profile/edit-profile.tsx
@@ -1,34 +1,12 @@
-import { useNavigate } from '@remix-run/react';
-import { useForm } from 'react-hook-form';
 import { PageContent } from '~/components/page';
-import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
+import { Separator } from '~/components/ui/separator';
 import { UpgradeGuestForm } from '~/features/settings/profile/upgrade-guest-form';
 import { SettingsViewHeader } from '~/features/settings/ui/settings-view-header';
 import { useUser } from '~/features/user/user-hooks';
-
-type ProfileForm = {
-  username: string;
-};
+import EditableUsername from './editable-username';
 
 export default function EditProfile() {
-  const navigate = useNavigate();
-  const user = useUser();
-
-  const { register, handleSubmit } = useForm<ProfileForm>({
-    defaultValues: {
-      username: 'satoshi', // This should come from actual user data
-    },
-  });
-  const onSubmit = async (data: ProfileForm) => {
-    try {
-      // TODO: Implement username update logic
-      console.log('Updating username...', data.username);
-      navigate('/settings');
-    } catch {
-      // TODO
-    }
-  };
+  const isGuest = useUser((s) => s.isGuest);
 
   return (
     <>
@@ -40,23 +18,14 @@ export default function EditProfile() {
           applyTo: 'oldView',
         }}
       />
-      <PageContent className="gap-4">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="username" className="font-medium text-sm">
-              Username
-            </label>
-            <Input
-              id="username"
-              {...register('username', { required: true })}
-              placeholder="Enter your username"
-            />
-          </div>
-          <Button type="submit" className="w-full">
-            Save Changes
-          </Button>
-        </form>
-        {user.isGuest && <UpgradeGuestForm />}
+      <PageContent className="gap-6">
+        <EditableUsername />
+        {isGuest && (
+          <>
+            <Separator />
+            <UpgradeGuestForm />
+          </>
+        )}
       </PageContent>
     </>
   );

--- a/app/features/settings/profile/editable-username.tsx
+++ b/app/features/settings/profile/editable-username.tsx
@@ -1,0 +1,153 @@
+import { Check, Edit } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Button } from '~/components/ui/button';
+import { useUpdateUsername, useUser } from '~/features/user/user-hooks';
+import useAnimation from '~/hooks/use-animation';
+import { useToast } from '~/hooks/use-toast';
+import { cn } from '~/lib/utils';
+
+// Reserved routes that can't be used as usernames
+// QUESTION: can we do this more efficiently so that
+// we don't have to update for every new route?
+const RESERVED_ROUTES = [
+  'settings',
+  'profile',
+  'login',
+  'signup',
+  'api',
+  'admin',
+  'help',
+  'about',
+  'terms',
+  'privacy',
+  'receive',
+  'send',
+  'verify-email',
+];
+
+type FormValues = {
+  username: string;
+};
+
+function validateUsername(username: string) {
+  // Check length (3-20 characters)
+  if (username.length < 3 || username.length > 20) {
+    return 'Username must be between 3 and 20 characters';
+  }
+
+  // Check characters (only a-z, 0-9, underscore, hyphen allowed)
+  // This requirement comes from LUD16 https://github.com/lnurl/luds/blob/luds/16.md
+  if (!/^[a-z0-9_-]+$/.test(username)) {
+    return 'Username can only contain lowercase letters, numbers, underscores and hyphens';
+  }
+
+  if (RESERVED_ROUTES.includes(username.toLowerCase())) {
+    return 'This username is not available';
+  }
+
+  return true;
+}
+
+export default function EditableUsername() {
+  const { animationClass, start: startAnimation } = useAnimation({
+    name: 'slam',
+    durationMs: 400,
+  });
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const user = useUser();
+  const updateUsername = useUpdateUsername();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      username: user.username,
+    },
+  });
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    isEditing && inputRef.current?.focus();
+  }, [isEditing]);
+
+  const onSubmit = async (data: FormValues) => {
+    if (data.username === user.username) {
+      setIsEditing(false);
+      return;
+    }
+
+    try {
+      await updateUsername(data.username);
+      startAnimation();
+      setIsEditing(false);
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to update username',
+      });
+    }
+  };
+
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsEditing(true);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className={'flex w-full flex-col gap-2'}
+    >
+      <div className="flex items-center gap-2">
+        <div className={cn('flex-1', animationClass)}>
+          {isEditing ? (
+            <input
+              {...register('username')}
+              ref={(e) => {
+                register('username', { validate: validateUsername }).ref(e);
+                // @ts-ignore: says it's readonly, but this works
+                inputRef.current = e;
+              }}
+              type="text"
+              autoComplete="username"
+              className="w-full bg-transparent text-2xl text-white outline-none"
+            />
+          ) : (
+            <span className="text-2xl text-white">{watch('username')}</span>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={handleEditClick}
+            className={cn(isEditing && 'invisible')}
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+
+          <Button
+            type="submit"
+            variant="ghost"
+            size="icon"
+            className={cn(!isEditing && 'invisible')}
+          >
+            <Check className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {errors.username && (
+        <div className="text-destructive text-sm">
+          {errors.username.message}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/app/features/settings/profile/upgrade-guest-form.tsx
+++ b/app/features/settings/profile/upgrade-guest-form.tsx
@@ -1,12 +1,5 @@
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import { Button } from '~/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { useUpgradeGuestToFullAccount } from '~/features/user/user-hooks';
@@ -48,15 +41,15 @@ export function UpgradeGuestForm() {
   };
 
   return (
-    <Card className="mx-auto max-w-sm">
-      <CardHeader>
-        <CardTitle>Upgrade</CardTitle>
-        <CardDescription>
+    <div className="mx-auto max-w-sm">
+      <div className="mb-6">
+        <h2 className="font-semibold text-lg">Upgrade</h2>
+        <p className="text-muted-foreground text-sm">
           Enter your email and password to backup your account and sync across
           devices.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
+        </p>
+      </div>
+      <div>
         <form
           className="mt-2 grid gap-4"
           onSubmit={handleSubmit(onSubmit)}
@@ -124,7 +117,7 @@ export function UpgradeGuestForm() {
             Upgrade to full account
           </Button>
         </form>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -13,12 +13,12 @@ import { LinkWithViewTransition } from '~/lib/transitions';
 import { useDefaultAccount } from '../accounts/account-hooks';
 import { AccountTypeIcon } from '../accounts/account-icons';
 import { useAuthActions } from '../user/auth';
-
-const username = 'satoshi';
+import { useUser } from '../user/user-hooks';
 
 export default function Settings() {
   const { signOut } = useAuthActions();
   const defaultAccount = useDefaultAccount();
+  const username = useUser((s) => s.username);
 
   const handleShare = async () => {
     const data = {

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -212,3 +212,12 @@ export const useSetDefaultAccount = () => {
     [updateUser],
   );
 };
+
+export const useUpdateUsername = () => {
+  const { mutateAsync: updateUser } = useUpdateUser();
+
+  return useCallback(
+    (username: string) => updateUser({ username }),
+    [updateUser],
+  );
+};

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -9,6 +9,7 @@ export type UpdateUser = {
   defaultBtcAccountId?: string;
   defaultUsdAccountId?: string;
   defaultCurrency?: Currency;
+  username?: string;
 };
 
 export class UserRepository {
@@ -54,6 +55,7 @@ export class UserRepository {
         default_btc_account_id: data.defaultBtcAccountId,
         default_usd_account_id: data.defaultUsdAccountId,
         default_currency: data.defaultCurrency,
+        username: data.username,
       })
       .eq('id', userId)
       .select();
@@ -136,6 +138,7 @@ export class UserRepository {
     if (dbUser.email) {
       return {
         id: dbUser.id,
+        username: dbUser.username,
         email: dbUser.email,
         emailVerified: dbUser.email_verified,
         createdAt: dbUser.created_at,
@@ -149,6 +152,7 @@ export class UserRepository {
 
     return {
       id: dbUser.id,
+      username: dbUser.username,
       emailVerified: dbUser.email_verified,
       createdAt: dbUser.created_at,
       updatedAt: dbUser.updated_at,
@@ -157,5 +161,20 @@ export class UserRepository {
       defaultCurrency: dbUser.default_currency,
       isGuest: true,
     };
+  }
+
+  async updateUsername(userId: string, username: string) {
+    const { data, error } = await this.db
+      .from('users')
+      .update({ username })
+      .eq('id', userId)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error('Failed to update username', error);
+    }
+
+    return data;
   }
 }

--- a/app/features/user/user.ts
+++ b/app/features/user/user.ts
@@ -2,6 +2,7 @@ import type { Currency } from '~/lib/money';
 
 type CommonUserData = {
   id: string;
+  username: string;
   emailVerified: boolean;
   createdAt: string;
   updatedAt: string;

--- a/app/hooks/use-animation.ts
+++ b/app/hooks/use-animation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 type Options = {
-  name: 'shake';
+  name: 'shake' | 'slam';
   durationMs?: number;
 };
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,6 +19,7 @@ import { Analytics } from '@vercel/analytics/react';
 import type { LinksFunction } from '@vercel/remix';
 import { useState } from 'react';
 import { useDehydratedState } from 'use-dehydrated-state';
+import animations from '~/animations.css?url';
 import { Button } from '~/components/ui/button';
 import {
   Card,
@@ -38,6 +39,7 @@ import stylesheet from '~/tailwind.css?url';
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: stylesheet },
   { rel: 'stylesheet', href: transitionStyles },
+  { rel: 'stylesheet', href: animations },
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   {
     rel: 'manifest',

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -57,6 +57,7 @@ export type Database = {
           email_verified: boolean
           id: string
           updated_at: string
+          username: string
         }
         Insert: {
           created_at?: string
@@ -67,6 +68,7 @@ export type Database = {
           email_verified: boolean
           id?: string
           updated_at?: string
+          username?: string
         }
         Update: {
           created_at?: string
@@ -77,6 +79,7 @@ export type Database = {
           email_verified?: boolean
           id?: string
           updated_at?: string
+          username?: string
         }
         Relationships: [
           {

--- a/supabase/migrations/20250219172216_users-and-accounts-updates.sql
+++ b/supabase/migrations/20250219172216_users-and-accounts-updates.sql
@@ -39,6 +39,7 @@ begin
   -- Select and lock the user row
   select jsonb_build_object(
     'id', u.id,
+    'username', u.username,
     'email', u.email,
     'email_verified', u.email_verified,
     'default_usd_account_id', u.default_usd_account_id,
@@ -120,6 +121,7 @@ begin
   where id = upsert_user_with_accounts.user_id
   returning jsonb_build_object(
     'id', u.id,
+    'username', u.username,
     'email', u.email,
     'email_verified', u.email_verified,
     'default_usd_account_id', u.default_usd_account_id,

--- a/supabase/migrations/20250225230703_add_username_to_user_table.sql
+++ b/supabase/migrations/20250225230703_add_username_to_user_table.sql
@@ -1,0 +1,23 @@
+alter table "wallet"."users" add column "username" text not null default ''::text;
+
+CREATE UNIQUE INDEX users_username_key ON wallet.users USING btree (username);
+
+alter table "wallet"."users" add constraint "users_username_key" UNIQUE using index "users_username_key";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION wallet.set_default_username()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$BEGIN
+    -- Set the username field to "user-" concatenated with the last 12 characters of the id
+    NEW.username := 'user-' || RIGHT(NEW.id::text, 12);
+    
+    -- Return the modified record
+    RETURN NEW;
+END;$function$
+;
+
+CREATE TRIGGER set_default_username_trigger BEFORE INSERT ON wallet.users FOR EACH ROW EXECUTE FUNCTION wallet.set_default_username();
+
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,17 +57,6 @@ export default {
         numeric: ['Teko', 'sans-serif'],
         primary: ['Kode Mono', 'monospace'],
       },
-      animation: {
-        shake: 'shake 0.2s ease-in-out',
-      },
-      keyframes: {
-        shake: {
-          '0%, 100%': { transform: 'translateX(0)' },
-          '25%': { transform: 'translateX(-5px)' },
-          '50%': { transform: 'translateX(5px)' },
-          '75%': { transform: 'translateX(-5px)' },
-        },
-      },
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
I added `username` to user table. Default username is just random numbers for now, I was wondering if modifying the `upsert_user_with_accounts` to make it so that it accepted the initial username as an argument would be the right approach, but wanted to wait until accounts are finalized.

I also created a workaround for the broken animations. From what I can tell, the issue with the animations is that if the initial load of the app has no usage of the animation it gets dropped so then when we use JS to inject the animation class our custom animations don't exist. I couldn't figure out a tailwind solution, so just made a separate animations.css. The animation classes I created follow the same syntax of tailwind animations so we can move their definitions later