### PR TITLE
sync ui theme with default currency

### DIFF
--- a/app/features/accounts/default-currency-switcher.tsx
+++ b/app/features/accounts/default-currency-switcher.tsx
@@ -10,7 +10,6 @@ import {
 import { RadioGroup, RadioGroupItem } from '~/components/ui/radio-group';
 import { Separator } from '~/components/ui/separator';
 import { Skeleton } from '~/components/ui/skeleton';
-import { useTheme } from '~/features/theme';
 import { useExchangeRate } from '~/hooks/use-exchange-rate';
 import { useToast } from '~/hooks/use-toast';
 import type { Currency } from '~/lib/money/types';
@@ -84,7 +83,6 @@ function CurrencyOption({ data, isSelected, onSelect }: CurrencyOptionProps) {
 export function DefaultCurrencySwitcher() {
   const { toast } = useToast();
   const [isOpen, setIsOpen] = useState(false);
-  const { setTheme } = useTheme();
   const defaultCurrency = useUser((user) => user.defaultCurrency);
   const setDefaultCurrency = useSetDefaultCurrency();
 
@@ -92,7 +90,6 @@ export function DefaultCurrencySwitcher() {
     try {
       await setDefaultCurrency(currency);
       setIsOpen(false);
-      setTheme(currency.toLowerCase() as 'usd' | 'btc');
     } catch (error) {
       console.error(error);
       toast({

--- a/app/features/wallet/wallet.tsx
+++ b/app/features/wallet/wallet.tsx
@@ -6,6 +6,7 @@ import { LoadingScreen } from '../loading/LoadingScreen';
 import { useTrackPendingCashuReceiveQuotes } from '../receive/cashu-receive-quote-hooks';
 import { useTrackPendingCashuTokenSwaps } from '../receive/cashu-token-swap-hooks';
 import { useTrackUnresolvedCashuSendQuotes } from '../send/cashu-send-quote-hooks';
+import { useTheme } from '../theme';
 import { type AuthUser, useHandleSessionExpiry } from '../user/auth';
 import { useUpsertUser, useUser } from '../user/user-hooks';
 
@@ -13,6 +14,19 @@ const useSetSupabseSession = (authUser: AuthUser) => {
   useEffect(() => {
     supabaseSessionStore.getState().setJwtPayload({ sub: authUser.id });
   }, [authUser]);
+};
+
+/**
+ * Syncs the theme settings stored in cookies to match the default currency
+ * according to the Agicash database.
+ */
+const useSyncThemeWithDefaultCurrency = () => {
+  const { setTheme } = useTheme();
+  const defaultCurrency = useUser((user) => user.defaultCurrency);
+  useEffect(() => {
+    const theme = defaultCurrency === 'BTC' ? 'btc' : 'usd';
+    setTheme(theme);
+  }, [defaultCurrency, setTheme]);
 };
 
 /**
@@ -47,6 +61,8 @@ const Wallet = ({ children }: PropsWithChildren) => {
       });
     },
   });
+
+  useSyncThemeWithDefaultCurrency();
 
   useTrackAccounts();
   useTrackPendingCashuReceiveQuotes();


### PR DESCRIPTION
If you switched default currency on another device, then returned to original device the default currency would get updated, but our theme colors are read from cookies and the cookies were not being updated