### PR TITLE
bug fix: convert guest instead of signup guest

### DIFF
--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -98,7 +98,7 @@ export const useUpgradeGuestToFullAccount = (): ((
   password: string,
 ) => Promise<void>) => {
   const userRef = useUserRef();
-  const { signUpGuest } = useOpenSecret();
+  const { convertGuestToUserAccount } = useOpenSecret();
 
   const { mutateAsync } = useMutation({
     mutationKey: ['upgrade-guest-to-full-account'],
@@ -107,7 +107,10 @@ export const useUpgradeGuestToFullAccount = (): ((
         throw new Error('User already has a full account');
       }
 
-      return signUpGuest(variables.email, variables.password).then(() => {
+      return convertGuestToUserAccount(
+        variables.email,
+        variables.password,
+      ).then(() => {
         guestAccountStorage.clear();
       });
     },


### PR DESCRIPTION
this is what was causing our user id to chnage when upgrade guest occurred. We were using the wrong function.