### PR TITLE
bug fix: use counter and outputAmounts from quote if set

### DIFF
--- a/app/features/receive/cashu-receive-quote-service.ts
+++ b/app/features/receive/cashu-receive-quote-service.ts
@@ -227,14 +227,17 @@ export class CashuReceiveQuoteService {
 
     const keysetId = quote.state === 'PAID' ? quote.keysetId : undefined;
     const keys = await wallet.getKeys(keysetId);
-    const counter = account.keysetCounters[wallet.keysetId] ?? 0;
+    const counter =
+      quote.state === 'PAID'
+        ? quote.keysetCounter
+        : (account.keysetCounters[wallet.keysetId] ?? 0);
+
     const outputData = OutputData.createDeterministicData(
       quote.amount.toNumber(cashuUnit),
       seed,
       counter,
       keys,
     );
-    const outputAmounts = amountsFromOutputData(outputData);
 
     const { updatedQuote, updatedAccount } =
       await this.cashuReceiveQuoteRepository.processPayment({
@@ -242,7 +245,7 @@ export class CashuReceiveQuoteService {
         quoteVersion: quote.version,
         keysetId: wallet.keysetId,
         keysetCounter: counter,
-        outputAmounts,
+        outputAmounts: amountsFromOutputData(outputData),
         accountVersion: account.version,
       });
 


### PR DESCRIPTION
The CashuReceiveQuoteService.completeReceive function can be called multiple times and if we don't use the stored counter and outputAmount values when the quote is PAID, then when we try to recover already issued proofs we might be using the wrong values and not be able to restore.