### PR TITLE
add editable usernames

### DIFF
--- a/app/features/settings/profile/edit-profile.tsx
+++ b/app/features/settings/profile/edit-profile.tsx
@@ -1,34 +1,12 @@
-import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router';
 import { PageContent } from '~/components/page';
-import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
+import { Separator } from '~/components/ui/separator';
 import { UpgradeGuestForm } from '~/features/settings/profile/upgrade-guest-form';
 import { SettingsViewHeader } from '~/features/settings/ui/settings-view-header';
 import { useUser } from '~/features/user/user-hooks';
-
-type ProfileForm = {
-  username: string;
-};
+import EditableUsername from './editable-username';
 
 export default function EditProfile() {
-  const navigate = useNavigate();
-  const user = useUser();
-
-  const { register, handleSubmit } = useForm<ProfileForm>({
-    defaultValues: {
-      username: 'satoshi', // This should come from actual user data
-    },
-  });
-  const onSubmit = async (data: ProfileForm) => {
-    try {
-      // TODO: Implement username update logic
-      console.log('Updating username...', data.username);
-      navigate('/settings');
-    } catch {
-      // TODO
-    }
-  };
+  const isGuest = useUser((s) => s.isGuest);
 
   return (
     <>
@@ -40,23 +18,14 @@ export default function EditProfile() {
           applyTo: 'oldView',
         }}
       />
-      <PageContent className="gap-4">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-2">
-            <label htmlFor="username" className="font-medium text-sm">
-              Username
-            </label>
-            <Input
-              id="username"
-              {...register('username', { required: true })}
-              placeholder="Enter your username"
-            />
-          </div>
-          <Button type="submit" className="w-full">
-            Save Changes
-          </Button>
-        </form>
-        {user.isGuest && <UpgradeGuestForm />}
+      <PageContent className="gap-6">
+        <EditableUsername />
+        {isGuest && (
+          <>
+            <Separator />
+            <UpgradeGuestForm />
+          </>
+        )}
       </PageContent>
     </>
   );

