### PR TITLE
refactor mint validation and validate on receive

### DIFF
--- a/app/features/accounts/account-selector.tsx
+++ b/app/features/accounts/account-selector.tsx
@@ -8,6 +8,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '~/components/ui/drawer';
+import { cn } from '~/lib/utils';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import { type Account, getAccountBalance } from './account';
 import { AccountTypeIcon } from './account-icons';
@@ -15,6 +16,8 @@ import { AccountTypeIcon } from './account-icons';
 export type AccountWithBadges<T extends Account = Account> = T & {
   /** Text to display as a badge in the account selector */
   badges?: string[];
+  /** Whether the account is selectable */
+  selectable?: boolean;
 };
 
 function AccountItem({ account }: { account: AccountWithBadges }) {
@@ -92,12 +95,16 @@ export function AccountSelector<T extends Account>({
               ...accounts.filter((a) => a.id !== selectedAccount.id),
             ].map((account) => (
               <button
+                disabled={account.selectable === false}
                 type="button"
                 key={account.id}
                 onClick={() => handleAccountSelect(account)}
-                className={`rounded-lg hover:bg-muted ${
-                  selectedAccount.id === account.id ? 'bg-muted' : ''
-                }`}
+                className={cn(
+                  'rounded-lg hover:bg-muted',
+                  selectedAccount.id === account.id && 'bg-muted',
+                  account.selectable === false &&
+                    'pointer-events-none cursor-not-allowed opacity-50',
+                )}
               >
                 <AccountItem account={account} />
               </button>

--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -83,6 +83,7 @@ function useCashuTokenSourceAccount(token: Token) {
       const validationResult = await cashuMintValidator(
         token.mint,
         getCashuProtocolUnit(tokenCurrency),
+        info,
       );
 
       return {

--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -11,8 +11,12 @@ import {
   useAddCashuAccount,
   useDefaultAccount,
 } from '~/features/accounts/account-hooks';
-import { tokenToMoney } from '~/features/shared/cashu';
-import { getClaimableProofs, getUnspentProofsFromToken } from '~/lib/cashu';
+import { cashuMintValidator, tokenToMoney } from '~/features/shared/cashu';
+import {
+  getCashuProtocolUnit,
+  getClaimableProofs,
+  getUnspentProofsFromToken,
+} from '~/lib/cashu';
 import { checkIsTestMint, getMintInfo } from '~/lib/cashu';
 import { useLatest } from '~/lib/use-latest';
 import type { AccountWithBadges } from '../accounts/account-selector';
@@ -50,7 +54,7 @@ type TokenQueryResult =
  * Takes a token and returns the account that the token is from.
  * If the account does not exist, we construct and return an account, but we do not store it in the database.
  */
-export function useCashuTokenSourceAccount(token: Token) {
+function useCashuTokenSourceAccount(token: Token) {
   const tokenCurrency = tokenToMoney(token).currency;
   const { data: allAccounts } = useAccounts({ type: 'cashu' });
   const existingAccount = allAccounts.find(
@@ -60,9 +64,15 @@ export function useCashuTokenSourceAccount(token: Token) {
 
   const { data } = useSuspenseQuery({
     queryKey: ['token-source-account', token.mint, tokenCurrency],
-    queryFn: async (): Promise<ExtendedCashuAccount> => {
+    queryFn: async (): Promise<{
+      isValid: boolean;
+      sourceAccount: ExtendedCashuAccount;
+    }> => {
       if (existingAccount) {
-        return existingAccount;
+        return {
+          isValid: true,
+          sourceAccount: existingAccount,
+        };
       }
 
       const [info, isTestMint] = await Promise.all([
@@ -70,18 +80,26 @@ export function useCashuTokenSourceAccount(token: Token) {
         checkIsTestMint(token.mint),
       ]);
 
+      const validationResult = await cashuMintValidator(
+        token.mint,
+        getCashuProtocolUnit(tokenCurrency),
+      );
+
       return {
-        id: '',
-        type: 'cashu',
-        mintUrl: token.mint,
-        createdAt: new Date().toISOString(),
-        name: info?.name ?? token.mint.replace('https://', ''),
-        currency: tokenToMoney(token).currency,
-        isTestMint,
-        version: 0,
-        keysetCounters: {},
-        proofs: [],
-        isDefault: false,
+        isValid: validationResult === true,
+        sourceAccount: {
+          id: '',
+          type: 'cashu',
+          mintUrl: token.mint,
+          createdAt: new Date().toISOString(),
+          name: info?.name ?? token.mint.replace('https://', ''),
+          currency: tokenToMoney(token).currency,
+          isTestMint,
+          version: 0,
+          keysetCounters: {},
+          proofs: [],
+          isDefault: false,
+        },
       };
     },
     staleTime: 3 * 60 * 1000,
@@ -133,7 +151,7 @@ export function useTokenWithClaimableProofs({
 }
 
 const getDefaultReceiveAccount = (
-  selectableAccounts: CashuAccount[],
+  selectableAccounts: CashuAccountWithBadges[],
   sourceAccount: CashuAccount,
   isCrossMintSwapDisabled: boolean,
   defaultAccount: Account,
@@ -144,8 +162,16 @@ const getDefaultReceiveAccount = (
       : defaultAccount;
 
   const matchingAccount = selectableAccounts.find(
-    (a) => a.id === targetAccount.id,
+    (a) => a.id === targetAccount.id && a.selectable,
   );
+
+  // If no matching selectable account found, get the first selectable account
+  if (!matchingAccount) {
+    const firstSelectable = selectableAccounts.find((a) => a.selectable);
+    if (firstSelectable) {
+      return firstSelectable;
+    }
+  }
 
   // Fall back to source account if no match found
   return matchingAccount ?? sourceAccount;
@@ -156,6 +182,7 @@ const getBadges = (
   allAccounts: CashuAccount[],
   sourceAccount: CashuAccount,
   defaultAccount: Account,
+  isSourceAccountValid: boolean,
 ) => {
   const badges: string[] = [];
 
@@ -164,6 +191,9 @@ const getBadges = (
   }
   if (account.id === sourceAccount.id) {
     badges.push('Source');
+    if (!isSourceAccountValid) {
+      badges.push('Invalid');
+    }
   }
   if (account.id === defaultAccount.id) {
     badges.push('Default');
@@ -177,6 +207,7 @@ const getBadges = (
 
 const getSelectableAccounts = (
   sourceAccount: CashuAccount,
+  isSourceAccountValid: boolean,
   isCrossMintSwapDisabled: boolean,
   accounts: CashuAccount[],
   defaultAccount: Account,
@@ -192,7 +223,14 @@ const getSelectableAccounts = (
 
   return baseAccounts.map((account) => ({
     ...account,
-    badges: getBadges(account, accounts, sourceAccount, defaultAccount),
+    badges: getBadges(
+      account,
+      accounts,
+      sourceAccount,
+      defaultAccount,
+      isSourceAccountValid,
+    ),
+    selectable: account.id === sourceAccount.id ? isSourceAccountValid : true,
   }));
 };
 
@@ -200,9 +238,9 @@ const getSelectableAccounts = (
  * Lets the user select an account to receive the token and returns data about the
  * selectable accounts based on the source account and the user's accounts in the database.
  */
-export function useReceiveCashuTokenAccounts(
-  sourceAccount: ExtendedCashuAccount,
-) {
+export function useReceiveCashuTokenAccounts(token: Token) {
+  const { sourceAccount, isValid: isSourceAccountValid } =
+    useCashuTokenSourceAccount(token);
   const { data: accounts } = useAccounts({ type: 'cashu' });
   const addCashuAccount = useAddCashuAccount();
   const defaultAccount = useDefaultAccount();
@@ -210,6 +248,7 @@ export function useReceiveCashuTokenAccounts(
   const isCrossMintSwapDisabled = sourceAccount.isTestMint;
   const selectableAccounts = getSelectableAccounts(
     sourceAccount,
+    isSourceAccountValid,
     isCrossMintSwapDisabled,
     accounts,
     defaultAccount,
@@ -224,13 +263,15 @@ export function useReceiveCashuTokenAccounts(
   const [receiveAccountId, setReceiveAccountId] = useState<string>(
     defaultReceiveAccount.id,
   );
-  const receiveAccount =
+  const receiveAccount: CashuAccountWithBadges =
     selectableAccounts.find((account) => account.id === receiveAccountId) ??
     defaultReceiveAccount;
 
   const setReceiveAccount = (account: CashuAccountWithBadges) => {
-    const isSelectable = selectableAccounts.some((a) => a.id === account.id);
-    if (!isSelectable) {
+    const selectableAccount = selectableAccounts.find(
+      (a) => a.id === account.id,
+    );
+    if (!selectableAccount || !selectableAccount.selectable) {
       throw new Error('Account is not selectable');
     }
 

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -9,12 +9,10 @@ import {
 } from '~/components/page';
 import { Button } from '~/components/ui/button';
 import { useToast } from '~/hooks/use-toast';
-import type { CashuAccount } from '../accounts/account';
 import { AccountSelector } from '../accounts/account-selector';
 import { tokenToMoney } from '../shared/cashu';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import {
-  useCashuTokenSourceAccount,
   useReceiveCashuToken,
   useReceiveCashuTokenAccounts,
   useTokenWithClaimableProofs,
@@ -33,14 +31,13 @@ export default function ReceiveToken({ token }: Props) {
     cashuPubKey: // TODO: replace with user's pubkey from OS
       '038127ae202c95f4cd4ea8ba34e73618f578adf516db553a902a8589796bdc373',
   });
-  const sourceAccount = useCashuTokenSourceAccount(token);
   const {
     selectableAccounts,
     receiveAccount,
     isCrossMintSwapDisabled,
     setReceiveAccount,
     addAndSetReceiveAccount,
-  } = useReceiveCashuTokenAccounts(sourceAccount);
+  } = useReceiveCashuTokenAccounts(token);
 
   const isReceiveAccountAdded = receiveAccount.id !== '';
 
@@ -59,7 +56,7 @@ export default function ReceiveToken({ token }: Props) {
       return;
     }
 
-    let account: CashuAccount = receiveAccount;
+    let account = receiveAccount;
 
     if (!isReceiveAccountAdded) {
       try {
@@ -134,6 +131,7 @@ export default function ReceiveToken({ token }: Props) {
         {claimableToken && (
           <div className="z-10 mt-auto mb-28">
             <Button
+              disabled={receiveAccount.selectable === false}
               onClick={handleClaim}
               className="min-w-[200px]"
               loading={status === 'CLAIMING'}

--- a/app/features/settings/accounts/add-mint-form.tsx
+++ b/app/features/settings/accounts/add-mint-form.tsx
@@ -1,5 +1,3 @@
-import { CashuMint } from '@cashu/cashu-ts';
-import type { WebSocketSupport } from '@cashu/cashu-ts';
 import { Controller, useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router';
 import { Button } from '~/components/ui/button';
@@ -13,9 +11,10 @@ import {
   SelectValue,
 } from '~/components/ui/select';
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
+import { cashuMintValidator } from '~/features/shared/cashu';
+import { useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
-import { getCashuWallet } from '~/lib/cashu';
-import type { MintInfo } from '~/lib/cashu/types';
+import { getCashuProtocolUnit } from '~/lib/cashu';
 import type { Currency } from '~/lib/money';
 
 type FormValues = {
@@ -25,246 +24,35 @@ type FormValues = {
 };
 
 const currencies = [
-  { value: 'BTC', label: 'BTC', unit: 'sat' },
-  { value: 'USD', label: 'USD', unit: 'usd' },
+  { value: 'BTC', label: 'BTC' },
+  { value: 'USD', label: 'USD' },
 ];
-
-const getCurrencyUnit = (currency: Currency) => {
-  return currencies.find((x) => x.value === currency)?.unit;
-};
-
-const getUnitsSupportedByMint = async (
-  mintUrl: string,
-): Promise<string[] | null> => {
-  try {
-    const mint = new CashuMint(mintUrl);
-    const { keysets } = await mint.getKeySets();
-    const activeUnits = keysets.filter((x) => x.active).map((x) => x.unit);
-    const distinctActiveUnits = [...new Set(activeUnits)];
-    return distinctActiveUnits;
-  } catch {
-    return null;
-  }
-};
-
-type NutValidationResult =
-  | { isValid: false; message: string }
-  | { isValid: true };
-
-type NutValidation = {
-  nut: number;
-  validate: (info: MintInfo, unit: string) => NutValidationResult;
-};
-
-const validateBolt11Support = (
-  info: MintInfo,
-  operation: 'minting' | 'melting',
-  unit: string,
-): NutValidationResult => {
-  const nut = operation === 'minting' ? 4 : 5;
-  const status = info.isSupported(nut);
-
-  if (status.disabled) {
-    return {
-      isValid: false,
-      message: `${operation} is disabled on this mint`,
-    };
-  }
-
-  const hasBolt11Support = status.params.some(
-    (method) => method.method === 'bolt11' && method.unit === unit,
-  );
-
-  if (!hasBolt11Support) {
-    return {
-      isValid: false,
-      message: `Mint does not support Lightning (bolt11) ${operation} for ${unit}`,
-    };
-  }
-
-  return { isValid: true };
-};
-
-const validateGenericNut = (
-  info: MintInfo,
-  nut: 7 | 8 | 9 | 10 | 11 | 12 | 20,
-  message: string,
-): NutValidationResult => {
-  const status = info.isSupported(nut);
-  if (!status.supported) {
-    return {
-      isValid: false,
-      message,
-    };
-  }
-  return { isValid: true };
-};
-
-const nutValidations: NutValidation[] = [
-  {
-    nut: 4,
-    validate: (info, unit) => validateBolt11Support(info, 'minting', unit),
-  },
-  {
-    nut: 5,
-    validate: (info, unit) => validateBolt11Support(info, 'melting', unit),
-  },
-  {
-    nut: 7,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        7,
-        'Mint does not support token state checks (NUT-7)',
-      ),
-  },
-  {
-    nut: 8,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        8,
-        'Mint does not support overpaid lightning fees (NUT-8)',
-      ),
-  },
-  {
-    nut: 9,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        9,
-        'Mint does not support signature restoration (NUT-9)',
-      ),
-  },
-  {
-    nut: 10,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        10,
-        'Mint does not support spending conditions (NUT-10)',
-      ),
-  },
-  {
-    nut: 11,
-    validate: (info) =>
-      validateGenericNut(info, 11, 'Mint does not support P2PK (NUT-11)'),
-  },
-  {
-    nut: 12,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        12,
-        'Mint does not support DLEQ proofs (NUT-12)',
-      ),
-  },
-  {
-    nut: 17,
-    validate: (info, unit) => {
-      const status = info.isSupported(17);
-      if (!status.supported) {
-        return {
-          isValid: false,
-          message: 'Mint does not support WebSockets (NUT-17)',
-        };
-      }
-
-      const requiredCommands = ['bolt11_melt_quote'];
-      const hasBolt11WebSocketSupport = status.params?.some(
-        (support: WebSocketSupport) =>
-          support.method === 'bolt11' &&
-          support.unit === unit &&
-          requiredCommands.every((cmd) => support.commands.includes(cmd)),
-      );
-
-      if (!hasBolt11WebSocketSupport) {
-        return {
-          isValid: false,
-          message: `Mint does not support required WebSocket commands for ${unit} via bolt11`,
-        };
-      }
-
-      return { isValid: true };
-    },
-  },
-  {
-    nut: 20,
-    validate: (info) =>
-      validateGenericNut(
-        info,
-        20,
-        'Mint does not support signed mint quotes (NUT-20)',
-      ),
-  },
-];
-
-const validateMintFeatures = async (
-  mintUrl: string,
-  unit: string,
-): Promise<NutValidationResult> => {
-  try {
-    const wallet = getCashuWallet(mintUrl);
-    const info = await wallet.getMintInfo();
-
-    for (const validation of nutValidations) {
-      const result = validation.validate(info, unit);
-      if (!result.isValid) {
-        return result;
-      }
-    }
-
-    return { isValid: true };
-  } catch {
-    return {
-      isValid: false,
-      message: 'Failed to connect to mint or validate features',
-    };
-  }
-};
 
 const validateMint = async (
   value: string,
   formValues: FormValues,
 ): Promise<string | true> => {
-  if (!/^https?:\/\/.+/.test(value)) {
-    return 'Must be a valid URL starting with http(s)://';
-  }
-
-  const selectedUnit = getCurrencyUnit(formValues.currency);
-  if (!selectedUnit) {
-    return true;
-  }
-
-  const units = await getUnitsSupportedByMint(value);
-
-  if (!units) {
-    return 'Failed to connect to mint. Please make sure the URL is correct or try again.';
-  }
-
-  if (!units.includes(selectedUnit)) {
-    return 'Mint does not support this currency';
-  }
-
-  const featuresResult = await validateMintFeatures(value, selectedUnit);
-  if (!featuresResult.isValid) {
-    return featuresResult.message;
-  }
-
-  return true;
+  const unit = getCashuProtocolUnit(formValues.currency);
+  return cashuMintValidator(value, unit);
 };
 
 export function AddMintForm() {
   const addAccount = useAddCashuAccount();
   const { toast } = useToast();
+  const navigate = useNavigate();
+  const defaultCurrency = useUser((u) => u.defaultCurrency);
+
   const {
     register,
     handleSubmit,
     control,
     getValues,
     formState: { isSubmitting, errors },
-  } = useForm<FormValues>();
-  const navigate = useNavigate();
+  } = useForm<FormValues>({
+    defaultValues: {
+      currency: defaultCurrency,
+    },
+  });
 
   const onSubmit = async (data: FormValues) => {
     try {
@@ -293,7 +81,7 @@ export function AddMintForm() {
   };
 
   const currency = getValues('currency');
-  const unit = currency === 'BTC' ? 'sat' : currency;
+  const unit = getCashuProtocolUnit(currency);
 
   return (
     <form

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -4,6 +4,7 @@ import { mnemonicToSeedSync } from '@scure/bip39';
 import { useMemo } from 'react';
 import { create } from 'zustand';
 import { sumProofs } from '~/lib/cashu';
+import { buildMintValidator } from '~/lib/cashu/mint-validation';
 import { type Currency, type CurrencyUnit, Money } from '~/lib/money';
 import { computeSHA256 } from '~/lib/sha256';
 import { getSeedPhraseDerivationPath } from '../accounts/account-cryptography';
@@ -118,3 +119,8 @@ export function getTokenHash(token: Token | string): Promise<string> {
     typeof token === 'string' ? token : getEncodedToken(token);
   return computeSHA256(encodedToken);
 }
+
+export const cashuMintValidator = buildMintValidator({
+  requiredNuts: [4, 5, 7, 8, 9, 10, 11, 12, 17, 20] as const,
+  requiredWebSocketCommands: ['bolt11_melt_quote', 'proof_state'] as const,
+});

--- a/app/lib/cashu/mint-validation.ts
+++ b/app/lib/cashu/mint-validation.ts
@@ -1,0 +1,269 @@
+import { CashuMint, type WebSocketSupport } from '@cashu/cashu-ts';
+import type {
+  CashuProtocolUnit,
+  MintInfo,
+  NUT,
+  NUT17WebSocketCommand,
+} from './types';
+import { getCashuWallet } from './utils';
+
+type NutValidationResult =
+  | { isValid: false; message: string }
+  | { isValid: true };
+
+type NutValidation = {
+  nut: NUT;
+  validate: (info: MintInfo, unit: string) => NutValidationResult;
+};
+
+type BuildMintValidatorOptions = {
+  /**
+   * The NUTs that the mint must support.
+   */
+  requiredNuts: NUT[];
+  /**
+   * The NUT-17 WebSocket commands to check for.
+   * @default: ['bolt11_mint_quote', 'bolt11_melt_quote', 'proof_state']
+   */
+  requiredWebSocketCommands?: NUT17WebSocketCommand[];
+};
+
+/**
+ * Builds a validator function that checks if the mint is valid according to the given NUTs
+ * and the selected unit and returns an error message if the mint is not valid.
+ * @returns The validator function.
+ */
+export const buildMintValidator = (params: BuildMintValidatorOptions) => {
+  return async (
+    mintUrl: string,
+    selectedUnit: CashuProtocolUnit,
+  ): Promise<string | true> => {
+    if (!/^https?:\/\/.+/.test(mintUrl)) {
+      return 'Must be a valid URL starting with http(s)://';
+    }
+
+    const units = await getUnitsSupportedByMint(mintUrl);
+
+    if (!units) {
+      return 'Failed to connect to mint. Please make sure the URL is correct or try again.';
+    }
+
+    if (!units.includes(selectedUnit)) {
+      return 'Mint does not support this currency';
+    }
+
+    const featuresResult = await validateMintFeatures(
+      mintUrl,
+      selectedUnit,
+      createNutValidators(params),
+    );
+    if (!featuresResult.isValid) {
+      return featuresResult.message;
+    }
+
+    return true;
+  };
+};
+
+const createNutValidators = ({
+  requiredNuts,
+  requiredWebSocketCommands,
+}: BuildMintValidatorOptions): NutValidation[] => {
+  requiredWebSocketCommands = requiredWebSocketCommands ?? [
+    'bolt11_mint_quote',
+    'bolt11_melt_quote',
+    'proof_state',
+  ];
+
+  const validatorMap: Record<NUT, NutValidation> = {
+    4: {
+      nut: 4,
+      validate: (info, unit) => validateBolt11Support(info, 'minting', unit),
+    },
+    5: {
+      nut: 5,
+      validate: (info, unit) => validateBolt11Support(info, 'melting', unit),
+    },
+    7: {
+      nut: 7,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          7,
+          'Mint does not support token state checks (NUT-7)',
+        ),
+    },
+    8: {
+      nut: 8,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          8,
+          'Mint does not support overpaid lightning fees (NUT-8)',
+        ),
+    },
+    9: {
+      nut: 9,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          9,
+          'Mint does not support signature restoration (NUT-9)',
+        ),
+    },
+    10: {
+      nut: 10,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          10,
+          'Mint does not support spending conditions (NUT-10)',
+        ),
+    },
+    11: {
+      nut: 11,
+      validate: (info) =>
+        validateGenericNut(info, 11, 'Mint does not support P2PK (NUT-11)'),
+    },
+    12: {
+      nut: 12,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          12,
+          'Mint does not support DLEQ proofs (NUT-12)',
+        ),
+    },
+    17: {
+      nut: 17,
+      validate: (info, unit) =>
+        validateWebSocketSupport(info, unit, requiredWebSocketCommands),
+    },
+    20: {
+      nut: 20,
+      validate: (info) =>
+        validateGenericNut(
+          info,
+          20,
+          'Mint does not support signed mint quotes (NUT-20)',
+        ),
+    },
+  };
+
+  return requiredNuts.map((nut) => validatorMap[nut]);
+};
+
+const validateBolt11Support = (
+  info: MintInfo,
+  operation: 'minting' | 'melting',
+  unit: string,
+): NutValidationResult => {
+  const nut = operation === 'minting' ? 4 : 5;
+  const status = info.isSupported(nut);
+
+  if (status.disabled) {
+    return {
+      isValid: false,
+      message: `${operation} is disabled on this mint`,
+    };
+  }
+
+  const hasBolt11Support = status.params.some(
+    (method) => method.method === 'bolt11' && method.unit === unit,
+  );
+
+  if (!hasBolt11Support) {
+    return {
+      isValid: false,
+      message: `Mint does not support Lightning (bolt11) ${operation} for ${unit}`,
+    };
+  }
+
+  return { isValid: true };
+};
+
+const validateGenericNut = (
+  info: MintInfo,
+  nut: Extract<NUT, 7 | 8 | 9 | 10 | 11 | 12 | 20>,
+  message: string,
+): NutValidationResult => {
+  const status = info.isSupported(nut);
+  if (!status.supported) {
+    return {
+      isValid: false,
+      message,
+    };
+  }
+  return { isValid: true };
+};
+
+const validateWebSocketSupport = (
+  info: MintInfo,
+  unit: string,
+  requiredCommands: NUT17WebSocketCommand[],
+): NutValidationResult => {
+  const status = info.isSupported(17);
+  if (!status.supported) {
+    return {
+      isValid: false,
+      message: 'Mint does not support WebSockets (NUT-17)',
+    };
+  }
+
+  const hasBolt11WebSocketSupport = status.params?.some(
+    (support: WebSocketSupport) =>
+      support.method === 'bolt11' &&
+      support.unit === unit &&
+      requiredCommands.every((cmd) => support.commands.includes(cmd)),
+  );
+
+  if (!hasBolt11WebSocketSupport) {
+    return {
+      isValid: false,
+      message: `Mint does not support required WebSocket commands for ${unit} via bolt11`,
+    };
+  }
+
+  return { isValid: true };
+};
+
+const validateMintFeatures = async (
+  mintUrl: string,
+  unit: string,
+  nutValidators: NutValidation[],
+): Promise<NutValidationResult> => {
+  try {
+    const wallet = getCashuWallet(mintUrl);
+    const info = await wallet.getMintInfo();
+
+    for (const { validate } of nutValidators) {
+      const result = validate(info, unit);
+      if (!result.isValid) {
+        return result;
+      }
+    }
+
+    return { isValid: true };
+  } catch {
+    return {
+      isValid: false,
+      message: 'Failed to connect to mint or validate features',
+    };
+  }
+};
+
+const getUnitsSupportedByMint = async (
+  mintUrl: string,
+): Promise<string[] | null> => {
+  try {
+    const mint = new CashuMint(mintUrl);
+    const { keysets } = await mint.getKeySets();
+    const activeUnits = keysets
+      .filter((x: { active: boolean }) => x.active)
+      .map((x: { unit: string }) => x.unit);
+    const distinctActiveUnits = [...new Set(activeUnits)];
+    return distinctActiveUnits;
+  } catch {
+    return null;
+  }
+};

--- a/app/lib/cashu/types.ts
+++ b/app/lib/cashu/types.ts
@@ -145,3 +145,26 @@ export type P2PKSecret = NUT10Secret & { kind: 'P2PK' };
  * [NUT-06 info endpoint](https://github.com/cashubtc/nuts/blob/main/06.md)
  */
 export type MintInfo = Awaited<ReturnType<CashuWallet['getMintInfo']>>;
+
+/**
+ * The units that are determined by the soft-consensus of cashu mints and wallets.
+ * These units are not definite as they are not defined in NUTs directly.
+ * The following units generally mean:
+ * - `sat`: satoshis
+ * - `usd`: cents in USD
+ */
+export type CashuProtocolUnit = 'sat' | 'usd';
+
+/**
+ * A subset of the cashu [NUTs](https://github.com/cashubtc/nuts).
+ */
+export type NUT = 4 | 5 | 7 | 8 | 9 | 10 | 11 | 12 | 17 | 20;
+
+/**
+ * Web socket commands as defined by NUT-17.
+ * @see https://github.com/cashubtc/nuts/blob/main/17.md for NUT-17 WebSocket commands
+ */
+export type NUT17WebSocketCommand =
+  | 'bolt11_mint_quote'
+  | 'bolt11_melt_quote'
+  | 'proof_state';

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -7,7 +7,7 @@ import {
 import type { DistributedOmit } from 'type-fest';
 import { decodeBolt11 } from '~/lib/bolt11';
 import type { Currency, CurrencyUnit } from '../money';
-import type { MintInfo } from './types';
+import type { CashuProtocolUnit, MintInfo } from './types';
 
 const knownTestMints = [
   'https://testnut.cashu.space',
@@ -21,8 +21,15 @@ const currencyToUnit: {
   USD: 'cent',
 };
 
+const currencyToCashuProtocolUnit: {
+  [K in Currency]: CashuProtocolUnit;
+} = {
+  BTC: 'sat',
+  USD: 'usd',
+};
+
 const cashuProtocolUnitToCurrency: {
-  [key in 'sat' | 'usd']: Currency;
+  [key in CashuProtocolUnit]: Currency;
 } = {
   sat: 'BTC',
   usd: 'USD',
@@ -30,6 +37,10 @@ const cashuProtocolUnitToCurrency: {
 
 export const getCashuUnit = (currency: Currency) => {
   return currencyToUnit[currency];
+};
+
+export const getCashuProtocolUnit = (currency: Currency) => {
+  return currencyToCashuProtocolUnit[currency];
 };
 
 export const getWalletCurrency = (wallet: CashuWallet) => {

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -35,10 +35,31 @@ const cashuProtocolUnitToCurrency: {
   usd: 'USD',
 };
 
+/**
+ * Gets the unit that should be used when dealing with amounts from Cashu in the rest of the application.
+ * Cashu uses 'usd' to represent cent values which is confusing, so we map it to 'cent'.
+ *
+ * See `getCashuProtocolUnit` for getting the unit to use when interfacing with the Cashu protocol.
+ *
+ * @param currency - The currency to get the unit for
+ * @returns The unit ('sat' for BTC, 'cent' for USD)
+ */
 export const getCashuUnit = (currency: Currency) => {
   return currencyToUnit[currency];
 };
 
+/**
+ * Gets the unit that the Cashu protocol expects for a given currency.
+ * These units are not defined in Cashu, but there is a convention that
+ * the amounts are in the smallest unit of the specified currency.
+ *
+ * For example, the cashu protocol unit for USD is 'usd' and represents amounts in cents.
+ *
+ * See `getCashuUnit` for getting the unit to use when dealing with amounts from Cashu in the rest of the application.
+ *
+ * @param currency - The currency to get the protocol unit for
+ * @returns The Cashu protocol unit ('sat' for BTC, 'usd' for USD amounts in cents)
+ */
 export const getCashuProtocolUnit = (currency: Currency) => {
   return currencyToCashuProtocolUnit[currency];
 };


### PR DESCRIPTION
I moved the mint validation to our cashu lib, then created a validation builder that gets used in our app to create a mint validator for required features. This validator then gets used in the add mint form and for the source account when receiving cashu tokens.

If the source account is invalid, then we disable it in the account selector so that the user cannot add it as a mint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced advanced validation for Cashu mints, ensuring compatibility with required protocol features and currency units before use.
  - Receive account selection now visually and functionally prevents choosing accounts that do not meet protocol requirements.
  - Receive form displays clear feedback when a mint does not support necessary features.
- **Improvements**
  - Account selection and badge display dynamically reflect mint validation results.
  - Mint validation logic is now consistent and user preference-aware across the app.
- **Bug Fixes**
  - Prevented users from proceeding with unsupported or invalid mints during token receive or account addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->