### PR TITLE
Make sure accounts are loaded into cache in the wallet component

### DIFF
--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -268,6 +268,9 @@ function useOnAccountChange({
 }
 
 export function useTrackAccounts() {
+  // Makes sure the accounts are loaded in the cache.
+  useAccounts();
+
   const accountCache = useAccountsCache();
 
   useOnAccountChange({


### PR DESCRIPTION
I noticed that currently we are currently using accounts cache in "background work" stuff and we expect the accounts to be loaded into cache without anything actually making sure to load them. This causes an error to be thrown if you directly try to open a page that doesn't call useAccounts. E.g. try opening http://localhost:3000/settings/appearance and see what happens.

To make sure accounts are always loaded I added a call to useAccounts inside the useTrackAccounts hook that is called from the wallet component. This means that every wallet route will now have accounts loaded before any other work starts