### PR TITLE
Fix mobile routing history

### DIFF
--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -26,9 +26,13 @@ export function Page({ children, className, ...props }: PageProps) {
 
 interface ClosePageButtonProps extends ViewTransitionLinkProps {}
 
-export function ClosePageButton({ className, ...props }: ClosePageButtonProps) {
+export function ClosePageButton({
+  className,
+  replace = true,
+  ...props
+}: ClosePageButtonProps) {
   return (
-    <LinkWithViewTransition {...props}>
+    <LinkWithViewTransition replace={replace} {...props}>
       <X />
     </LinkWithViewTransition>
   );
@@ -36,9 +40,13 @@ export function ClosePageButton({ className, ...props }: ClosePageButtonProps) {
 
 export interface PageBackButtonProps extends ViewTransitionLinkProps {}
 
-export function PageBackButton({ className, ...props }: PageBackButtonProps) {
+export function PageBackButton({
+  className,
+  replace = true,
+  ...props
+}: PageBackButtonProps) {
   return (
-    <LinkWithViewTransition {...props}>
+    <LinkWithViewTransition replace={replace} {...props}>
       <ChevronLeft />
     </LinkWithViewTransition>
   );

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,5 +1,5 @@
-import { useDebounceCallback } from 'usehooks-ts';
 import { LoaderCircle } from 'lucide-react';
+import { useDebounceCallback } from 'usehooks-ts';
 import { Input } from '~/components/ui/input';
 
 type SearchBarProps = {


### PR DESCRIPTION
## Summary
- update `PageBackButton` and `ClosePageButton` to default to replacing history
- adjust import order in `SearchBar`

## Testing
- `bun run fix:all`
- `bun test`
- `bun run test:e2e` *(fails: Docker Desktop is missing)*

------
https://chatgpt.com/codex/tasks/task_b_684039a0b0d8832fb6bd2931ba9c36c9