### PR TITLE
Update button not to change width when switched to loading state

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -58,13 +58,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const Comp = asChild ? Slot : 'button';
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn('relative', buttonVariants({ variant, size, className }))}
         ref={ref}
         disabled={loading || disabled}
         {...props}
       >
         {loading ? (
-          <LoaderCircle className="h-5 w-5 animate-spin text-muted-foreground" />
+          <>
+            <span className="invisible">{children}</span>
+            <span className="absolute inset-0 flex items-center justify-center">
+              <LoaderCircle className="h-5 w-5 animate-spin text-muted-foreground" />
+            </span>
+          </>
         ) : (
           children
         )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved loading state for buttons to prevent layout shifts and maintain accessibility by keeping original content invisible and overlaying the loader icon.
- **Style**
  - Ensured consistent button positioning by always including the "relative" CSS class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->