### PR TITLE
temporarily disable sockets for debugging

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -291,6 +291,8 @@ const checkIfMintSupportsWebSocketsForMintQuotes = (
   mintInfo: MintInfo,
   currency: string,
 ): boolean => {
+  return false;
+  // biome-ignore lint/correctness/noUnreachable: temporarily disabled
   const wallet = getCashuWallet(mintUrl);
   const walletCurrency = getWalletCurrency(wallet);
   const nut17Info = mintInfo.isSupported(17);


### PR DESCRIPTION
Here websockets are disabled for mint quote status updates. I did this to eliminate one variable.

To test, set your username and a default *test* mint, then fetch an invoice using lightning address from `deployment.url`/.well-known/lnurlp/`username`

Using our lnurl server allows us to test when the wallet is open or closed. And test mint so mint quotes get paid automatically

There are two main issues I've observed:
### Missing receive quotes
When you close your phone and leave it for at least 5-10 seconds, generate an invoice, then open your phone the app will not pick up the receive quote that was created.

### Concurrency errors
When multiple mint quotes are unresolved and get processed together there ends up being concurrency errors. Most of the time one succeeds, then the second one fails and then retries and is able to resolve itself. Seems about 30% of the time the concurrency error persists and you need to refresh the app (sometimes multiple times to get back a good state)


Recommended experiments:
- start fresh by opening the app and force reloading. While the app is open generate some invoices. It should all work as expected
- close the app, wait, generate an invoice, open the app. Observe that there is no log saying "Processing mint quote". This means we did not get the INSERT event
- start with the app closed, generate 2 invoices, open the app and observe the concurrency errors. 

Sometimes these things resolve themselves, but the more receive quotes that I generate within the same session (no reload) the worse it gets.