### PR TITLE
add editable usernames by creating public-profiles

### DIFF
--- a/app/animations.css
+++ b/app/animations.css
@@ -1,0 +1,55 @@
+.animate-shake {
+  animation: shake 0.4s ease-out both;
+  transform-origin: center;
+  display: inline-block;
+}
+
+.animate-slam {
+  animation: slam 0.4s ease-out both;
+  transform-origin: center;
+  display: inline-block;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  50% {
+    transform: translateX(5px);
+  }
+  75% {
+    transform: translateX(-5px);
+  }
+}
+
+@keyframes slam {
+  0% {
+    transform: scale(1);
+    letter-spacing: normal;
+    opacity: 1;
+  }
+  25% {
+    transform: scale(1.05);
+    letter-spacing: 0.05em;
+    opacity: 0.9;
+  }
+  50% {
+    transform: scale(0.98);
+    letter-spacing: -0.02em;
+    opacity: 0.95;
+  }
+  75% {
+    transform: scale(1.02);
+    letter-spacing: 0.02em;
+    opacity: 0.98;
+  }
+  100% {
+    transform: scale(1);
+    letter-spacing: normal;
+    opacity: 1;
+  }
+}

--- a/app/features/settings/profile/edit-profile.tsx
+++ b/app/features/settings/profile/edit-profile.tsx
@@ -1,34 +1,12 @@
-import { useNavigate } from '@remix-run/react';
-import { useForm } from 'react-hook-form';
 import { PageContent } from '~/components/page';
-import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
+import { Separator } from '~/components/ui/separator';
 import { UpgradeGuestForm } from '~/features/settings/profile/upgrade-guest-form';
 import { SettingsViewHeader } from '~/features/settings/ui/settings-view-header';
 import { useUser } from '~/features/user/user-hooks';
-
-type ProfileForm = {
-  username: string;
-};
+import EditableUsername from './editable-username';
 
 export default function EditProfile() {
-  const navigate = useNavigate();
-  const user = useUser();
-
-  const { register, handleSubmit } = useForm<ProfileForm>({
-    defaultValues: {
-      username: 'satoshi', // This should come from actual user data
-    },
-  });
-  const onSubmit = async (data: ProfileForm) => {
-    try {
-      // TODO: Implement username update logic
-      console.log('Updating username...', data.username);
-      navigate('/settings');
-    } catch {
-      // TODO
-    }
-  };
+  const isGuest = useUser((s) => s.isGuest);
 
   return (
     <>
@@ -40,23 +18,14 @@ export default function EditProfile() {
           applyTo: 'oldView',
         }}
       />
-      <PageContent className="gap-4">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="username" className="font-medium text-sm">
-              Username
-            </label>
-            <Input
-              id="username"
-              {...register('username', { required: true })}
-              placeholder="Enter your username"
-            />
-          </div>
-          <Button type="submit" className="w-full">
-            Save Changes
-          </Button>
-        </form>
-        {user.isGuest && <UpgradeGuestForm />}
+      <PageContent className="gap-6">
+        <EditableUsername />
+        {isGuest && (
+          <>
+            <Separator />
+            <UpgradeGuestForm />
+          </>
+        )}
       </PageContent>
     </>
   );