--- a/app/features/settings/profile/editable-username.tsx
+++ b/app/features/settings/profile/editable-username.tsx
@@ -1,0 +1,104 @@
+import { Check, Edit } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useUpdateUsername, useUser } from '~/features/user/user-hooks';
+import useAnimation from '~/hooks/use-animation';
+import { useToast } from '~/hooks/use-toast';
+import { cn } from '~/lib/utils';
+
+type FormValues = {
+  username: string;
+};
+
+function validateUsername(username: string) {
+  // Check length (3-20 characters)
+  if (username.length < 3 || username.length > 20) {
+    return 'Username must be between 3 and 20 characters';
+  }
+
+  // Check characters (only a-z, 0-9, underscore, hyphen allowed)
+  // This requirement comes from LUD16 https://github.com/lnurl/luds/blob/luds/16.md
+  if (!/^[a-z0-9_-]+$/.test(username)) {
+    return 'Username can only contain lowercase letters, numbers, underscores and hyphens';
+  }
+
+  return true;
+}
+
+export default function EditableUsername() {
+  const { animationClass, start: startAnimation } = useAnimation({
+    name: 'slam',
+    durationMs: 400,
+  });
+  const { toast } = useToast();
+  const user = useUser();
+  const updateUsername = useUpdateUsername();
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      username: user.username,
+    },
+  });
+  const [isEditing, setIsEditing] = useState(false);
+
+  const onSubmit = async (data: FormValues) => {
+    if (data.username === user.username) {
+      setIsEditing(false);
+      return;
+    }
+
+    try {
+      await updateUsername(data.username);
+      startAnimation();
+      setIsEditing(false);
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to update username',
+      });
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      {!isEditing ? (
+        <div className="flex items-center gap-2">
+          <div className={cn('flex-1', animationClass)}>
+            <span className="text-2xl text-white">{watch('username')}</span>
+          </div>
+          <button type="button" onClick={() => setIsEditing(true)}>
+            <Edit className="h-4 w-4" />
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex items-center gap-2">
+            <div className={cn('flex-1', animationClass)}>
+              <input
+                {...register('username', { validate: validateUsername })}
+                type="text"
+                className="w-full bg-transparent text-2xl text-white outline-none"
+                // biome-ignore lint/a11y/noAutofocus: the rule is for accessibility reasons, but for this case it makes sense to autofocus so that the user is editing as soon as they click the edit button
+                autoFocus
+                spellCheck="false"
+              />
+            </div>
+            <button type="submit">
+              <Check className="h-4 w-4" />
+            </button>
+          </div>
+
+          {errors.username && (
+            <div className="text-destructive text-sm">
+              {errors.username.message}
+            </div>
+          )}
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/features/settings/profile/upgrade-guest-form.tsx
+++ b/app/features/settings/profile/upgrade-guest-form.tsx
@@ -60,6 +60,7 @@ export function UpgradeGuestForm() {
             <Input
               id="email"
               type="email"
+              autoComplete="email"
               placeholder="satoshi@nakamoto.com"
               aria-invalid={errors.email ? 'true' : 'false'}
               {...register('email', {

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -13,12 +13,12 @@ import { LinkWithViewTransition } from '~/lib/transitions';
 import { useDefaultAccount } from '../accounts/account-hooks';
 import { AccountTypeIcon } from '../accounts/account-icons';
 import { useAuthActions } from '../user/auth';
-
-const username = 'satoshi';
+import { useUser } from '../user/user-hooks';
 
 export default function Settings() {
   const { signOut } = useAuthActions();
   const defaultAccount = useDefaultAccount();
+  const username = useUser((s) => s.username);
 
   const handleShare = async () => {
     const data = {

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -204,3 +204,12 @@ export const useSetDefaultAccount = () => {
     [updateUser],
   );
 };
+
+export const useUpdateUsername = () => {
+  const { mutateAsync: updateUser } = useUpdateUser();
+
+  return useCallback(
+    (username: string) => updateUser({ username }),
+    [updateUser],
+  );
+};

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -13,6 +13,7 @@ export type UpdateUser = {
   defaultBtcAccountId?: string;
   defaultUsdAccountId?: string;
   defaultCurrency?: Currency;
+  username?: string;
 };
 
 type Options = {
@@ -70,6 +71,7 @@ export class UserRepository {
         default_btc_account_id: data.defaultBtcAccountId,
         default_usd_account_id: data.defaultUsdAccountId,
         default_currency: data.defaultCurrency,
+        username: data.username,
       })
       .eq('id', userId)
       .select();
@@ -158,6 +160,7 @@ export class UserRepository {
     if (dbUser.email) {
       return {
         id: dbUser.id,
+        username: dbUser.username,
         email: dbUser.email,
         emailVerified: dbUser.email_verified,
         createdAt: dbUser.created_at,
@@ -171,6 +174,7 @@ export class UserRepository {
 
     return {
       id: dbUser.id,
+      username: dbUser.username,
       emailVerified: dbUser.email_verified,
       createdAt: dbUser.created_at,
       updatedAt: dbUser.updated_at,

--- a/app/features/user/user.ts
+++ b/app/features/user/user.ts
@@ -2,6 +2,7 @@ import type { Currency } from '~/lib/money';
 
 type CommonUserData = {
   id: string;
+  username: string;
   emailVerified: boolean;
   createdAt: string;
   updatedAt: string;

--- a/app/hooks/use-animation.ts
+++ b/app/hooks/use-animation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 type Options = {
-  name: 'shake';
+  name: 'shake' | 'slam';
   durationMs?: number;
 };
 
@@ -10,11 +10,18 @@ type Result = {
   start: () => void;
 };
 
+// NOTE: animations class names must be statically defined so that
+// when tailwind scans our source files it can find them
+const animations: Record<Options['name'], `animate-${Options['name']}`> = {
+  shake: 'animate-shake',
+  slam: 'animate-slam',
+};
+
 const useAnimation = ({ name, durationMs = 200 }: Options): Result => {
   const [animationClass, setAnimationClass] = useState('');
 
   const start = useCallback(() => {
-    setAnimationClass(`animate-${name}`);
+    setAnimationClass(animations[name]);
     setTimeout(() => setAnimationClass(''), durationMs);
   }, [name, durationMs]);
 

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -201,6 +201,7 @@ export type Database = {
           email_verified: boolean
           id: string
           updated_at: string
+          username: string
         }
         Insert: {
           created_at?: string
@@ -211,6 +212,7 @@ export type Database = {
           email_verified: boolean
           id?: string
           updated_at?: string
+          username: string
         }
         Update: {
           created_at?: string
@@ -221,6 +223,7 @@ export type Database = {
           email_verified?: boolean
           id?: string
           updated_at?: string
+          username?: string
         }
         Relationships: [
           {

--- a/supabase/migrations/20250416224601_add-username-to-user-table.sql
+++ b/supabase/migrations/20250416224601_add-username-to-user-table.sql
@@ -1,0 +1,155 @@
+alter table "wallet"."users" add column "username" text not null;
+
+CREATE UNIQUE INDEX users_username_key ON wallet.users USING btree (username);
+
+-- This constraint comes from lud16 https://github.com/lnurl/luds/blob/luds/16.md
+alter table "wallet"."users" add constraint "users_username_format" CHECK ((username ~ '^[a-z0-9_-]+$'::text)) not valid;
+
+alter table "wallet"."users" validate constraint "users_username_format";
+
+alter table "wallet"."users" add constraint "users_username_key" UNIQUE using index "users_username_key";
+
+alter table "wallet"."users" add constraint "users_username_length" CHECK (((length(username) >= 3) AND (length(username) <= 20))) not valid;
+
+alter table "wallet"."users" validate constraint "users_username_length";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION wallet.set_default_username()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$BEGIN
+    -- Set the username field to "user-" concatenated with the last 12 characters of the id
+    NEW.username := 'user-' || RIGHT(NEW.id::text, 12);
+    
+    RETURN NEW;
+END;$function$
+;
+
+CREATE TRIGGER set_default_username_trigger BEFORE INSERT ON wallet.users FOR EACH ROW EXECUTE FUNCTION wallet.set_default_username();
+
+CREATE OR REPLACE FUNCTION wallet.upsert_user_with_accounts(p_user_id uuid, p_email text, p_email_verified boolean, p_accounts jsonb[])
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$declare
+  result_user jsonb;
+  existing_accounts jsonb;
+  acct jsonb;
+  new_acc wallet.accounts%ROWTYPE;
+  added_accounts jsonb := '[]'::jsonb;
+  usd_account_id uuid := null;
+  btc_account_id uuid := null;
+begin
+  -- Upsert user
+  insert into wallet.users (id, email, email_verified)
+  values (p_user_id, p_email, p_email_verified)
+  on conflict (id) do update set
+    email = coalesce(EXCLUDED.email, wallet.users.email),
+    email_verified = EXCLUDED.email_verified;
+
+  -- Select and lock the user row
+  select jsonb_build_object(
+    'id', u.id,
+    'username', u.username,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at
+  ) into result_user
+  from wallet.users u
+  where u.id = p_user_id
+  for update;
+
+  -- Select existing accounts
+  select jsonb_agg(jsonb_build_object(
+    'id', a.id,
+    'type', a.type,
+    'currency', a.currency,
+    'name', a.name,
+    'details', a.details,
+    'created_at', a.created_at,
+    'version', a.version
+  )) into existing_accounts
+  from wallet.accounts a
+  where a.user_id = p_user_id;
+
+  -- If user already has accounts, return user with accounts
+  if jsonb_array_length(coalesce(existing_accounts, '[]'::jsonb)) > 0 then    
+    result_user := jsonb_set(result_user, '{accounts}', existing_accounts);
+    return result_user;
+  end if;
+
+  -- Validate accounts to insert
+  if array_length(p_accounts, 1) is null then
+    raise exception 'p_accounts cannot be empty array';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(p_accounts)::jsonb, '$[*] ? (@.currency == "USD")') then
+    raise exception 'At least one USD account is required';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(p_accounts)::jsonb, '$[*] ? (@.currency == "BTC")') then
+    raise exception 'At least one BTC account is required';
+  end if;
+
+  -- Insert accounts
+  foreach acct in array p_accounts loop
+    insert into wallet.accounts (user_id, type, currency, name, details)
+    values (
+      p_user_id,
+      acct->>'type',
+      acct->>'currency',
+      acct->>'name',
+      acct->'details'
+    )
+    returning * into new_acc;
+
+    -- Append to added accounts list
+    added_accounts := added_accounts || jsonb_build_object(
+      'id', new_acc.id,
+      'user_id', new_acc.user_id,
+      'type', new_acc.type,
+      'currency', new_acc.currency,
+      'name', new_acc.name,
+      'details', new_acc.details,
+      'version', new_acc.version,
+      'created_at', new_acc.created_at
+    );
+
+    -- Set default account IDs
+    if new_acc.currency = 'USD' then
+      usd_account_id := new_acc.id;
+    elsif new_acc.currency = 'BTC' then
+      btc_account_id := new_acc.id;
+    end if;
+  end loop;
+
+  -- Update user with default account IDs (keeping existing values)
+  update wallet.users u
+  set 
+    default_usd_account_id = coalesce(usd_account_id, u.default_usd_account_id),
+    default_btc_account_id = coalesce(btc_account_id, u.default_btc_account_id)
+  where id = p_user_id
+  returning jsonb_build_object(
+    'id', u.id,
+    'username', u.username,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at,
+    'accounts', added_accounts
+  ) into result_user;
+
+  return result_user;
+
+end;$function$
+;
+
+
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -62,6 +62,7 @@ export default {
       },
       animation: {
         shake: 'shake 0.2s ease-in-out',
+        slam: 'slam 0.4s ease-out both',
       },
       keyframes: {
         shake: {
@@ -69,6 +70,33 @@ export default {
           '25%': { transform: 'translateX(-5px)' },
           '50%': { transform: 'translateX(5px)' },
           '75%': { transform: 'translateX(-5px)' },
+        },
+        slam: {
+          '0%': {
+            transform: 'scale(1)',
+            letterSpacing: 'normal',
+            opacity: '1',
+          },
+          '25%': {
+            transform: 'scale(1.05)',
+            letterSpacing: '0.05em',
+            opacity: '0.9',
+          },
+          '50%': {
+            transform: 'scale(0.98)',
+            letterSpacing: '-0.02em',
+            opacity: '0.95',
+          },
+          '75%': {
+            transform: 'scale(1.02)',
+            letterSpacing: '0.02em',
+            opacity: '0.98',
+          },
+          '100%': {
+            transform: 'scale(1)',
+            letterSpacing: 'normal',
+            opacity: '1',
+          },
         },
       },
     },


### PR DESCRIPTION
Adds username to the user table. 

There is a trigger that fires before the user is inserted that gives the user a default username. The call to insert the user is made -> then the trigger function is ran -> user gets inserted -> user is returned with the default username value.

And I updated `upsert_user_with_accounts` to return the username along with the rest of the user.

You can now see your username in `/settings` and edit your username at `/settings/profile/edit`

NOTE: I still need to fix the tailwind issue...