### PR TITLE
Return account in send swap hook and add 404 page

### DIFF
--- a/app/features/send/cashu-send-swap-hooks.ts
+++ b/app/features/send/cashu-send-swap-hooks.ts
@@ -334,6 +334,7 @@ export function useCashuSendSwap({
   const onFailedRef = useLatest(onFailed);
   const cashuSendSwapCache = useCashuSendSwapCache();
   const cashuSendSwapRepository = useCashuSendSwapRepository();
+  const accountsCache = useAccountsCache();
 
   const result = useQuery({
     queryKey: [cashuSendSwapQueryKey, id],
@@ -345,6 +346,7 @@ export function useCashuSendSwap({
   });
 
   const { data } = result;
+  const account = data ? accountsCache.get(data.accountId) : undefined;
 
   useEffect(() => {
     if (!data) return;
@@ -358,7 +360,11 @@ export function useCashuSendSwap({
     }
   }, [data]);
 
-  return result;
+  if (data && !account) {
+    throw new Error(`Account not found for Cashu send swap ${id}`);
+  }
+
+  return { ...result, account };
 }
 
 type OnProofStateChangeProps = {

--- a/app/routes/404.tsx
+++ b/app/routes/404.tsx
@@ -1,0 +1,16 @@
+import { Page, PageContent } from '~/components/page';
+import { useSearchParams } from 'react-router';
+
+export default function NotFoundPage() {
+  const [params] = useSearchParams();
+  const message = params.get('message') || 'Page not found';
+
+  return (
+    <Page>
+      <PageContent className="justify-center text-center">
+        <h1 className="font-medium text-xl">404</h1>
+        <p className="mt-2 text-muted-foreground">{message}</p>
+      </PageContent>
+    </Page>
+  );
+}

--- a/app/routes/_protected.send.share.$swapId.tsx
+++ b/app/routes/_protected.send.share.$swapId.tsx
@@ -1,21 +1,21 @@
 import { Page } from '~/components/page';
 import { Redirect } from '~/components/redirect';
-import { useAccountsCache } from '~/features/accounts/account-hooks';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { useCashuSendSwap } from '~/features/send/cashu-send-swap-hooks';
 import { ShareCashuToken } from '~/features/send/share-cashu-token';
 import { SuccessfulSendPage } from '~/features/send/succesful-send-page';
+import type { Account } from '~/features/accounts/account';
 import { getCashuProtocolUnit } from '~/lib/cashu';
 import type { Route } from './+types/_protected.send.share.$swapId';
 
 export default function SendShare({ params }: Route.ComponentProps) {
-  const accountsCache = useAccountsCache();
   const { swapId } = params;
 
   const {
     data: swap,
     status,
     error,
+    account,
   } = useCashuSendSwap({
     id: swapId,
   });
@@ -25,18 +25,19 @@ export default function SendShare({ params }: Route.ComponentProps) {
   }
 
   if (error) {
-    return <Redirect to="/send" logMessage="Error fetching swap" />;
+    return (
+      <Redirect
+        to="/404?message=Cashu%20send%20not%20fount"
+        logMessage="Error fetching swap"
+      />
+    );
   }
 
   if (swap.state === 'COMPLETED') {
-    const account = accountsCache.get(swap.accountId);
-    if (!account) {
-      return <Redirect to="/send" logMessage="Account not found" />;
-    }
     return (
       <SuccessfulSendPage
         amount={swap.amountToSend}
-        account={account}
+        account={account as Account}
         destination={'ecash'}
         feesPaid={swap.sendSwapFee.add(swap.receiveSwapFee)}
       />


### PR DESCRIPTION
## Summary
- extend `useCashuSendSwap` hook to provide the related account when the swap is completed
- add a small `/404` route that displays a custom message
- update `send/share` route to use the new hook result and redirect to the 404 page when the swap is missing

## Testing
- `bun run lint:check`
- `bun run format:check`
- `bun test`
- `bun run test:e2e` *(fails: Docker daemon not running)*