### PR TITLE
Refactor reverse send flow

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -3,7 +3,6 @@ import type { Database as DatabaseGenerated } from 'supabase/database.types';
 import type { MergeDeep } from 'type-fest';
 import type { Currency, CurrencyUnit } from '~/lib/money';
 import type { AccountType } from '../accounts/account';
-import type { CashuTokenSwap } from '../receive/cashu-token-swap';
 import type { CashuSendSwap } from '../send/cashu-send-swap';
 import type { SerializedOutputData } from '../send/cashu-send-swap-repository';
 import type { Transaction } from '../transactions/transaction';
@@ -84,17 +83,14 @@ export type Database = MergeDeep<
           Row: {
             currency: Currency;
             unit: CurrencyUnit;
-            type: CashuTokenSwap['type'];
           };
           Insert: {
             currency: Currency;
             unit: CurrencyUnit;
-            type: CashuTokenSwap['type'];
           };
           Update: {
             currency?: Currency;
             unit?: CurrencyUnit;
-            type?: CashuTokenSwap['type'];
           };
         };
         cashu_send_quotes: {
@@ -141,6 +137,7 @@ export type Database = MergeDeep<
           Row: {
             currency: Currency;
             unit: CurrencyUnit;
+            reversed_txid: string | null;
             direction: Transaction['direction'];
             type: Transaction['type'];
             state: Transaction['state'];

--- a/app/features/receive/cashu-token-swap-repository.ts
+++ b/app/features/receive/cashu-token-swap-repository.ts
@@ -53,13 +53,6 @@ type CreateTokenSwap = {
    * Version of the account as seen by the client. Used for optimistic concurrency control.
    */
   accountVersion: number;
-  /**
-   * Type of the token swap
-   *
-   * - RECEIVE: directly receiving a token
-   * - CANCEL_CASHU_SEND_SWAP: cancelling a cashu send swap by swapping the sent proofs back to the account
-   */
-  type: 'RECEIVE' | 'CANCEL_CASHU_SEND_SWAP';
 };
 
 export class CashuTokenSwapRepository {
@@ -83,9 +76,8 @@ export class CashuTokenSwapRepository {
       keysetCounter,
       outputAmounts,
       accountVersion,
-      type,
     }: CreateTokenSwap,
-    options?: Options,
+    options?: Options & { reversedTxid?: string },
   ): Promise<CashuTokenSwap> {
     const amount = tokenToMoney(token);
     const unit = getDefaultUnit(amount.currency);
@@ -106,7 +98,7 @@ export class CashuTokenSwapRepository {
       p_receive_amount: sum(outputAmounts) - fee,
       p_fee_amount: fee,
       p_account_version: accountVersion,
-      p_type: type,
+      p_reversed_txid: options?.reversedTxid,
     });
 
     if (options?.abortSignal) {
@@ -284,7 +276,6 @@ export class CashuTokenSwapRepository {
       state: data.state as CashuTokenSwap['state'],
       version: data.version,
       transactionId: data.transaction_id,
-      type: data.type,
     };
   }
 }

--- a/app/features/receive/cashu-token-swap-service.ts
+++ b/app/features/receive/cashu-token-swap-service.ts
@@ -34,12 +34,12 @@ export class CashuTokenSwapService {
     userId,
     token,
     account,
-    type = 'RECEIVE',
+    reversedTxid,
   }: {
     userId: string;
     token: Token;
     account: CashuAccount;
-    type?: 'RECEIVE' | 'CANCEL_CASHU_SEND_SWAP';
+    reversedTxid?: string;
   }) {
     if (account.mintUrl !== token.mint) {
       throw new Error('Cannot swap a token to a different mint');
@@ -71,17 +71,19 @@ export class CashuTokenSwapService {
     );
     const outputAmounts = amountsFromOutputData(outputData);
 
-    const tokenSwap = await this.tokenSwapRepository.create({
-      token,
-      userId,
-      accountId: account.id,
-      keysetId: wallet.keysetId,
-      keysetCounter: counter,
-      outputAmounts,
-      fee,
-      accountVersion: account.version,
-      type,
-    });
+    const tokenSwap = await this.tokenSwapRepository.create(
+      {
+        token,
+        userId,
+        accountId: account.id,
+        keysetId: wallet.keysetId,
+        keysetCounter: counter,
+        outputAmounts,
+        fee,
+        accountVersion: account.version,
+      },
+      { reversedTxid },
+    );
 
     return tokenSwap;
   }

--- a/app/features/receive/cashu-token-swap.ts
+++ b/app/features/receive/cashu-token-swap.ts
@@ -39,11 +39,6 @@ export type CashuTokenSwap = {
    */
   state: 'PENDING' | 'COMPLETED' | 'FAILED';
   /**
-   * - RECEIVE: directly receiving a token
-   * - CANCEL_CASHU_SEND_SWAP: cancelling a cashu send swap by swapping the sent proofs back to the account
-   */
-  type: 'RECEIVE' | 'CANCEL_CASHU_SEND_SWAP';
-  /**
    * ID of the corresponding transaction
    */
   transactionId: string;

--- a/app/features/send/cashu-send-swap-hooks.ts
+++ b/app/features/send/cashu-send-swap-hooks.ts
@@ -183,7 +183,7 @@ function useSwapForProofsToSend() {
   });
 }
 
