### PR TITLE
handle duplicate token swaps

### DIFF
--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -1,8 +1,9 @@
-import type { Token } from '@cashu/cashu-ts';
+import { type Token, getEncodedToken } from '@cashu/cashu-ts';
 import { useMemo } from 'react';
 import { create } from 'zustand';
 import { sumProofs } from '~/lib/cashu';
 import { type Currency, type CurrencyUnit, Money } from '~/lib/money';
+import { computeSHA256 } from '~/lib/sha256';
 import { getSeedPhraseDerivationPath } from '../accounts/account-cryptography';
 import { useEncryption } from './encryption';
 
@@ -74,4 +75,10 @@ export function useCashuCryptography(): CashuCryptography {
 
     return { getSeed, encrypt, decrypt };
   }, [getPrivateKeyBytes, encrypt, decrypt]);
+}
+
+export function getTokenHash(token: Token | string): Promise<string> {
+  const encodedToken =
+    typeof token === 'string' ? token : getEncodedToken(token);
+  return computeSHA256(encodedToken);
 }


### PR DESCRIPTION
1. If Alice has already input and clicked claim for this token, then we show a message that she has already claimed the token.

2. If Alice has already started claiming this token and Bob tries to claim it, Bob will get a toast that the token has already been claimed at the time that the creating the swap is attempted. In this case we have to wait until the swap creation is attempted because Bob cannot query Alice's swaps.

I decided to only allow one entry in the database per token. This way as soon as any user starts to claim a token we can consider the token claimed. We still may be attempting to swap the proofs, but this is just finalizing the claiming of the token. We assume this will either succeed eventually or if Alice can't claim the token, Bob is most likely going to hit the same error so no point in letting him try to claim.