### PR TITLE
Fix view transition state with programmatic navigation

### DIFF
--- a/app/lib/transitions/view-transition.tsx
+++ b/app/lib/transitions/view-transition.tsx
@@ -205,7 +205,19 @@ type NavigateWithViewTransitionOptions = NavigateOptions & ViewTransitionState;
 export function useNavigateWithViewTransition() {
   const navigate = useNavigate();
 
-  return (to: To, options: NavigateWithViewTransitionOptions) => {
-    navigate(to, { ...options, viewTransition: true });
+  return (
+    to: To,
+    {
+      transition,
+      applyTo = 'bothViews',
+      state,
+      ...options
+    }: NavigateWithViewTransitionOptions,
+  ) => {
+    navigate(to, {
+      ...options,
+      viewTransition: true,
+      state: { ...(state ?? {}), transition, applyTo },
+    });
   };
 }


### PR DESCRIPTION
## Summary
- store transition data in navigation state when using `useNavigateWithViewTransition`

## Testing
- `bun test`
- `bun run test:e2e` *(fails: Docker not running)*