-export function useCancelCashuSendSwap() {
+export function useReverseCashuSendSwap() {
   const cashuSendSwapService = useCashuSendSwapService();
   const cashuTokenSwapService = useCashuTokenSwapService();
   const getLatestCashuAccount = useGetLatestCashuAccount();
@@ -204,7 +204,7 @@ export function useCancelCashuSendSwap() {
           proofs: swap.proofsToSend,
           unit: getCashuProtocolUnit(swap.currency),
         },
-        type: 'CANCEL_CASHU_SEND_SWAP',
+        reversedTxid: swap.transactionId,
       });
 
       return swap;

--- a/app/features/send/cashu-send-swap-repository.ts
+++ b/app/features/send/cashu-send-swap-repository.ts
@@ -419,10 +419,10 @@ export class CashuSendSwapRepository {
       };
     }
 
-    if (data.state === 'CANCELLED') {
+    if (data.state === 'REVERSED') {
       return {
         ...commonData,
-        state: 'CANCELLED',
+        state: 'REVERSED',
       };
     }
 

--- a/app/features/send/cashu-send-swap.ts
+++ b/app/features/send/cashu-send-swap.ts
@@ -10,7 +10,7 @@ import type { Currency, Money } from '~/lib/money';
  * the inputProofs are swapped for proofsToSend.
  *
  * When PENDING, the proofsToSend exist and we are just waiting for them to be spent.
- * In this state, the transaction can be cancelled by swapping the proofsToSend back
+ * In this state, the transaction can be reversed by swapping the proofsToSend back
  * into the account.
  *
  * Once the proofsToSend are spent, the swap is COMPLETED.
@@ -67,9 +67,9 @@ export type CashuSendSwap = {
    * we have only taken the inputProofs from the account
    * - PENDING: There are proofs to send and the swap is waiting for the proofsToSend to be spent.
    * - COMPLETED: The proofsToSend have been spent.
-   * - CANCELLED: The swap was cancelled before the proofsToSend were spent.
+   * - REVERSED: The swap was reversed before the proofsToSend were spent.
    */
-  state: 'DRAFT' | 'PENDING' | 'COMPLETED' | 'CANCELLED' | 'FAILED';
+  state: 'DRAFT' | 'PENDING' | 'COMPLETED' | 'REVERSED' | 'FAILED';
   /**
    * The version of the swap used for optimistic locking.
    */
@@ -123,7 +123,7 @@ export type CashuSendSwap = {
       failureReason: string;
     }
   | {
-      state: 'CANCELLED';
+      state: 'REVERSED';
     }
 );
 

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -59,7 +59,7 @@ export default function Settings() {
           Appearance
         </SettingsNavButton>
         <SettingsNavButton to="/settings/contacts">Contacts</SettingsNavButton>
-        {/* this is temporary just so we can test cancelling the pending swaps */}
+        {/* this is temporary just so we can test reversing the pending swaps */}
         <SettingsNavButton to="/demo">Pending Sends</SettingsNavButton>
 
         <Separator />

--- a/app/features/transactions/transaction-repository.ts
+++ b/app/features/transactions/transaction-repository.ts
@@ -41,6 +41,7 @@ export class TransactionRepository {
         amount: data.amount,
         currency: data.currency,
       }),
+      reversedTxid: data.reversed_txid,
       createdAt: data.created_at,
       pendingAt: data.pending_at,
       completedAt: data.completed_at,

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -16,21 +16,17 @@ export type Transaction = {
   /**
    * Type of the transaction.
    */
-  type:
-    | 'CASHU_LIGHTNING'
-    | 'CASHU_TOKEN'
-    | 'CASHU_PAYMENT_REQUEST'
-    | 'CANCEL_CASHU_SEND_SWAP';
+  type: 'CASHU_LIGHTNING' | 'CASHU_TOKEN' | 'CASHU_PAYMENT_REQUEST';
   /**
    * State of the transaction.
    * Transaction states are:
    * - DRAFT: The transaction is drafted but might never be initiated and thus completed.
-   * - PENDING: The transaction was initiated and is being processed. At this point the sender cannot cancel the transaction.
+   * - PENDING: The transaction was initiated and is being processed. At this point the sender cannot reverse the transaction.
    * - COMPLETED: The transaction has been completed.
    * - FAILED: The transaction has failed.
-   * - CANCELLED: The transaction was cancelled and money was returned to the account.
+   * - REVERSED: The transaction was reversed and money was returned to the account.
    */
-  state: 'DRAFT' | 'PENDING' | 'COMPLETED' | 'FAILED' | 'CANCELLED';
+  state: 'DRAFT' | 'PENDING' | 'COMPLETED' | 'FAILED' | 'REVERSED';
   /**
    * ID of the account that the transaction was sent from or received to.
    * For SEND transactions, it is the account that the transaction was sent from.
@@ -41,6 +37,11 @@ export type Transaction = {
    * Amount of the transaction.
    */
   amount: Money;
+  /**
+   * If this transaction reverses another transaction, this is the id of the
+   * reversed transaction.
+   */
+  reversedTxid?: string | null;
   /**
    * Date and time the transaction was created in ISO 8601 format.
    */

--- a/app/routes/_protected.demo.tsx
+++ b/app/routes/_protected.demo.tsx
@@ -9,24 +9,24 @@ import {
 import { Button } from '~/components/ui/button';
 import type { CashuSendSwap } from '~/features/send/cashu-send-swap';
 import {
-  useCancelCashuSendSwap,
+  useReverseCashuSendSwap,
   useUnresolvedCashuSendSwaps,
 } from '~/features/send/cashu-send-swap-hooks';
 import { getDefaultUnit } from '~/features/shared/currencies';
 
 export default function Demo() {
   const { pending } = useUnresolvedCashuSendSwaps();
-  const { mutate: cancelCashuSendSwap } = useCancelCashuSendSwap();
+  const { mutate: reverseCashuSendSwap } = useReverseCashuSendSwap();
 
-  const handleCancelCashuSendSwap = (swap: CashuSendSwap) => {
-    cancelCashuSendSwap(
+  const handleReverseCashuSendSwap = (swap: CashuSendSwap) => {
+    reverseCashuSendSwap(
       { swap },
       {
         onSuccess: () => {
-          console.log('Swap cancelled');
+          console.log('Swap reversed');
         },
         onError: (error) => {
-          console.error('Failed to cancel swap', error);
+          console.error('Failed to reverse swap', error);
         },
       },
     );
@@ -57,7 +57,7 @@ export default function Demo() {
                     <Button
                       variant="destructive"
                       size="sm"
-                      onClick={() => handleCancelCashuSendSwap(swap)}
+                      onClick={() => handleReverseCashuSendSwap(swap)}
                     >
                       Cancel
                     </Button>

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -360,7 +360,6 @@ export type Database = {
           token_hash: string
           token_proofs: string
           transaction_id: string
-          type: string | null
           unit: string
           user_id: string
           version: number
@@ -380,7 +379,6 @@ export type Database = {
           token_hash: string
           token_proofs: string
           transaction_id: string
-          type?: string | null
           unit: string
           user_id: string
           version?: number
@@ -400,7 +398,6 @@ export type Database = {
           token_hash?: string
           token_proofs?: string
           transaction_id?: string
-          type?: string | null
           unit?: string
           user_id?: string
           version?: number
@@ -470,6 +467,7 @@ export type Database = {
           account_id: string
           amount: number
           completed_at: string | null
+          reversed_txid: string | null
           created_at: string
           currency: string
           direction: string
@@ -484,6 +482,7 @@ export type Database = {
           account_id: string
           amount: number
           completed_at?: string | null
+          reversed_txid?: string | null
           created_at?: string
           currency: string
           direction: string
@@ -498,6 +497,7 @@ export type Database = {
           account_id?: string
           amount?: number
           completed_at?: string | null
+          reversed_txid?: string | null
           created_at?: string
           currency?: string
           direction?: string


### PR DESCRIPTION
## Summary
- rename cancellation logic to reversing
- track reversed transaction ids in DB
- update send swap state transitions
- revise frontend hooks and services accordingly

## Testing
- `bun run fix:staged`
- `bun test`
