### PR TITLE
Fix realtime not resuming after soft close

### DIFF
--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,5 +1,5 @@
-import { useDebounceCallback } from 'usehooks-ts';
 import { LoaderCircle } from 'lucide-react';
+import { useDebounceCallback } from 'usehooks-ts';
 import { Input } from '~/components/ui/input';
 
 type SearchBarProps = {

--- a/app/features/agicash-db/supabase-realtime-hooks.ts
+++ b/app/features/agicash-db/supabase-realtime-hooks.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { agicashDb } from './database';
+
+/**
+ * Reconnects Supabase realtime when the page becomes visible again.
+ * This is needed on mobile where backgrounding the app often closes
+ * the websocket connection.
+ */
+export function useReconnectSupabaseRealtime() {
+  useEffect(() => {
+    const reconnect = () => {
+      if (document.visibilityState === 'visible') {
+        agicashDb.realtime.connect();
+      }
+    };
+
+    document.addEventListener('visibilitychange', reconnect);
+    window.addEventListener('focus', reconnect);
+
+    return () => {
+      document.removeEventListener('visibilitychange', reconnect);
+      window.removeEventListener('focus', reconnect);
+    };
+  }, []);
+}

--- a/app/features/wallet/wallet.tsx
+++ b/app/features/wallet/wallet.tsx
@@ -1,6 +1,7 @@
 import { type PropsWithChildren, Suspense, useEffect } from 'react';
 import { useToast } from '~/hooks/use-toast';
 import { useTrackAccounts } from '../accounts/account-hooks';
+import { useReconnectSupabaseRealtime } from '../agicash-db/supabase-realtime-hooks';
 import { supabaseSessionStore } from '../agicash-db/supabse-session-store';
 import { LoadingScreen } from '../loading/LoadingScreen';
 import { useTrackPendingCashuReceiveQuotes } from '../receive/cashu-receive-quote-hooks';
@@ -62,6 +63,8 @@ const Wallet = ({ children }: PropsWithChildren) => {
       });
     },
   });
+
+  useReconnectSupabaseRealtime();
 
   useSyncThemeWithDefaultCurrency();
 


### PR DESCRIPTION
## Summary
- create `useReconnectSupabaseRealtime` hook
- invoke realtime reconnect on mobile in `Wallet`
- run repo lint/format

## Testing
- `bun test`
- `bun run test:e2e` *(fails: Docker unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_683f7cd425a0832bab774baddcdd063d