### PR TITLE
use signed mint quotes instead of encrypting quote ID

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -16,7 +16,6 @@ import {
   type BoardwalkDbCashuReceiveQuote,
   boardwalkDb,
 } from '../boardwalk-db/database';
-import { useCashuCryptography } from '../shared/cashu';
 import { useUserRef } from '../user/user-hooks';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 import {
@@ -278,7 +277,6 @@ function useOnCashuReceiveQuoteChange({
   onCreated: (quote: CashuReceiveQuote) => void;
   onUpdated: (quote: CashuReceiveQuote) => void;
 }) {
-  const cashuCryptography = useCashuCryptography();
   const onCreatedRef = useLatest(onCreated);
   const onUpdatedRef = useLatest(onUpdated);
 
@@ -292,19 +290,15 @@ function useOnCashuReceiveQuoteChange({
           schema: 'wallet',
           table: 'cashu_receive_quotes',
         },
-        async (
+        (
           payload: RealtimePostgresChangesPayload<BoardwalkDbCashuReceiveQuote>,
         ) => {
           if (payload.eventType === 'INSERT') {
-            const addedQuote = await CashuReceiveQuoteRepository.toQuote(
-              payload.new,
-              cashuCryptography.decrypt,
-            );
+            const addedQuote = CashuReceiveQuoteRepository.toQuote(payload.new);
             onCreatedRef.current(addedQuote);
           } else if (payload.eventType === 'UPDATE') {
-            const updatedQuote = await CashuReceiveQuoteRepository.toQuote(
+            const updatedQuote = CashuReceiveQuoteRepository.toQuote(
               payload.new,
-              cashuCryptography.decrypt,
             );
             onUpdatedRef.current(updatedQuote);
           }
@@ -315,7 +309,7 @@ function useOnCashuReceiveQuoteChange({
     return () => {
       channel.unsubscribe();
     };
-  }, [cashuCryptography]);
+  }, []);
 }
 
 export function useTrackPendingCashuReceiveQuotes() {

--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -214,13 +214,13 @@ export class CashuReceiveQuoteRepository {
       });
     }
 
-    const [updatedQuote, updatedAccount] = await Promise.all([
-      CashuReceiveQuoteRepository.toQuote(data.updated_quote),
-      AccountRepository.toAccount(
-        data.updated_account,
-        this.encryption.decrypt,
-      ),
-    ]);
+    const updatedQuote = CashuReceiveQuoteRepository.toQuote(
+      data.updated_quote,
+    );
+    const updatedAccount = await AccountRepository.toAccount(
+      data.updated_account,
+      this.encryption.decrypt,
+    );
 
     return {
       updatedQuote,

--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -53,6 +53,10 @@ type CreateQuote = {
    * State of the quote.
    */
   state: CashuReceiveQuote['state'];
+  /**
+   * The full BIP32 derivation path used to derive the public key for locking the cashu mint quote.
+   */
+  lockingDerivationPath: string;
 };
 
 export class CashuReceiveQuoteRepository {
@@ -75,10 +79,10 @@ export class CashuReceiveQuoteRepository {
       expiresAt,
       description,
       state,
+      lockingDerivationPath,
     }: CreateQuote,
     options?: Options,
   ): Promise<CashuReceiveQuote> {
-    const encryptedQuoteId = await this.encryption.encrypt(quoteId);
     const unit = getDefaultUnit(amount.currency);
 
     const query = this.db
@@ -89,11 +93,12 @@ export class CashuReceiveQuoteRepository {
         amount: amount.toNumber(unit),
         currency: amount.currency,
         unit,
-        quote_id: encryptedQuoteId,
+        quote_id: quoteId,
         payment_request: paymentRequest,
         expires_at: expiresAt,
         description,
         state,
+        locking_derivation_path: lockingDerivationPath,
       })
       .select();
 
@@ -107,7 +112,7 @@ export class CashuReceiveQuoteRepository {
       throw new Error('Failed to create cashu receive quote', { cause: error });
     }
 
-    return CashuReceiveQuoteRepository.toQuote(data, this.encryption.decrypt);
+    return CashuReceiveQuoteRepository.toQuote(data);
   }
 
   /**
@@ -210,10 +215,7 @@ export class CashuReceiveQuoteRepository {
     }
 
     const [updatedQuote, updatedAccount] = await Promise.all([
-      CashuReceiveQuoteRepository.toQuote(
-        data.updated_quote,
-        this.encryption.decrypt,
-      ),
+      CashuReceiveQuoteRepository.toQuote(data.updated_quote),
       AccountRepository.toAccount(
         data.updated_account,
         this.encryption.decrypt,
@@ -297,7 +299,7 @@ export class CashuReceiveQuoteRepository {
       throw new Error('Failed to get cashu receive quote', { cause: error });
     }
 
-    return CashuReceiveQuoteRepository.toQuote(data, this.encryption.decrypt);
+    return CashuReceiveQuoteRepository.toQuote(data);
   }
 
   /**
@@ -325,61 +327,46 @@ export class CashuReceiveQuoteRepository {
       throw new Error('Failed to get cashu receive quotes', { cause: error });
     }
 
-    return await Promise.all(
-      data.map(
-        async (data) =>
-          await CashuReceiveQuoteRepository.toQuote(
-            data,
-            this.encryption.decrypt,
-          ),
-      ),
-    );
+    return data.map((data) => CashuReceiveQuoteRepository.toQuote(data));
   }
 
-  static async toQuote(
-    data: BoardwalkDbCashuReceiveQuote,
-    decryptData: Encryption['decrypt'],
-  ): Promise<CashuReceiveQuote> {
-    const decryptedData = {
-      ...data,
-      quote_id: await decryptData<string>(data.quote_id),
-    };
-
+  static toQuote(data: BoardwalkDbCashuReceiveQuote): CashuReceiveQuote {
     const commonData = {
-      id: decryptedData.id,
-      userId: decryptedData.user_id,
-      accountId: decryptedData.account_id,
-      quoteId: decryptedData.quote_id,
+      id: data.id,
+      userId: data.user_id,
+      accountId: data.account_id,
+      quoteId: data.quote_id,
       amount: new Money({
-        amount: decryptedData.amount,
-        currency: decryptedData.currency,
-        unit: decryptedData.unit,
+        amount: data.amount,
+        currency: data.currency,
+        unit: data.unit,
       }),
-      description: decryptedData.description ?? undefined,
-      createdAt: decryptedData.created_at,
-      expiresAt: decryptedData.expires_at,
-      paymentRequest: decryptedData.payment_request,
-      version: decryptedData.version,
+      description: data.description ?? undefined,
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      paymentRequest: data.payment_request,
+      version: data.version,
+      lockingDerivationPath: data.locking_derivation_path,
     };
 
-    if (decryptedData.state === 'PAID' || decryptedData.state === 'COMPLETED') {
+    if (data.state === 'PAID' || data.state === 'COMPLETED') {
       return {
         ...commonData,
-        state: decryptedData.state,
-        keysetId: decryptedData.keyset_id ?? '',
-        keysetCounter: decryptedData.keyset_counter ?? 0,
-        outputAmounts: decryptedData.output_amounts ?? [],
+        state: data.state,
+        keysetId: data.keyset_id ?? '',
+        keysetCounter: data.keyset_counter ?? 0,
+        outputAmounts: data.output_amounts ?? [],
       };
     }
 
-    if (decryptedData.state === 'UNPAID' || decryptedData.state === 'EXPIRED') {
+    if (data.state === 'UNPAID' || data.state === 'EXPIRED') {
       return {
         ...commonData,
-        state: decryptedData.state,
+        state: data.state,
       };
     }
 
-    throw new Error(`Unexpected quote state ${decryptedData.state}`);
+    throw new Error(`Unexpected quote state ${data.state}`);
   }
 }
 

--- a/app/features/receive/cashu-receive-quote.ts
+++ b/app/features/receive/cashu-receive-quote.ts
@@ -41,6 +41,13 @@ export type CashuReceiveQuote = {
    * Used for optimistic locking.
    */
   version: number;
+  /**
+   * BIP32 derivation path used for locking and signing the quote.
+   * This is the full path used to derive the locking key from the cashu seed.
+   * The last index is unhardened so that we can derive public keys without requiring the private key.
+   * @example "m/129372'/0'/0'/4321"
+   */
+  lockingDerivationPath: string;
 } & (
   | {
       state: 'UNPAID' | 'EXPIRED';

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -40,10 +40,7 @@ export type CashuCryptography = Pick<
 > & {
   getSeed: () => Promise<Uint8Array>;
   getXpub: (derivationPath?: string) => Promise<string>;
-  signMessage: (
-    message: Uint8Array,
-    derivationPath?: string,
-  ) => Promise<string>;
+  getPrivateKey: (derivationPath?: string) => Promise<string>;
 };
 
 type CashuSeedStore = {
@@ -94,18 +91,16 @@ export function useCashuCryptography(): CashuCryptography {
       return hdKey.publicExtendedKey;
     };
 
-    const signMessage = async (
-      message: Uint8Array,
-      derivationPath?: string,
-    ) => {
-      const { signature } = await crypto.signMessage(message, 'schnorr', {
-        seed_phrase_derivation_path: seedDerivationPath,
-        private_key_derivation_path: derivationPath,
-      });
-      return signature;
+    const getPrivateKey = async (derivationPath?: string) => {
+      return crypto
+        .getPrivateKeyBytes({
+          seed_phrase_derivation_path: seedDerivationPath,
+          private_key_derivation_path: derivationPath,
+        })
+        .then((response) => response.private_key);
     };
 
-    return { getSeed, signMessage, encrypt, decrypt, getXpub };
+    return { getSeed, getPrivateKey, encrypt, decrypt, getXpub };
   }, [crypto, encrypt, decrypt]);
 }
 

--- a/app/features/shared/cryptography.ts
+++ b/app/features/shared/cryptography.ts
@@ -8,6 +8,7 @@ export const useCryptography = () => {
     getPrivateKey: getMnemonic,
     signMessage,
     getPublicKey,
+    getPrivateKeyBytes,
   } = useOpenSecret();
 
   return useMemo(() => {
@@ -15,8 +16,9 @@ export const useCryptography = () => {
       getMnemonic,
       signMessage,
       getPublicKey,
+      getPrivateKeyBytes,
     };
-  }, [getMnemonic, signMessage, getPublicKey]);
+  }, [getMnemonic, signMessage, getPublicKey, getPrivateKeyBytes]);
 };
 
 /**

--- a/app/features/shared/cryptography.ts
+++ b/app/features/shared/cryptography.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 
 export const useCryptography = () => {
   const {
+    // getPrivateKey returns a mnemonic (not a private key) that can derive the seed, so we rename it to getMnemonic
     getPrivateKey: getMnemonic,
     signMessage,
     getPublicKey,

--- a/app/features/shared/cryptography.ts
+++ b/app/features/shared/cryptography.ts
@@ -1,0 +1,35 @@
+import { useOpenSecret } from '@opensecret/react';
+import { HDKey } from '@scure/bip32';
+import { useMemo } from 'react';
+
+export const useCryptography = () => {
+  const {
+    getPrivateKey: getMnemonic,
+    signMessage,
+    getPublicKey,
+  } = useOpenSecret();
+
+  return useMemo(() => {
+    return {
+      getMnemonic,
+      signMessage,
+      getPublicKey,
+    };
+  }, [getMnemonic, signMessage, getPublicKey]);
+};
+
+/**
+ * Derives a public key from an xpub and a derivation path.
+ * @param xpub - The base58-check encoded xpub.
+ * @param derivationPath - The derivation path to derive the public key from.
+ * @returns The derived public key as a hex string.
+ */
+export const derivePublicKey = (xpub: string, derivationPath: string) => {
+  const hdKey = HDKey.fromExtendedKey(xpub);
+  const childKey = hdKey.derive(derivationPath);
+  return childKey.publicKey
+    ? Array.from(childKey.publicKey)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('')
+    : '';
+};

