### PR TITLE
handle case where proofs are spent and none are recovered

### DIFF
--- a/app/features/receive/cashu-token-swap-repository.ts
+++ b/app/features/receive/cashu-token-swap-repository.ts
@@ -171,6 +171,53 @@ export class CashuTokenSwapRepository {
   }
 
   /**
+   * Updates the state of a token swap to FAILED.
+   */
+  async fail(
+    {
+      tokenHash,
+      reason,
+      version,
+    }: {
+      /**
+       * Hash of the token to be failed.
+       */
+      tokenHash: string;
+      /**
+       * Reason for the failure.
+       */
+      reason: string;
+      /**
+       * Version of the token swap as seen by the client. Used for optimistic concurrency control.
+       */
+      version: number;
+    },
+    options?: Options,
+  ): Promise<void> {
+    const query = this.db
+      .from('cashu_token_swaps')
+      .update({
+        state: 'FAILED',
+        error: reason,
+      })
+      .match({
+        token_hash: tokenHash,
+        version,
+      })
+      .select();
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { error } = await query;
+
+    if (error) {
+      throw new Error('Failed to fail token swap', { cause: error });
+    }
+  }
+
+  /**
    * Gets all pending token swaps for a given user.
    * @returns All token swaps in a PENDING state for the given user.
    */

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -73,7 +73,7 @@ export default function ReceiveToken({ token }: Props) {
       }
     }
 
-    await claimToken({ token, account });
+    await claimToken({ token: claimableToken, account });
   };
 
   if (status === 'SUCCESS') {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -127,6 +127,7 @@ export type Database = {
           account_id: string
           created_at: string
           currency: string
+          error: string | null
           fee_amount: number
           input_amount: number
           keyset_counter: number
@@ -144,6 +145,7 @@ export type Database = {
           account_id: string
           created_at?: string
           currency: string
+          error?: string | null
           fee_amount: number
           input_amount: number
           keyset_counter: number
@@ -161,6 +163,7 @@ export type Database = {
           account_id?: string
           created_at?: string
           currency?: string
+          error?: string | null
           fee_amount?: number
           input_amount?: number
           keyset_counter?: number
@@ -299,6 +302,7 @@ export type Database = {
           account_id: string
           created_at: string
           currency: string
+          error: string | null
           fee_amount: number
           input_amount: number
           keyset_counter: number

--- a/supabase/migrations/20250327204116_cashu-token-swaps.sql
+++ b/supabase/migrations/20250327204116_cashu-token-swaps.sql
@@ -13,6 +13,7 @@ create table "wallet"."cashu_token_swaps" (
     "receive_amount" numeric not null,
     "fee_amount" numeric not null,
     "state" text not null default 'PENDING',
+    "error" text,
     "version" integer not null default 0
 );
 


### PR DESCRIPTION
If a token gets claimed by some other wallet while Alice is trying to claim it, then Alice will get an error that the token is already spent. When Alice tries to restore she will not get any proofs back. At that point we know it was claimed by some one else rather than claimed by Alice so we can fail the swap.

I also added an 'error' column to the swaps to help us debug or determine what to do with the swap