### PR TITLE
Reduce redundant quote subscription churn

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -20,3 +20,22 @@ export function uint8ArrayToHex(uint8Array: Uint8Array) {
     .map((byte) => byte.toString(16).padStart(2, '0'))
     .join('');
 }
+
+export function isSubset<T>(subset: Set<T>, superset: Set<T>): boolean {
+  const isSubsetOf = (
+    subset as unknown as {
+      isSubsetOf?: (other: ReadonlySet<T>) => boolean;
+    }
+  ).isSubsetOf;
+
+  if (typeof isSubsetOf === 'function') {
+    return isSubsetOf.call(subset, superset);
+  }
+
+  for (const item of subset) {
+    if (!superset.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- simplify melt quote subscription logic and reuse existing subscriptions when possible
- simplify mint quote subscription logic and reuse existing subscriptions when possible
- simplify proof state subscription logic and reuse existing subscriptions when possible
- use Sets with subset checks to determine when resubscription is needed

Related codex task https://chatgpt.com/codex/tasks/task_b_68397fd47d1c832fa15a21d64332c9c7 