--- a/app/features/shared/encryption.ts
+++ b/app/features/shared/encryption.ts
@@ -29,11 +29,10 @@ function preprocessData(obj: unknown): unknown {
 }
 
 export const useEncryption = () => {
-  const { getPrivateKeyBytes, encryptData, decryptData } = useOpenSecret();
+  const { encryptData, decryptData } = useOpenSecret();
 
   return useMemo(() => {
     return {
-      getPrivateKeyBytes,
       encrypt: async <T = unknown>(
         data: T,
         keyOptions?: KeyOptions,
@@ -77,5 +76,5 @@ export const useEncryption = () => {
         }) as T;
       },
     };
-  }, [getPrivateKeyBytes, encryptData, decryptData]);
+  }, [encryptData, decryptData]);
 };

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,8 @@
         "@react-router/fs-routes": "7.4.1",
         "@react-router/node": "7.4.1",
         "@supabase/supabase-js": "2.49.4",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
         "@tanstack/react-query": "5.65.1",
         "@tanstack/react-query-devtools": "5.65.1",
         "@vercel/analytics": "1.4.1",
@@ -398,7 +400,7 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.37.0", "", { "os": "win32", "cpu": "x64" }, "sha512-LWbXUBwn/bcLx2sSsqy7pK5o+Nr+VCoRoAohfJ5C/aBio9nfJmGQqHAhU6pwxV/RmyTk5AqdySma7uwWGlmeuA=="],
 
