### PR TITLE
alternative swap to claim flow

### DIFF
--- a/app/features/boardwalk-db/database.ts
+++ b/app/features/boardwalk-db/database.ts
@@ -93,7 +93,7 @@ type Database = MergeDeep<
         process_cashu_receive_quote_payment: {
           Returns: CashuReceiveQuotePaymentResult;
         };
-        create_token_swap: {
+        get_or_create_cashu_token_swap: {
           Returns: BoardwalkDbCashuTokenSwap;
         };
         complete_token_swap: {

--- a/app/features/receive/cashu-token-swap-hooks.ts
+++ b/app/features/receive/cashu-token-swap-hooks.ts
@@ -1,5 +1,4 @@
-import { type Token, getEncodedToken } from '@cashu/cashu-ts';
-import type { RealtimePostgresChangesPayload } from '@supabase/supabase-js';
+import type { Token } from '@cashu/cashu-ts';
 import {
   type QueryClient,
   useMutation,
@@ -7,22 +6,14 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
-import { useEffect, useMemo } from 'react';
-import { computeSHA256 } from '~/lib/sha256';
-import { useLatest } from '~/lib/use-latest';
 import type { CashuAccount } from '../accounts/account';
 import { useAccountsCache } from '../accounts/account-hooks';
-import {
-  type BoardwalkDbCashuTokenSwap,
-  boardwalkDb,
-} from '../boardwalk-db/database';
-import { useCashuCryptography } from '../shared/cashu';
 import { useUserRef } from '../user/user-hooks';
-import type { CashuTokenSwap } from './cashu-token-swap';
 import {
-  CashuTokenSwapRepository,
-  useCashuTokenSwapRepository,
-} from './cashu-token-swap-repository';
+  type CashuTokenSwap,
+  FailedToCompleteTokenSwapError,
+} from './cashu-token-swap';
+import { useCashuTokenSwapRepository } from './cashu-token-swap-repository';
 import { useCashuTokenSwapService } from './cashu-token-swap-service';
 
 type CreateProps = {
@@ -30,33 +21,7 @@ type CreateProps = {
   account: CashuAccount;
 };
 
-const cashuTokenSwapQueryKey = 'cashu-token-swap';
 const pendingCashuTokenSwapsQueryKey = 'pending-cashu-token-swaps';
-
-class CashuTokenSwapCache {
-  constructor(private readonly queryClient: QueryClient) {}
-
-  get(tokenHash: string) {
-    return this.queryClient.getQueryData<CashuTokenSwap>([
-      cashuTokenSwapQueryKey,
-      tokenHash,
-    ]);
-  }
-
-  add(tokenSwap: CashuTokenSwap) {
-    this.queryClient.setQueryData<CashuTokenSwap>(
-      [cashuTokenSwapQueryKey, tokenSwap.tokenHash],
-      tokenSwap,
-    );
-  }
-
-  updateIfExists(tokenSwap: CashuTokenSwap) {
-    this.queryClient.setQueryData<CashuTokenSwap>(
-      [cashuTokenSwapQueryKey, tokenSwap.tokenHash],
-      (curr) => (curr ? tokenSwap : undefined),
-    );
-  }
-}
 
 class PendingCashuTokenSwapsCache {
   constructor(private readonly queryClient: QueryClient) {}
@@ -68,21 +33,10 @@ class PendingCashuTokenSwapsCache {
     );
   }
 
-  get(tokenHash: string) {
+  get(userId: string, tokenHash: string) {
     return this.queryClient
-      .getQueryData<CashuTokenSwap[]>([
-        pendingCashuTokenSwapsQueryKey,
-        tokenHash,
-      ])
+      .getQueryData<CashuTokenSwap[]>([pendingCashuTokenSwapsQueryKey, userId])
       ?.find((d) => d.tokenHash === tokenHash);
-  }
-
-  update(tokenSwap: CashuTokenSwap) {
-    this.queryClient.setQueryData<CashuTokenSwap[]>(
-      [pendingCashuTokenSwapsQueryKey, tokenSwap.userId],
-      (curr) =>
-        curr?.map((d) => (d.tokenHash === tokenSwap.tokenHash ? tokenSwap : d)),
-    );
   }
 
   remove(tokenSwap: CashuTokenSwap) {
@@ -93,217 +47,75 @@ class PendingCashuTokenSwapsCache {
   }
 }
 
-export function useCashuTokenSwapCache() {
+function usePendingCashuTokenSwapsCache() {
   const queryClient = useQueryClient();
-  return useMemo(() => new CashuTokenSwapCache(queryClient), [queryClient]);
+  return new PendingCashuTokenSwapsCache(queryClient);
 }
 
-export function usePrepareCashuTokenSwap() {
+export function useSwapToClaimCashuToken() {
   const userRef = useUserRef();
-  const queryClient = useQueryClient();
   const tokenSwapService = useCashuTokenSwapService();
-  const cashuTokenSwapCache = useCashuTokenSwapCache();
-  const pendingSwapsCache = useMemo(
-    () => new PendingCashuTokenSwapsCache(queryClient),
-    [queryClient],
-  );
+  const pendingCashuTokenSwapsCache = usePendingCashuTokenSwapsCache();
 
   return useMutation({
-    mutationKey: ['create-cashu-token-swap'],
-    scope: {
-      id: 'create-cashu-token-swap',
-    },
+    mutationKey: ['swap-to-claim-cashu-token'],
     mutationFn: async ({ token, account }: CreateProps) => {
-      // TODO: right now we calculate the hash here and in prepareSwap.
-      const tokenHash = await computeSHA256(getEncodedToken(token));
-
-      const existingTokenSwap = pendingSwapsCache.get(tokenHash);
-      if (existingTokenSwap) {
-        return existingTokenSwap;
-      }
-
-      return tokenSwapService.prepareSwap({
+      return tokenSwapService.swapToClaim({
         userId: userRef.current.id,
         token,
         account,
       });
     },
-    onSuccess: (tokenSwap) => {
-      console.log('Created token swap', tokenSwap);
-      cashuTokenSwapCache.add(tokenSwap);
+    onSuccess: (data) => {
+      pendingCashuTokenSwapsCache.remove(data);
+    },
+    onError: (error) => {
+      if (error instanceof FailedToCompleteTokenSwapError) {
+        const tokenSwap = pendingCashuTokenSwapsCache.get(
+          userRef.current.id,
+          error.tokenSwap.tokenHash,
+        );
+        if (!tokenSwap) {
+          pendingCashuTokenSwapsCache.add(error.tokenSwap);
+        }
+      }
+      console.error('Error claiming token', error);
     },
   });
-}
-
-type UseTokenSwapProps = {
-  tokenHash?: string;
-  onCompleted?: (swap: CashuTokenSwap) => void;
-  onFailed?: (swap: CashuTokenSwap) => void;
-};
-
-type UseTokenSwapResponse =
-  | {
-      status: 'LOADING';
-      swap?: undefined;
-    }
-  | {
-      status: CashuTokenSwap['state'];
-      swap: CashuTokenSwap;
-    };
-
-export function useTokenSwap({
-  tokenHash,
-  onCompleted,
-  onFailed,
-}: UseTokenSwapProps): UseTokenSwapResponse {
-  const enabled = !!tokenHash;
-  const onCompletedRef = useLatest(onCompleted);
-  const onFailedRef = useLatest(onFailed);
-  const cache = useCashuTokenSwapCache();
-
-  const { data } = useQuery({
-    queryKey: [cashuTokenSwapQueryKey, tokenHash],
-    queryFn: () => cache.get(tokenHash ?? ''),
-    staleTime: Number.POSITIVE_INFINITY,
-    enabled,
-  });
-
-  useEffect(() => {
-    if (!data) return;
-
-    if (data.state === 'COMPLETED') {
-      onCompletedRef.current?.(data);
-    } else if (data.state === 'FAILED') {
-      onFailedRef.current?.(data);
-    }
-  }, [data]);
-
-  if (!data) {
-    return { status: 'LOADING' };
-  }
-
-  return {
-    status: data.state,
-    swap: data,
-  };
 }
 
 function usePendingCashuTokenSwaps() {
   const userRef = useUserRef();
   const tokenSwapRepository = useCashuTokenSwapRepository();
-  const queryClient = useQueryClient();
-  const pendingSwapsCache = useMemo(
-    () => new PendingCashuTokenSwapsCache(queryClient),
-    [queryClient],
-  );
-  const tokenSwapCache = useCashuTokenSwapCache();
 
   const { data } = useQuery({
     queryKey: [pendingCashuTokenSwapsQueryKey, userRef.current.id],
     queryFn: () => tokenSwapRepository.getPending(userRef.current.id),
-    staleTime: Number.POSITIVE_INFINITY,
     throwOnError: true,
-    initialData: [] as CashuTokenSwap[],
-  });
-
-  useOnCashuTokenSwapChange({
-    onCreated: (swap) => {
-      pendingSwapsCache.add(swap);
-    },
-    onUpdated: (swap) => {
-      tokenSwapCache.updateIfExists(swap);
-
-      const isSwapStillPending = swap.state === 'PENDING';
-      if (isSwapStillPending) {
-        pendingSwapsCache.update(swap);
-      } else {
-        pendingSwapsCache.remove(swap);
-      }
-    },
+    initialData: [],
+    refetchOnWindowFocus: false,
   });
 
   return data;
 }
 
-function useFinalizeTokenSwap(swaps: CashuTokenSwap[]) {
-  const tokenSwapService = useCashuTokenSwapService();
+export function useRecoverPendingCashuTokenSwaps() {
+  const pendingSwaps = usePendingCashuTokenSwaps();
+  const { mutate: swapToClaim } = useSwapToClaimCashuToken();
   const accountsCache = useAccountsCache();
 
   useQueries({
-    queries: swaps
-      .filter((swap) => swap.state === 'PENDING')
-      .map((swap) => ({
-        queryKey: ['finalize-cashu-token-swap', swap.id],
-        queryFn: async () => {
-          try {
-            const account = accountsCache.get(swap.accountId);
-            if (!account || account.type !== 'cashu') {
-              throw new Error(`Account not found for id: ${swap.accountId}`);
-            }
-            console.log('Finalizing token swap', swap);
-            return tokenSwapService.finalizeSwap(account, swap);
-          } catch (error) {
-            console.error('Error finalizing token swap', error);
-            throw error;
-          }
-        },
-        refetchInterval: 10000,
-        refetchIntervalInBackground: true,
-      })),
+    queries: pendingSwaps.map((swap) => ({
+      queryKey: ['recover-cashu-token-swap', swap.tokenHash],
+      queryFn: () => {
+        const { token, accountId } = swap;
+        const account = accountsCache.get(accountId);
+        if (!account || account.type !== 'cashu') {
+          throw new Error(`Account not found for id: ${accountId}`);
+        }
+        return swapToClaim({ token, account });
+      },
+      refetchInterval: 30_000,
+    })),
   });
-}
-
-function useOnCashuTokenSwapChange({
-  onCreated,
-  onUpdated,
-}: {
-  onCreated: (swap: CashuTokenSwap) => void;
-  onUpdated: (swap: CashuTokenSwap) => void;
-}) {
-  const cashuCryptography = useCashuCryptography();
-  const onCreatedRef = useLatest(onCreated);
-  const onUpdatedRef = useLatest(onUpdated);
-
-  useEffect(() => {
-    const channel = boardwalkDb
-      .channel('cashu-token-swaps')
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'wallet',
-          table: 'cashu_token_swaps',
-        },
-        async (
-          payload: RealtimePostgresChangesPayload<BoardwalkDbCashuTokenSwap>,
-        ) => {
-          if (payload.eventType === 'INSERT') {
-            console.log('Token swap created', payload.new);
-            const swap = await CashuTokenSwapRepository.toTokenSwap(
-              payload.new,
-              cashuCryptography.decrypt,
-            );
-            onCreatedRef.current(swap);
-          } else if (payload.eventType === 'UPDATE') {
-            console.log('Token swap updated', payload.new);
-            const swap = await CashuTokenSwapRepository.toTokenSwap(
-              payload.new,
-              cashuCryptography.decrypt,
-            );
-            onUpdatedRef.current(swap);
-          }
-        },
-      )
-      .subscribe();
-
-    return () => {
-      channel.unsubscribe();
-    };
-  }, [cashuCryptography]);
-}
-
-export function useTrackCashuTokenSwaps() {
-  const pendingSwaps = usePendingCashuTokenSwaps();
-  useFinalizeTokenSwap(pendingSwaps);
-  return pendingSwaps;
 }

--- a/app/features/receive/cashu-token-swap.ts
+++ b/app/features/receive/cashu-token-swap.ts
@@ -1,17 +1,56 @@
-import type { Proof } from '@cashu/cashu-ts';
+import type { Token } from '@cashu/cashu-ts';
 import type { Money } from '~/lib/money';
 
 export type CashuTokenSwap = {
-  id: string;
-  /** A hash of the token being received */
-  tokenHash: string; // QUESTION: should we have this and the ID if we will use the hash to query? The id could be set as the hash.
-  tokenProofs: Proof[];
+  /**
+   * A hash of the token being received
+   */
+  tokenHash: string;
+  /**
+   * The token being received as a Token object
+   */
+  token: Token;
+  /**
+   * The user ID of the user receiving the token
+   */
   userId: string;
+  /**
+   * The account ID of the account receiving the token
+   */
   accountId: string;
+  /**
+   * The amount of the token being received
+   */
   amount: Money;
+  /**
+   * ID of the keyset used to create the blinded messages
+   */
   keysetId: string;
+  /**
+   * Counter value for the keyset at the time the time of quote payment
+   */
   keysetCounter: number;
+  /**
+   * The output amount for each blinded message
+   */
   outputAmounts: number[];
+  /**
+   * The state of the token swap
+   */
+  state: 'PENDING' | 'COMPLETED';
+  /**
+   * Timestamp when the token swap was created
+   */
   createdAt: string;
-  state: 'PENDING' | 'COMPLETED' | 'FAILED';
 };
+
+export class FailedToCompleteTokenSwapError extends Error {
+  /**
+   * The token swap that failed to complete
+   */
+  tokenSwap: CashuTokenSwap;
+  constructor(message: string, tokenSwap: CashuTokenSwap) {
+    super(message);
+    this.tokenSwap = tokenSwap;
+  }
+}

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -44,7 +44,11 @@ export default function ReceiveToken({ token }: Props) {
     claimableToken,
   } = tokenData;
 
-  const { status: receiveTokenStatus, startReceive } = useReceiveCashuToken();
+  const {
+    mutate: receiveToken,
+    status: receiveTokenStatus,
+    data: receiveTokenData,
+  } = useReceiveCashuToken();
 
   const handleClaim = async () => {
     if (!claimableToken) {
@@ -68,10 +72,11 @@ export default function ReceiveToken({ token }: Props) {
       }
     }
 
-    startReceive({ token, receiveAccount: account });
+    receiveToken({ token, receiveAccount: account });
   };
 
-  if (receiveTokenStatus === 'success') {
+  // TODO: receiveTokenData should be more detailed, for now if true it means swapToClaim was successful
+  if (receiveTokenStatus === 'success' && receiveTokenData === true) {
     return (
       <SuccessfulReceivePage
         amount={tokenToMoney(claimableToken ?? token)}

--- a/app/features/wallet/wallet.tsx
+++ b/app/features/wallet/wallet.tsx
@@ -4,7 +4,7 @@ import { useTrackAccounts } from '../accounts/account-hooks';
 import { supabaseSessionStore } from '../boardwalk-db/supabse-session-store';
 import { LoadingScreen } from '../loading/LoadingScreen';
 import { useTrackPendingCashuReceiveQuotes } from '../receive/cashu-receive-quote-hooks';
-import { useTrackCashuTokenSwaps } from '../receive/cashu-token-swap-hooks';
+import { useRecoverPendingCashuTokenSwaps } from '../receive/cashu-token-swap-hooks';
 import { type AuthUser, useHandleSessionExpiry } from '../user/auth';
 import { useUpsertUser, useUser } from '../user/user-hooks';
 
@@ -49,7 +49,7 @@ const Wallet = ({ children }: PropsWithChildren) => {
 
   useTrackAccounts();
   useTrackPendingCashuReceiveQuotes();
-  useTrackCashuTokenSwaps();
+  useRecoverPendingCashuTokenSwaps();
 
   return children;
 };

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -1,4 +1,9 @@
-import { CashuMint, CashuWallet, type MintKeyset } from '@cashu/cashu-ts';
+import {
+  CashuMint,
+  CashuWallet,
+  type MintKeyset,
+  type Token,
+} from '@cashu/cashu-ts';
 import type { DistributedOmit } from 'type-fest';
 import { decodeBolt11 } from '~/lib/bolt11';
 import type { Currency, CurrencyUnit } from '../money';
@@ -18,6 +23,17 @@ const currencyToUnit: {
 
 export const getCashuUnit = (currency: Currency) => {
   return currencyToUnit[currency];
+};
+
+export const getCashuUnitFromToken = (token: Token) => {
+  switch (token.unit) {
+    case 'sat':
+      return 'sat';
+    case 'usd':
+      return 'cent';
+    default:
+      throw new Error(`Unknown token unit: ${token.unit}`);
+  }
 };
 
 export const getCashuWallet = (

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -128,13 +128,13 @@ export type Database = {
           amount: number
           created_at: string
           currency: string
+          encoded_token: string
           id: string
           keyset_counter: number
           keyset_id: string
           output_amounts: number[]
           state: string
           token_hash: string
-          token_proofs: string
           unit: string
           user_id: string
         }
@@ -143,13 +143,13 @@ export type Database = {
           amount: number
           created_at?: string
           currency: string
+          encoded_token: string
           id?: string
           keyset_counter: number
           keyset_id: string
           output_amounts: number[]
           state?: string
           token_hash: string
-          token_proofs: string
           unit: string
           user_id: string
         }
@@ -158,13 +158,13 @@ export type Database = {
           amount?: number
           created_at?: string
           currency?: string
+          encoded_token?: string
           id?: string
           keyset_counter?: number
           keyset_id?: string
           output_amounts?: number[]
           state?: string
           token_hash?: string
-          token_proofs?: string
           unit?: string
           user_id?: string
         }
@@ -272,36 +272,6 @@ export type Database = {
         }
         Returns: undefined
       }
-      create_token_swap: {
-        Args: {
-          p_token_hash: string
-          p_token_proofs: string
-          p_account_id: string
-          p_user_id: string
-          p_currency: string
-          p_unit: string
-          p_keyset_id: string
-          p_keyset_counter: number
-          p_output_amounts: number[]
-          p_amount: number
-          p_account_version: number
-        }
-        Returns: {
-          account_id: string
-          amount: number
-          created_at: string
-          currency: string
-          id: string
-          keyset_counter: number
-          keyset_id: string
-          output_amounts: number[]
-          state: string
-          token_hash: string
-          token_proofs: string
-          unit: string
-          user_id: string
-        }
-      }
       expire_cashu_receive_quote: {
         Args: {
           p_quote_id: string
@@ -324,6 +294,36 @@ export type Database = {
           unit: string
           user_id: string
           version: number
+        }
+      }
+      get_or_create_cashu_token_swap: {
+        Args: {
+          p_token_hash: string
+          p_encoded_token: string
+          p_account_id: string
+          p_user_id: string
+          p_currency: string
+          p_unit: string
+          p_keyset_id: string
+          p_keyset_counter: number
+          p_output_amounts: number[]
+          p_amount: number
+          p_account_version: number
+        }
+        Returns: {
+          account_id: string
+          amount: number
+          created_at: string
+          currency: string
+          encoded_token: string
+          id: string
+          keyset_counter: number
+          keyset_id: string
+          output_amounts: number[]
+          state: string
+          token_hash: string
+          unit: string
+          user_id: string
         }
       }
       process_cashu_receive_quote_payment: {


### PR DESCRIPTION
I made a single function to handle claiming tokens in the service called `swapToClaim`. 

When an initial attempt to swap in `useSwapToClaimCashuToken`  fails to store the proofs but a swap was created in the db, then we add the swap to our pending swap cache so that it gets picked up by the background job. Whenever `swapToClaim` succeeds it will be removed from the pending swap cache.

So, the background job only picks up stuck swaps if the initial attempt fails 
