### PR TITLE
decrese onPresented carousel threshold to 0.3

### DIFF
--- a/app/components/ui/carousel.tsx
+++ b/app/components/ui/carousel.tsx
@@ -191,7 +191,7 @@ const CarouselItem = React.forwardRef<
           observer.disconnect(); // only trigger once
         }
       },
-      { threshold: 0.7 },
+      { threshold: 0.3 },
     );
 
     if (itemRef.current) observer.observe(itemRef.current);


### PR DESCRIPTION
Tested on iPhone SE size and 0.5 works, but if I go smaller on the width then that doesn't work so I did 0.3 to be safe