--- a/app/features/settings/profile/editable-username.tsx
+++ b/app/features/settings/profile/editable-username.tsx
@@ -1,0 +1,153 @@
+import { Check, Edit } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Button } from '~/components/ui/button';
+import { useUpdateUsername, useUserProfile } from '~/features/user/user-hooks';
+import useAnimation from '~/hooks/use-animation';
+import { useToast } from '~/hooks/use-toast';
+import { cn } from '~/lib/utils';
+
+// Reserved routes that can't be used as usernames
+// QUESTION: can we do this more efficiently so that
+// we don't have to update for every new route?
+const RESERVED_ROUTES = [
+  'settings',
+  'profile',
+  'login',
+  'signup',
+  'api',
+  'admin',
+  'help',
+  'about',
+  'terms',
+  'privacy',
+  'receive',
+  'send',
+  'verify-email',
+];
+
+type FormValues = {
+  username: string;
+};
+
+function validateUsername(username: string) {
+  // Check length (3-20 characters)
+  if (username.length < 3 || username.length > 20) {
+    return 'Username must be between 3 and 20 characters';
+  }
+
+  // Check characters (only a-z, 0-9, underscore, hyphen allowed)
+  // This requirement comes from LUD16 https://github.com/lnurl/luds/blob/luds/16.md
+  if (!/^[a-z0-9_-]+$/.test(username)) {
+    return 'Username can only contain lowercase letters, numbers, underscores and hyphens';
+  }
+
+  if (RESERVED_ROUTES.includes(username.toLowerCase())) {
+    return 'This username is not available';
+  }
+
+  return true;
+}
+
+export default function EditableUsername() {
+  const { animationClass, start: startAnimation } = useAnimation({
+    name: 'slam',
+    durationMs: 400,
+  });
+  const { toast } = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { username } = useUserProfile();
+  const updateUsername = useUpdateUsername();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      username: username,
+    },
+  });
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    isEditing && inputRef.current?.focus();
+  }, [isEditing]);
+
+  const onSubmit = async (data: FormValues) => {
+    if (data.username === username) {
+      setIsEditing(false);
+      return;
+    }
+
+    try {
+      await updateUsername(data.username);
+      startAnimation();
+      setIsEditing(false);
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to update username',
+      });
+    }
+  };
+
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsEditing(true);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className={'flex w-full flex-col gap-2'}
+    >
+      <div className="flex items-center gap-2">
+        <div className={cn('flex-1', animationClass)}>
+          {isEditing ? (
+            <input
+              {...register('username')}
+              ref={(e) => {
+                register('username', { validate: validateUsername }).ref(e);
+                // @ts-ignore: says it's readonly, but this works
+                inputRef.current = e;
+              }}
+              type="text"
+              autoComplete="username"
+              className="w-full bg-transparent text-2xl text-white outline-none"
+            />
+          ) : (
+            <span className="text-2xl text-white">{watch('username')}</span>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={handleEditClick}
+            className={cn(isEditing && 'invisible')}
+          >
+            <Edit className="h-4 w-4" />
+          </Button>
+
+          <Button
+            type="submit"
+            variant="ghost"
+            size="icon"
+            className={cn(!isEditing && 'invisible')}
+          >
+            <Check className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {errors.username && (
+        <div className="text-destructive text-sm">
+          {errors.username.message}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/app/features/settings/profile/upgrade-guest-form.tsx
+++ b/app/features/settings/profile/upgrade-guest-form.tsx
@@ -1,12 +1,5 @@
 import { type SubmitHandler, useForm } from 'react-hook-form';
 import { Button } from '~/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { useUpgradeGuestToFullAccount } from '~/features/user/user-hooks';
@@ -48,15 +41,15 @@ export function UpgradeGuestForm() {
   };
 
   return (
-    <Card className="mx-auto max-w-sm">
-      <CardHeader>
-        <CardTitle>Upgrade</CardTitle>
-        <CardDescription>
+    <div className="mx-auto max-w-sm">
+      <div className="mb-6">
+        <h2 className="font-semibold text-lg">Upgrade</h2>
+        <p className="text-muted-foreground text-sm">
           Enter your email and password to backup your account and sync across
           devices.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
+        </p>
+      </div>
+      <div>
         <form
           className="mt-2 grid gap-4"
           onSubmit={handleSubmit(onSubmit)}
@@ -124,7 +117,7 @@ export function UpgradeGuestForm() {
             Upgrade to full account
           </Button>
         </form>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -13,12 +13,12 @@ import { LinkWithViewTransition } from '~/lib/transitions';
 import { useDefaultAccount } from '../accounts/account-hooks';
 import { AccountTypeIcon } from '../accounts/account-icons';
 import { useAuthActions } from '../user/auth';
-
-const username = 'satoshi';
+import { useUserProfile } from '../user/user-hooks';
 
 export default function Settings() {
   const { signOut } = useAuthActions();
   const defaultAccount = useDefaultAccount();
+  const { username } = useUserProfile();
 
   const handleShare = async () => {
     const data = {

--- a/app/features/user/user.ts
+++ b/app/features/user/user.ts
@@ -8,6 +8,7 @@ type CommonUserData = {
   defaultBtcAccountId: string;
   defaultUsdAccountId: string;
   defaultCurrency: Currency;
+  profileId: string;
 };
 
 export type FullUser = CommonUserData & {

--- a/app/hooks/use-animation.ts
+++ b/app/hooks/use-animation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 type Options = {
-  name: 'shake';
+  name: 'shake' | 'slam';
   durationMs?: number;
 };
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -19,6 +19,7 @@ import { Analytics } from '@vercel/analytics/react';
 import type { LinksFunction } from '@vercel/remix';
 import { useState } from 'react';
 import { useDehydratedState } from 'use-dehydrated-state';
+import animations from '~/animations.css?url';
 import { Button } from '~/components/ui/button';
 import {
   Card,
@@ -38,6 +39,7 @@ import stylesheet from '~/tailwind.css?url';
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: stylesheet },
   { rel: 'stylesheet', href: transitionStyles },
+  { rel: 'stylesheet', href: animations },
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   {
     rel: 'manifest',

--- a/app/routes/_public.search.tsx
+++ b/app/routes/_public.search.tsx
@@ -1,0 +1,161 @@
+import { type LoaderFunctionArgs, json } from '@remix-run/node';
+import {
+  useLoaderData,
+  useNavigation,
+  useSearchParams,
+} from '@remix-run/react';
+import { createClient } from '@supabase/supabase-js';
+import { useEffect, useState } from 'react';
+import { Input } from '~/components/ui/input';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? '';
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is not set');
+}
+
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY is not set');
+}
+
+export const boardwalkDbPublic = createClient(supabaseUrl, supabaseAnonKey, {
+  db: { schema: 'wallet' },
+});
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+type SearchResult = {
+  username: string;
+  id: string;
+};
+
+type LoaderData = {
+  results: SearchResult[];
+  error?: string;
+};
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const query = url.searchParams.get('q') || '';
+
+  if (!query || query.length < 3) {
+    return json<LoaderData>({ results: [] });
+  }
+
+  console.log('Searching with query:', query);
+
+  const { data, error } = await boardwalkDbPublic.rpc(
+    'search_for_user_by_username',
+    {
+      query,
+    },
+  );
+
+  console.log('Raw response data:', data);
+  console.log('Response type:', typeof data);
+  if (Array.isArray(data)) {
+    console.log('Array length:', data.length);
+    console.log('First item:', data[0]);
+  }
+
+  if (error) {
+    console.error('Search error:', error);
+    return json<LoaderData>({ results: [], error: 'Failed to search users' });
+  }
+
+  // Transform the data to match our expected format
+  const results = Array.isArray(data)
+    ? data.map((item) => ({
+        id: item.id,
+        username: item.username,
+      }))
+    : [];
+
+  console.log('Processed results:', results);
+
+  return json<LoaderData>({ results });
+}
+
+export default function SearchPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [query, setQuery] = useState(searchParams.get('q') || '');
+  const debouncedQuery = useDebounce(query, 300);
+  const navigation = useNavigation();
+  const { results, error } = useLoaderData<typeof loader>();
+
+  useEffect(() => {
+    setSearchParams((prev) => {
+      if (!debouncedQuery || debouncedQuery.length < 3) {
+        prev.delete('q');
+      } else {
+        prev.set('q', debouncedQuery);
+      }
+      return prev;
+    });
+  }, [debouncedQuery, setSearchParams]);
+
+  const isSearching = navigation.state === 'loading';
+  const showMinCharactersMessage = query.length > 0 && query.length < 3;
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <h1 className="mb-6 font-bold text-2xl">Search Users</h1>
+
+      <div className="relative">
+        <Input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Start typing a username..."
+        />
+        {isSearching && (
+          <div className="absolute top-2.5 right-3">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+          </div>
+        )}
+      </div>
+
+      {showMinCharactersMessage && (
+        <div className="mt-4 text-center text-gray-500">
+          Please enter at least 3 characters to search
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 rounded-lg bg-red-100 p-4 text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-6 space-y-2">
+        {results.map((user) => (
+          <div
+            key={user.id}
+            className="rounded-lg border p-4 transition-colors hover:bg-gray-50"
+          >
+            <p className="font-medium">{user.username}</p>
+          </div>
+        ))}
+        {query.length >= 3 && results.length === 0 && !isSearching && (
+          <p className="py-4 text-center text-gray-500">
+            No users found matching "{query}"
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -47,6 +47,35 @@ export type Database = {
           },
         ]
       }
+      public_profiles: {
+        Row: {
+          created_at: string
+          id: string
+          user_id: string | null
+          username: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          user_id?: string | null
+          username: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          user_id?: string | null
+          username?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "public_profiles_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       users: {
         Row: {
           created_at: string
@@ -56,6 +85,7 @@ export type Database = {
           email: string | null
           email_verified: boolean
           id: string
+          profile_id: string | null
           updated_at: string
         }
         Insert: {
@@ -66,6 +96,7 @@ export type Database = {
           email?: string | null
           email_verified: boolean
           id?: string
+          profile_id?: string | null
           updated_at?: string
         }
         Update: {
@@ -76,6 +107,7 @@ export type Database = {
           email?: string | null
           email_verified?: boolean
           id?: string
+          profile_id?: string | null
           updated_at?: string
         }
         Relationships: [
@@ -93,6 +125,13 @@ export type Database = {
             referencedRelation: "accounts"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "users_profile_id_fkey"
+            columns: ["profile_id"]
+            isOneToOne: false
+            referencedRelation: "public_profiles"
+            referencedColumns: ["id"]
+          },
         ]
       }
     }
@@ -100,12 +139,24 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      search_for_user_by_username: {
+        Args: {
+          query: string
+        }
+        Returns: {
+          id: string
+          username: string
+          user_id: string
+          created_at: string
+        }[]
+      }
       upsert_user_with_accounts: {
         Args: {
           user_id: string
           email: string
           email_verified: boolean
           accounts: Json[]
+          profile: Json
         }
         Returns: Json
       }

--- a/supabase/migrations/20250228194403_add-public-profile-table.sql
+++ b/supabase/migrations/20250228194403_add-public-profile-table.sql
@@ -1,0 +1,277 @@
+drop function if exists "wallet"."upsert_user_with_accounts"(user_id uuid, email text, email_verified boolean, accounts jsonb[]);
+
+create table "wallet"."public_profiles" (
+    "id" uuid not null default gen_random_uuid(),
+    "created_at" timestamp with time zone not null default now(),
+    "username" text not null,
+    "user_id" uuid
+);
+
+alter table "wallet"."public_profiles" enable row level security;
+
+alter table "wallet"."users" add column "profile_id" uuid;
+
+CREATE UNIQUE INDEX public_profiles_pkey ON wallet.public_profiles USING btree (id);
+
+CREATE UNIQUE INDEX public_profiles_username_key ON wallet.public_profiles USING btree (username);
+
+alter table "wallet"."public_profiles" add constraint "public_profiles_pkey" PRIMARY KEY using index "public_profiles_pkey";
+
+alter table "wallet"."public_profiles" add constraint "public_profiles_user_id_fkey" FOREIGN KEY (user_id) REFERENCES wallet.users(id) not valid;
+
+alter table "wallet"."public_profiles" validate constraint "public_profiles_user_id_fkey";
+
+alter table "wallet"."public_profiles" add constraint "public_profiles_username_key" UNIQUE using index "public_profiles_username_key";
+
+alter table "wallet"."users" add constraint "users_profile_id_fkey" FOREIGN KEY (profile_id) REFERENCES wallet.public_profiles(id) not valid;
+
+alter table "wallet"."users" validate constraint "users_profile_id_fkey";
+
+ALTER TABLE "wallet"."public_profiles" ENABLE ROW LEVEL SECURITY;
+
+-- Create a security definer function that will bypass RLS for search
+CREATE FUNCTION wallet.search_for_user_by_username(query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  user_id uuid,
+  created_at timestamp with time zone
+)
+LANGUAGE plpgsql
+SECURITY DEFINER -- This is the key part - function runs with definer's privileges
+SET search_path = wallet
+AS $function$
+BEGIN
+  -- Return empty result if query is less than 3 characters
+  IF length(query) < 3 THEN
+    RETURN;
+  END IF;
+  
+  -- Return only the first 10 matching user profiles
+  RETURN QUERY
+  SELECT p.id, p.username, p.user_id, p.created_at
+  FROM wallet.public_profiles p
+  WHERE p.username ILIKE '%' || query || '%'
+  LIMIT 10;
+END;
+$function$;
+
+-- Policy for authenticated users to manage their own profiles
+CREATE POLICY "Users can manage their own profiles"
+ON "wallet"."public_profiles"
+AS PERMISSIVE
+FOR ALL
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Grant execute permission to the search function
+GRANT EXECUTE ON FUNCTION wallet.search_for_user_by_username(text) TO public;
+GRANT EXECUTE ON FUNCTION wallet.search_for_user_by_username(text) TO authenticated;
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION wallet.upsert_user_with_accounts(user_id uuid, email text, email_verified boolean, accounts jsonb[], profile jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+declare
+  result_user jsonb;
+  existing_accounts jsonb;
+  existing_profile jsonb;
+  acct jsonb;
+  new_acc wallet.accounts%ROWTYPE;
+  new_profile wallet.public_profiles%ROWTYPE;
+  added_accounts jsonb := '[]'::jsonb;
+  usd_account_id uuid := null;
+  btc_account_id uuid := null;
+begin
+  -- Upsert user
+  insert into wallet.users (id, email, email_verified)
+  values (upsert_user_with_accounts.user_id, upsert_user_with_accounts.email, email_verified)
+  on conflict (id) do update set
+    email = coalesce(EXCLUDED.email, wallet.users.email),
+    email_verified = EXCLUDED.email_verified;
+
+  -- Select and lock the user row
+  select jsonb_build_object(
+    'id', u.id,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'profile_id', u.profile_id,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at
+  ) into result_user
+  from wallet.users u
+  where u.id = upsert_user_with_accounts.user_id
+  for update;
+
+  -- Select existing accounts
+  select jsonb_agg(jsonb_build_object(
+    'id', a.id,
+    'type', a.type,
+    'currency', a.currency,
+    'name', a.name,
+    'details', a.details,
+    'created_at', a.created_at
+  )) into existing_accounts
+  from wallet.accounts a
+  where a.user_id = upsert_user_with_accounts.user_id;
+
+  -- Select existing profile
+  select jsonb_build_object(
+    'id', p.id,
+    'username', p.username,
+    'created_at', p.created_at
+  ) into existing_profile
+  from wallet.public_profiles p
+  where p.user_id = upsert_user_with_accounts.user_id;
+
+  -- If user already has accounts and profile, return user with accounts and profile
+  if jsonb_array_length(coalesce(existing_accounts, '[]'::jsonb)) > 0 then    
+    result_user := jsonb_set(result_user, '{accounts}', existing_accounts);
+    if existing_profile is not null then
+      result_user := jsonb_set(result_user, '{profile}', existing_profile);
+    end if;
+    return result_user;
+  end if;
+
+  -- Validate profile to insert
+  if profile is null then
+    raise exception 'Profile is required for new users';
+  end if;
+
+  if profile->>'username' is null then
+    raise exception 'Username is required in profile';
+  end if;
+
+  -- Insert profile
+  insert into wallet.public_profiles (username, user_id)
+  values (profile->>'username', user_id)
+  returning * into new_profile;
+
+  -- Update user with profile_id
+  update wallet.users
+  set profile_id = new_profile.id
+  where id = user_id;
+
+  -- Validate accounts to insert
+  if array_length(accounts, 1) is null then
+    raise exception 'Accounts array cannot be empty';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(accounts)::jsonb, '$[*] ? (@.currency == "USD")') then
+    raise exception 'At least one USD account is required';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(accounts)::jsonb, '$[*] ? (@.currency == "BTC")') then
+    raise exception 'At least one BTC account is required';
+  end if;
+
+  -- Insert accounts
+  foreach acct in array accounts loop
+    insert into wallet.accounts (user_id, type, currency, name, details)
+    values (
+      upsert_user_with_accounts.user_id,
+      acct->>'type',
+      acct->>'currency',
+      acct->>'name',
+      acct->'details'
+    )
+    returning * into new_acc;
+
+    -- Append to added accounts list
+    added_accounts := added_accounts || jsonb_build_object(
+      'id', new_acc.id,
+      'user_id', new_acc.user_id,
+      'type', new_acc.type,
+      'currency', new_acc.currency,
+      'name', new_acc.name,
+      'details', new_acc.details
+    );
+
+    -- Set default account IDs
+    if new_acc.currency = 'USD' then
+      usd_account_id := new_acc.id;
+    elsif new_acc.currency = 'BTC' then
+      btc_account_id := new_acc.id;
+    end if;
+  end loop;
+
+  -- Update user with default account IDs (keeping existing values)
+  update wallet.users u
+  set 
+    default_usd_account_id = coalesce(usd_account_id, u.default_usd_account_id),
+    default_btc_account_id = coalesce(btc_account_id, u.default_btc_account_id)
+  where id = upsert_user_with_accounts.user_id
+  returning jsonb_build_object(
+    'id', u.id,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'profile_id', u.profile_id,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at,
+    'accounts', added_accounts,
+    'profile', jsonb_build_object(
+      'id', new_profile.id,
+      'username', new_profile.username,
+      'created_at', new_profile.created_at
+    )
+  ) into result_user;
+
+  return result_user;
+
+end;
+$function$
+;
+
+grant delete on table "wallet"."public_profiles" to "anon";
+
+grant insert on table "wallet"."public_profiles" to "anon";
+
+grant references on table "wallet"."public_profiles" to "anon";
+
+grant select on table "wallet"."public_profiles" to "anon";
+
+grant trigger on table "wallet"."public_profiles" to "anon";
+
+grant truncate on table "wallet"."public_profiles" to "anon";
+
+grant update on table "wallet"."public_profiles" to "anon";
+
+grant delete on table "wallet"."public_profiles" to "authenticated";
+
+grant insert on table "wallet"."public_profiles" to "authenticated";
+
+grant references on table "wallet"."public_profiles" to "authenticated";
+
+grant select on table "wallet"."public_profiles" to "authenticated";
+
+grant trigger on table "wallet"."public_profiles" to "authenticated";
+
+grant truncate on table "wallet"."public_profiles" to "authenticated";
+
+grant update on table "wallet"."public_profiles" to "authenticated";
+
+grant delete on table "wallet"."public_profiles" to "service_role";
+
+grant insert on table "wallet"."public_profiles" to "service_role";
+
+grant references on table "wallet"."public_profiles" to "service_role";
+
+grant select on table "wallet"."public_profiles" to "service_role";
+
+grant trigger on table "wallet"."public_profiles" to "service_role";
+
+grant truncate on table "wallet"."public_profiles" to "service_role";
+
+grant update on table "wallet"."public_profiles" to "service_role";
+
+
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,17 +57,6 @@ export default {
         numeric: ['Teko', 'sans-serif'],
         primary: ['Kode Mono', 'monospace'],
       },
-      animation: {
-        shake: 'shake 0.2s ease-in-out',
-      },
-      keyframes: {
-        shake: {
-          '0%, 100%': { transform: 'translateX(0)' },
-          '25%': { transform: 'translateX(-5px)' },
-          '50%': { transform: 'translateX(5px)' },
-          '75%': { transform: 'translateX(-5px)' },
-        },
-      },
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
This is the start of profiles. For now I just gave users a username in their profile. 

I created a database function `search_for_user_by_username` that will only allow profiles to be searched by anyone if you have at least 3 characters of a username. [see](https://discord.com/channels/1189257044264501288/1192544908603572346/1344455336320569495) Discord chat. RLS is enabled for CRUD on public_profiles. So the only way to publicly find a profile is to use the search db function.

You said a while ago for default usernames that I should use a db trigger, but now that profiles are there own table I decided to use the upsert user function. If there's a different approach you would like to see lmk.

This also adds the ability to update usernames.

I put all the user profile logic in with the user feature, not sure if it should be its own feature or not.

## Testing

Test public search by going to the `/search` route and searching for an existing user. You can set your username in `/settings/profile/edit` or search for me "damian"