### PR TITLE
receive-cashu-token: normalize mint urls and fix badges

### DIFF
--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -320,22 +320,17 @@ export function useAccounts<T extends AccountType = AccountType>(select?: {
 /**
  * Hook to get an account by ID.
  * @param id - The ID of the account to retrieve.
- * @param getFallbackAccount - Optional function that returns a fallback account if the requested account is not found.
- * @returns The specified account or the result of the fallback function if provided.
- * @throws Error if the account is not found and no fallback function is provided.
+ * @returns The specified account.
+ * @throws Error if the account is not found.
  */
 export function useAccount<T extends ExtendedAccount = ExtendedAccount>(
   id: string,
-  getFallbackAccount?: () => T,
 ) {
   const user = useUser();
   const { data: accounts } = useAccounts();
   const account = accounts.find((x) => x.id === id);
 
   if (!account) {
-    if (getFallbackAccount) {
-      return getFallbackAccount();
-    }
     throw new Error(`Account with id ${id} not found`);
   }
 


### PR DESCRIPTION
Sometimes a token from a different wallet would be from a mint we already had added, but the urls did not match exactly. Now when we decode the token we normalize the url and also normalize urls when we take them from our database.
There was also a bug where the receive account was not read from selectable accounts, so we were not including the badges there. We want the receive account to have badges too so they show in the selector.