### PR TITLE
Handle swap cashu token race condition

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -229,7 +229,7 @@ const useOnMintQuoteStateChange = ({
       queryKey: ['mint-quote', quote.id],
       queryFn: async () => {
         try {
-          const account = accountsCache.get(quote.accountId);
+          const account = await accountsCache.getLatest(quote.accountId);
           if (!account || account.type !== 'cashu') {
             throw new Error(`Account not found for id: ${quote.accountId}`);
           }


### PR DESCRIPTION
I solved it by adding a separate cache for latest known account versions and then when we get a notification of account being updated we update the latest known account version in this new cache and only then start decrypting the account data. Then when someone wants to read the latest account from the cache they can do it by calling getLatest on the accounts cache and that will now wait for the data to be updated if it detects the version in the versions cache being bigger than the version in the accounts cache.

It goes something like this:

1. accounts cache: [{ id: `q1w2`, version: `1` }], versions cache for `q1w2` account: `1` (at this point version cache is actually empty but when reading from the empty cache it will return the version from the accounts cache so effectively it is `1`)
2. user triggers action that updates the account
3. notification about account updated is received via web socket
4. socket handler immediately updates the versions cache so at this point we have:
    accounts cache: [{ id: `q1w2`, version: `1` }], versions cache for `q1w2` account: `2`
5. socket handler now triggers the requests to decrypt the sensitive data
6. decryption is done and socket handler updates the account cache with latest data so at this point we have:
    accounts cache: [{ id: `q1w2`, version: `2` }], versions cache for `q1w2` account: `2`
    
If anyone calls `await accounts.getLatest()` after step 4 above it will wait for step 6 to be done before resolving.

The solution is not prettiest and adds some complexity but it is the simplest thing I could think of.