### PR TITLE
implement lightning address receives

### DIFF
--- a/app/features/boardwalk-db/database.server.ts
+++ b/app/features/boardwalk-db/database.server.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './database';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? '';
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL is not set');
+}
+
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+if (!supabaseServiceRoleKey) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY is not set');
+}
+
+export const boardwalkDbServiceRole = createClient<Database>(
+  supabaseUrl,
+  supabaseServiceRoleKey,
+  {
+    db: {
+      schema: 'wallet',
+    },
+  },
+);

--- a/app/features/boardwalk-db/database.ts
+++ b/app/features/boardwalk-db/database.ts
@@ -32,7 +32,7 @@ type UpdateCashuSendQuoteResult = {
 
 // Use when you need to fix/improve generated types
 // See https://supabase.com/docs/guides/api/rest/generating-types#helper-types-for-tables-and-joins
-type Database = MergeDeep<
+export type Database = MergeDeep<
   DatabaseGenerated,
   {
     wallet: {

--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -284,22 +284,22 @@ export class CashuReceiveQuoteRepository {
   /**
    * Gets the cashu receive quote with the given id.
    * @param id - The id of the cashu receive quote to get.
-   * @returns The cashu receive quote.
+   * @returns The cashu receive quote or null if it does not exist.
    */
-  async get(id: string, options?: Options): Promise<CashuReceiveQuote> {
+  async get(id: string, options?: Options): Promise<CashuReceiveQuote | null> {
     const query = this.db.from('cashu_receive_quotes').select().eq('id', id);
 
     if (options?.abortSignal) {
       query.abortSignal(options.abortSignal);
     }
 
-    const { data, error } = await query.single();
+    const { data, error } = await query.maybeSingle();
 
     if (error) {
       throw new Error('Failed to get cashu receive quote', { cause: error });
     }
 
-    return CashuReceiveQuoteRepository.toQuote(data);
+    return data ? CashuReceiveQuoteRepository.toQuote(data) : null;
   }
 
   /**

--- a/app/features/receive/cashu-receive-quote-service.ts
+++ b/app/features/receive/cashu-receive-quote-service.ts
@@ -14,15 +14,17 @@ import {
 } from '~/lib/cashu';
 import type { Money } from '~/lib/money';
 import type { CashuAccount } from '../accounts/account';
-import { type CashuCryptography, useCashuCryptography } from '../shared/cashu';
+import {
+  BASE_CASHU_LOCKING_DERIVATION_PATH,
+  type CashuCryptography,
+  useCashuCryptography,
+} from '../shared/cashu';
 import { derivePublicKey } from '../shared/cryptography';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 import {
   type CashuReceiveQuoteRepository,
   useCashuReceiveQuoteRepository,
 } from './cashu-receive-quote-repository';
-
-const BASE_CASHU_LOCKING_DERIVATION_PATH = "m/129372'/0'/0'";
 
 export class CashuReceiveQuoteService {
   constructor(

--- a/app/features/receive/lightning-address-service.tsx
+++ b/app/features/receive/lightning-address-service.tsx
@@ -1,0 +1,216 @@
+import { getCashuWallet } from '~/lib/cashu';
+import type {
+  LNURLError,
+  LNURLPayParams,
+  LNURLPayResult,
+  LNURLVerifyResult,
+} from '~/lib/lnurl/types';
+import { Money } from '~/lib/money';
+import { AccountRepository } from '../accounts/account-repository';
+import type { BoardwalkDb } from '../boardwalk-db/database';
+import type { CashuCryptography } from '../shared/cashu';
+import { UserRepository } from '../user/user-repository';
+import { CashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
+import { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+
+const fakeCryptography: CashuCryptography = {
+  encrypt: async <T = unknown>(data: T): Promise<string> =>
+    JSON.stringify(data),
+  decrypt: async <T = unknown>(data: string): Promise<T> => data as T,
+  getSeed: (): Promise<Uint8Array> => {
+    throw new Error('getSeed is not supported in this context');
+  },
+  getXpub: (): Promise<string> => {
+    throw new Error('getXpub is not supported in this context');
+  },
+  getPrivateKey: (): Promise<string> => {
+    throw new Error('getPrivateKey is not supported in this context');
+  },
+};
+
+export class LightningAddressService {
+  private baseUrl: string;
+  private userRepository: UserRepository;
+  private cashuReceiveQuoteRepository: CashuReceiveQuoteRepository;
+  private accountRepository: AccountRepository;
+  private minSendable: Money<'BTC'>;
+  private maxSendable: Money<'BTC'>;
+  private cryptography: CashuCryptography = fakeCryptography;
+
+  constructor(request: Request, db: BoardwalkDb) {
+    this.userRepository = new UserRepository(db, this.cryptography);
+    this.cashuReceiveQuoteRepository = new CashuReceiveQuoteRepository(
+      db,
+      this.cryptography,
+    );
+    this.accountRepository = new AccountRepository(db, this.cryptography);
+    this.baseUrl = new URL(request.url).origin;
+    this.minSendable = new Money({
+      amount: 1,
+      currency: 'BTC',
+      unit: 'sat',
+    });
+    this.maxSendable = new Money({
+      amount: 1_000_000,
+      currency: 'BTC',
+      unit: 'sat',
+    });
+  }
+
+  /**
+   * Returns the LNURL-p params for the given username or
+   * returns an error if the user is not found.
+   */
+  async handleLud16Request(
+    username: string,
+  ): Promise<LNURLPayParams | LNURLError> {
+    try {
+      const user = await this.userRepository.getByUsername(username);
+
+      if (!user) {
+        return {
+          status: 'ERROR',
+          reason: 'not found',
+        };
+      }
+
+      const callback = `${this.baseUrl}/api/lnurlp/callback/${user.id}`;
+      const address = `${user.username}@${new URL(this.baseUrl).host}`;
+      const metadata = JSON.stringify([
+        ['text/plain', `Pay to ${address}`],
+        ['text/identifier', address],
+      ]);
+
+      return {
+        callback,
+        maxSendable: this.maxSendable.toNumber('msat'),
+        minSendable: this.minSendable.toNumber('msat'),
+        metadata,
+        tag: 'payRequest',
+      };
+    } catch (error) {
+      console.error('Error processing LNURL-pay request', { cause: error });
+      return {
+        status: 'ERROR',
+        reason: 'Internal server error',
+      };
+    }
+  }
+
+  /**
+   * Creates a new cashu receive quote for the given user and amount.
+   * @returns the bolt11 invoice from the receive quote and the verify callback url.
+   */
+  async handleLnurlpCallback(
+    userId: string,
+    amount: Money<'BTC'>,
+  ): Promise<LNURLPayResult | LNURLError> {
+    if (
+      amount.lessThan(this.minSendable) ||
+      amount.greaterThan(this.maxSendable)
+    ) {
+      return {
+        status: 'ERROR',
+        reason: `Amount out of range. Min: ${this.minSendable.toNumber('sat')} sats, Max: ${this.maxSendable.toNumber('sat').toLocaleString()} sats.`,
+      };
+    }
+
+    try {
+      const user = await this.userRepository.get(userId);
+
+      if (!user) {
+        return {
+          status: 'ERROR',
+          reason: 'not found',
+        };
+      }
+
+      const cashuReceiveQuoteService = new CashuReceiveQuoteService(
+        {
+          ...this.cryptography,
+          getXpub: () => Promise.resolve(user.cashuLockingXpub),
+        },
+        this.cashuReceiveQuoteRepository,
+      );
+
+      // We only support BTC for lightning address because we need to get invoices for the exact satoshi amount.
+      // Other currency accounts would require an exchange rate which will create a mismatch in amounts.
+      const account = await this.userRepository.getDefaultAccount(
+        userId,
+        'BTC',
+      );
+
+      if (account.type !== 'cashu') {
+        throw new Error(`Account type not supported. Got ${account.type}`);
+      }
+
+      const quote = await cashuReceiveQuoteService.create({
+        userId,
+        account,
+        amount: amount as Money,
+      });
+
+      return {
+        pr: quote.paymentRequest,
+        verify: `${this.baseUrl}/api/lnurlp/verify/${quote.id}`,
+        routes: [],
+      };
+    } catch (error) {
+      console.error('Error processing LNURL-pay callback', { cause: error });
+      return {
+        status: 'ERROR',
+        reason: 'Internal server error',
+      };
+    }
+  }
+
+  /**
+   * Checks if the payment of a cashu receive quote has been settled.
+   * @param receiveQuoteId the id of the cashu receive quote to check.
+   * @return the lnurl-verify result
+   */
+  async handleLnurlpVerify(
+    receiveQuoteId: string,
+  ): Promise<LNURLVerifyResult | LNURLError> {
+    try {
+      const quote = await this.cashuReceiveQuoteRepository.get(receiveQuoteId);
+
+      if (!quote) {
+        return {
+          status: 'ERROR',
+          reason: 'Not found',
+        };
+      }
+
+      const account = await this.accountRepository.get(quote.accountId);
+      if (account.type !== 'cashu') {
+        throw new Error(`Account type not supported. Got ${account.type}`);
+      }
+
+      const wallet = getCashuWallet(account.mintUrl);
+      const quoteState = await wallet.checkMintQuote(quote.quoteId);
+
+      if (quoteState.state === 'PAID') {
+        return {
+          status: 'OK',
+          settled: true,
+          preimage: '',
+          pr: quote.paymentRequest,
+        };
+      }
+
+      return {
+        status: 'OK',
+        settled: false,
+        preimage: null,
+        pr: quote.paymentRequest,
+      };
+    } catch (error) {
+      console.error('Error processing LNURL-pay verify', { cause: error });
+      return {
+        status: 'ERROR',
+        reason: 'Internal server error',
+      };
+    }
+  }
+}

--- a/app/features/settings/profile/share-profile-qr.tsx
+++ b/app/features/settings/profile/share-profile-qr.tsx
@@ -1,9 +1,30 @@
+import { CopyIcon } from 'lucide-react';
+import { CheckIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { useState } from 'react';
 import { PageContent, PageFooter } from '~/components/page';
+import { Button } from '~/components/ui/button';
 import { SettingsViewHeader } from '~/features/settings/ui/settings-view-header';
+import { useUser } from '~/features/user/user-hooks';
 
-export default function ProfileQR() {
-  // TODO: Get actual username and profile URL from user context
-  const username = 'username';
+export default function ShareProfileQR() {
+  const username = useUser((u) => u.username);
+  const [lightningAddress, setLightningAddress] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    // TODO: use loader to get domain like in app/routes/_protected.send.share.tsx which is used in app/features/send/share-cashu-token.tsx
+    const domain = window.location.host;
+    setLightningAddress(`${username}@${domain}`);
+  }, [username]);
+
+  const copyToClipboard = () => {
+    if (lightningAddress) {
+      navigator.clipboard.writeText(lightningAddress);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   return (
     <>
@@ -22,6 +43,25 @@ export default function ProfileQR() {
           <p className="text-center text-muted-foreground text-sm">
             Scan to view profile
           </p>
+          {lightningAddress && (
+            <div className="mt-4">
+              <div className="flex items-center gap-2 rounded-md bg-muted px-4 py-2">
+                <span className="text-sm">{lightningAddress}</span>
+                <Button
+                  className="h-8 w-8 p-0"
+                  onClick={copyToClipboard}
+                  size="sm"
+                  variant="ghost"
+                >
+                  {copied ? (
+                    <CheckIcon className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <CopyIcon className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
       </PageContent>
       <PageFooter>

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -10,6 +10,15 @@ import { getSeedPhraseDerivationPath } from '../accounts/account-cryptography';
 import { useCryptography } from './cryptography';
 import { useEncryption } from './encryption';
 
+// Cashu-specific derivation path with hardnened indexes to derive public keys for
+// locking mint quotes and proofs. 129372 is UTF-8 for 🥜 (see NUT-13) and the other
+// 2 indexes are the coin type (0) and account (0) which can be changed to derive
+// different keys if needed. This path is "proprietary" and not part of any standard.
+// The index values are unimportant as long as they are hardened and remain constant.
+// DO NOT CHANGE THIS VALUE WITHOUT UPDATING USER'S XPUB IN THE DATABASE. IF THIS
+// IS NOT DONE, THEN WE WILL CREATE THE WRONG DERIVATION PATH WHEN GETTING PRIVATE KEYS.
+export const BASE_CASHU_LOCKING_DERIVATION_PATH = "m/129372'/0'/0'";
+
 function getCurrencyAndUnitFromToken(token: Token): {
   currency: Currency;
   unit: CurrencyUnit;

--- a/app/features/user/user.ts
+++ b/app/features/user/user.ts
@@ -9,6 +9,7 @@ type CommonUserData = {
   defaultBtcAccountId: string;
   defaultUsdAccountId: string;
   defaultCurrency: Currency;
+  cashuLockingXpub: string;
 };
 
 export type FullUser = CommonUserData & {

--- a/app/lib/lnurl/types.ts
+++ b/app/lib/lnurl/types.ts
@@ -1,0 +1,71 @@
+export type LNURLError = {
+  status: 'ERROR';
+  reason: string;
+};
+
+/**
+ * Response from the lnurlp endpoint
+ * @see https://github.com/lnurl/luds/blob/luds/06.md
+ */
+export type LNURLPayParams = {
+  /**
+   * The type of the LNURL
+   */
+  tag: 'payRequest';
+  /**
+   * The URL from LN SERVICE which will accept the pay request parameters
+   * @example https://domain.com/api/lnurlp/callback/${user.id}
+   */
+  callback: string;
+  /**
+   * Max millisatoshi amount LN SERVICE is willing to receive
+   */
+  maxSendable: number;
+  /**
+   * Min millisatoshi amount LN SERVICE is willing to receive,
+   * can not be less than 1 or more than `maxSendable`
+   */
+  minSendable: number;
+  /**
+   * Metadata json which must be presented as raw string here,
+   * @example `[['text/plain', 'Pay to ${address}']]`
+   */
+  metadata: string;
+};
+
+/** Response from the lnurlp callback */
+export type LNURLPayResult = {
+  /**
+   * bech-32 encoded bolt11 invoice
+   */
+  pr: string;
+  /**
+   * Optional URL to check the status of the invoice
+   * @example https://domain.com/api/lnurlp/verify/${payment_id}
+   */
+  verify?: string;
+  /**
+   * Optional routes to the lightning node. Defaults to empty array
+   */
+  routes: string[];
+};
+
+/**
+ * Response from the verify endpoint returned by the lnurlp callback
+ * @see https://github.com/lnurl/luds/blob/luds/21.md
+ */
+export type LNURLVerifyResult = {
+  status: 'OK';
+  /**
+   * True if the payment was settled, false otherwise
+   */
+  settled?: boolean;
+  /**
+   * Preimage of the payment
+   */
+  preimage: string | null;
+  /**
+   * bech-32 encoded bolt11 invoice
+   */
+  pr?: string;
+};

--- a/app/routes/[.]well-known.lnurlp.$username.ts
+++ b/app/routes/[.]well-known.lnurlp.$username.ts
@@ -1,0 +1,25 @@
+/**
+ * This route implements the `/.well-known/lnurlp/$username` endpoint
+ * defined by LUD 16: https://github.com/lnurl/luds/blob/luds/16.md
+ */
+
+import { boardwalkDbServiceRole } from '~/features/boardwalk-db/database.server';
+import { LightningAddressService } from '~/features/receive/lightning-address-service';
+import type { Route } from './+types/[.]well-known.lnurlp.$username';
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const lightningAddressService = new LightningAddressService(
+    request,
+    boardwalkDbServiceRole,
+  );
+
+  const response = await lightningAddressService.handleLud16Request(
+    params.username,
+  );
+
+  return new Response(JSON.stringify(response), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/app/routes/api.lnurlp.callback.$user_id.ts
+++ b/app/routes/api.lnurlp.callback.$user_id.ts
@@ -1,0 +1,41 @@
+/**
+ * This route implements the lnurlp callback endpoint
+ * defined by LUD 06: https://github.com/lnurl/luds/blob/luds/06.md
+ */
+
+import { boardwalkDbServiceRole } from '~/features/boardwalk-db/database.server';
+import { LightningAddressService } from '~/features/receive/lightning-address-service';
+import { Money } from '~/lib/money';
+import type { Route } from './+types/api.lnurlp.callback.$user_id';
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const userId = params.user_id;
+
+  const amountMsat = new URL(request.url).searchParams.get('amount');
+
+  if (!amountMsat || Number.isNaN(Number(amountMsat))) {
+    return new Response(
+      JSON.stringify({ status: 'ERROR', reason: 'Invalid amount' }),
+    );
+  }
+
+  const amount = new Money({
+    amount: amountMsat,
+    currency: 'BTC',
+    unit: 'msat',
+  });
+
+  const lightningAddressService = new LightningAddressService(
+    request,
+    boardwalkDbServiceRole,
+  );
+
+  const response = await lightningAddressService.handleLnurlpCallback(
+    userId,
+    amount,
+  );
+
+  return new Response(JSON.stringify(response), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/app/routes/api.lnurlp.verify.$cashu_receive_quote_id.ts
+++ b/app/routes/api.lnurlp.verify.$cashu_receive_quote_id.ts
@@ -1,0 +1,26 @@
+/**
+ * This route implements the LNURL-pay verify endpoint
+ * defined by LUD21:  https://github.com/lnurl/luds/blob/luds/21.md
+ */
+
+import { boardwalkDbServiceRole } from '~/features/boardwalk-db/database.server';
+import { LightningAddressService } from '~/features/receive/lightning-address-service';
+import type { Route } from './+types/api.lnurlp.verify.$cashu_receive_quote_id';
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const cashuReceiveQuoteId = params.cashu_receive_quote_id;
+
+  const lightningAddressService = new LightningAddressService(
+    request,
+    boardwalkDbServiceRole,
+  );
+
+  const response =
+    await lightningAddressService.handleLnurlpVerify(cashuReceiveQuoteId);
+
+  return new Response(JSON.stringify(response), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -292,6 +292,7 @@ export type Database = {
       }
       users: {
         Row: {
+          cashu_locking_xpub: string
           created_at: string
           default_btc_account_id: string | null
           default_currency: string
@@ -303,6 +304,7 @@ export type Database = {
           username: string
         }
         Insert: {
+          cashu_locking_xpub: string
           created_at?: string
           default_btc_account_id?: string | null
           default_currency?: string
@@ -314,6 +316,7 @@ export type Database = {
           username: string
         }
         Update: {
+          cashu_locking_xpub?: string
           created_at?: string
           default_btc_account_id?: string | null
           default_currency?: string
@@ -510,6 +513,7 @@ export type Database = {
           p_email: string
           p_email_verified: boolean
           p_accounts: Json[]
+          p_cashu_locking_xpub: string
         }
         Returns: Json
       }

--- a/supabase/migrations/20250422235033_add-cashu-xpubs-to-user.sql
+++ b/supabase/migrations/20250422235033_add-cashu-xpubs-to-user.sql
@@ -1,0 +1,150 @@
+alter table "wallet"."users" add column "cashu_locking_xpub" text;
+
+-- Set the default value to an empty string to avoid breaking existing data
+UPDATE "wallet"."users" SET "cashu_locking_xpub" = '';
+
+-- Make the column non-nullable
+ALTER TABLE "wallet"."users" ALTER COLUMN "cashu_locking_xpub" SET NOT NULL;
+
+CREATE UNIQUE INDEX users_cashu_locking_xpub_key ON wallet.users USING btree (cashu_locking_xpub);
+
+alter table "wallet"."users" add constraint "users_cashu_locking_xpub_key" UNIQUE using index "users_cashu_locking_xpub_key";
+
+-- Drop the old function before creating the new one with the additional parameter
+drop function if exists "wallet"."upsert_user_with_accounts"(p_user_id uuid, p_email text, p_email_verified boolean, p_accounts jsonb[]);
+
+set check_function_bodies = off;
+
+-- update to include cashu_locking_xpub
+CREATE OR REPLACE FUNCTION wallet.upsert_user_with_accounts(
+  p_user_id uuid,
+  p_email text,
+  p_email_verified boolean,
+  p_accounts jsonb[],
+  p_cashu_locking_xpub text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $function$declare
+  result_user jsonb;
+  existing_accounts jsonb;
+  acct jsonb;
+  new_acc wallet.accounts%ROWTYPE;
+  added_accounts jsonb := '[]'::jsonb;
+  usd_account_id uuid := null;
+  btc_account_id uuid := null;
+begin
+  -- Upsert user
+  insert into wallet.users (id, email, email_verified, cashu_locking_xpub)
+  values (p_user_id, p_email, p_email_verified, p_cashu_locking_xpub)
+  on conflict (id) do update set
+    email = coalesce(EXCLUDED.email, wallet.users.email),
+    email_verified = EXCLUDED.email_verified;
+
+  -- Select and lock the user row
+  select jsonb_build_object(
+    'id', u.id,
+    'username', u.username,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'cashu_locking_xpub', u.cashu_locking_xpub,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at
+  ) into result_user
+  from wallet.users u
+  where u.id = p_user_id
+  for update;
+
+  -- Select existing accounts
+  select jsonb_agg(jsonb_build_object(
+    'id', a.id,
+    'type', a.type,
+    'currency', a.currency,
+    'name', a.name,
+    'details', a.details,
+    'created_at', a.created_at,
+    'version', a.version
+  )) into existing_accounts
+  from wallet.accounts a
+  where a.user_id = p_user_id;
+
+  -- If user already has accounts, return user with accounts
+  if jsonb_array_length(coalesce(existing_accounts, '[]'::jsonb)) > 0 then    
+    result_user := jsonb_set(result_user, '{accounts}', existing_accounts);
+    return result_user;
+  end if;
+
+  -- Validate accounts to insert
+  if array_length(p_accounts, 1) is null then
+    raise exception 'p_accounts cannot be empty array';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(p_accounts)::jsonb, '$[*] ? (@.currency == "USD")') then
+    raise exception 'At least one USD account is required';
+  end if;
+
+  if not jsonb_path_exists(array_to_json(p_accounts)::jsonb, '$[*] ? (@.currency == "BTC")') then
+    raise exception 'At least one BTC account is required';
+  end if;
+
+  -- Insert accounts
+  foreach acct in array p_accounts loop
+    insert into wallet.accounts (user_id, type, currency, name, details)
+    values (
+      p_user_id,
+      acct->>'type',
+      acct->>'currency',
+      acct->>'name',
+      acct->'details'
+    )
+    returning * into new_acc;
+
+    -- Append to added accounts list
+    added_accounts := added_accounts || jsonb_build_object(
+      'id', new_acc.id,
+      'user_id', new_acc.user_id,
+      'type', new_acc.type,
+      'currency', new_acc.currency,
+      'name', new_acc.name,
+      'details', new_acc.details,
+      'version', new_acc.version,
+      'created_at', new_acc.created_at
+    );
+
+    -- Set default account IDs
+    if new_acc.currency = 'USD' then
+      usd_account_id := new_acc.id;
+    elsif new_acc.currency = 'BTC' then
+      btc_account_id := new_acc.id;
+    end if;
+  end loop;
+
+  -- Update user with default account IDs (keeping existing values)
+  update wallet.users u
+  set 
+    default_usd_account_id = coalesce(usd_account_id, u.default_usd_account_id),
+    default_btc_account_id = coalesce(btc_account_id, u.default_btc_account_id)
+  where id = p_user_id
+  returning jsonb_build_object(
+    'id', u.id,
+    'username', u.username,
+    'email', u.email,
+    'email_verified', u.email_verified,
+    'default_usd_account_id', u.default_usd_account_id,
+    'default_btc_account_id', u.default_btc_account_id,
+    'default_currency', u.default_currency,
+    'cashu_locking_xpub', u.cashu_locking_xpub,
+    'created_at', u.created_at,
+    'updated_at', u.updated_at,
+    'accounts', added_accounts
+  ) into result_user;
+
+  return result_user;
+
+end;$function$
+;
+
+


### PR DESCRIPTION
Depends on #350 because we need the NUT20 signed mint quotes.

This gives all our users a lightning address at user@example.domain

This adds 3 routes all defined by the [LUDs](https://github.com/lnurl/luds/tree/luds):
- `.well-known/lnurlp/<username>` - to get the lnurlp params from a lightning address
- `api/lnurlp/callback/<user_id>` - to get the invoice to pay
- `api/lnurlp/verify/<payment_id>` - to verify the payment status of an invoice

I added a cashuLockingXpub to users when they are upserted, and this is then used in the `LightningAddressService` to create a `CashuReceiveQuote` locked to a public key the user controls. When the user is online, we detect the new receive quote and finish the receive flow.