-    "@scure/base": ["@scure/base@1.1.1", "", {}, "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="],
+    "@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
 
     "@scure/bip32": ["@scure/bip32@1.6.2", "", { "dependencies": { "@noble/curves": "~1.8.1", "@noble/hashes": "~1.7.1", "@scure/base": "~1.2.2" } }, "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw=="],
 
@@ -1380,10 +1382,6 @@
 
     "@react-router/fs-routes/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
-
-    "@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ=="],
-
     "@ts-morph/common/mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
     "bin-links/proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
@@ -1405,6 +1403,8 @@
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "light-bolt11-decoder/@scure/base": ["@scure/base@1.1.1", "", {}, "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="],
 
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@react-router/fs-routes": "7.4.1",
     "@react-router/node": "7.4.1",
     "@supabase/supabase-js": "2.49.4",
+    "@scure/bip32": "1.6.2",
+    "@scure/bip39": "1.5.4",
     "@tanstack/react-query": "5.65.1",
     "@tanstack/react-query-devtools": "5.65.1",
     "@vercel/analytics": "1.4.1",

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -61,6 +61,7 @@ export type Database = {
           id: string
           keyset_counter: number | null
           keyset_id: string | null
+          locking_derivation_path: string
           output_amounts: number[] | null
           payment_request: string
           quote_id: string
@@ -79,6 +80,7 @@ export type Database = {
           id?: string
           keyset_counter?: number | null
           keyset_id?: string | null
+          locking_derivation_path: string
           output_amounts?: number[] | null
           payment_request: string
           quote_id: string
@@ -97,6 +99,7 @@ export type Database = {
           id?: string
           keyset_counter?: number | null
           keyset_id?: string | null
+          locking_derivation_path?: string
           output_amounts?: number[] | null
           payment_request?: string
           quote_id?: string
@@ -360,6 +363,7 @@ export type Database = {
           id: string
           keyset_counter: number | null
           keyset_id: string | null
+          locking_derivation_path: string
           output_amounts: number[] | null
           payment_request: string
           quote_id: string
@@ -460,6 +464,7 @@ export type Database = {
           id: string
           keyset_counter: number | null
           keyset_id: string | null
+          locking_derivation_path: string
           output_amounts: number[] | null
           payment_request: string
           quote_id: string

--- a/supabase/migrations/20250508000000_add_locking_derivation_path.sql
+++ b/supabase/migrations/20250508000000_add_locking_derivation_path.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "wallet"."cashu_receive_quotes" ADD COLUMN "locking_derivation_path" text;
+
+-- Set the default value to an empty string to avoid breaking existing data
+UPDATE "wallet"."cashu_receive_quotes" SET "locking_derivation_path" = '';
+
+-- Make the column non-nullable
+ALTER TABLE "wallet"."cashu_receive_quotes" ALTER COLUMN "locking_derivation_path" SET NOT NULL;


### PR DESCRIPTION
Uses nut20 signed mint quotes instead of encrypting the mint quote id

## What changed
- store quote id as plaintext in the db
- create mint quotes locked to a public key
- include a signature on the quote when minting proofs
- fixed `getSeed` to correctly get the mnemonic and then convert that to a seed instead of using the extended key
- I separated the private keys and signing functions out of the useEncryption hook and made a useCryptography hook because those things aren't encryption related