### PR TITLE
make number input accessible and disable on other input

### DIFF
--- a/app/components/money-display.tsx
+++ b/app/components/money-display.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import type { Currency, CurrencyUnit } from '~/lib/money';
 import { Money } from '~/lib/money';
 import { cn } from '~/lib/utils';
+import { type NumpadButton, isValidNumpadButton } from './numpad';
 
 interface MoneyInputDisplayProps<C extends Currency = Currency> {
   /** Raw input value from user (e.g., "1", "1.", "1.0") */
@@ -8,6 +10,11 @@ interface MoneyInputDisplayProps<C extends Currency = Currency> {
   currency: C;
   unit: CurrencyUnit<C>;
   locale?: string;
+  onNumpadInput?: (button: NumpadButton) => void;
+  /** ID for the input element for accessibility connections */
+  inputId?: string;
+  /** ID for ARIA describedby connections */
+  ariaDescribedBy?: string;
 }
 
 export function MoneyInputDisplay<C extends Currency>({
@@ -15,6 +22,9 @@ export function MoneyInputDisplay<C extends Currency>({
   currency,
   unit,
   locale,
+  onNumpadInput,
+  inputId,
+  ariaDescribedBy,
 }: MoneyInputDisplayProps<C>) {
   const money = new Money({ amount: inputValue, currency, unit });
   const {
@@ -48,10 +58,57 @@ export function MoneyInputDisplay<C extends Currency>({
     <span className="text-[3.45rem] text-currencySymbol">{currencySymbol}</span>
   );
 
+  // Global keyboard listener for numpad input
+  useEffect(() => {
+    if (!onNumpadInput) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Don't handle keyboard input if another input element is focused
+      const activeElement = document.activeElement;
+      const isInputFocused =
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.tagName === 'SELECT' ||
+          activeElement.getAttribute('contenteditable') === 'true');
+
+      if (isInputFocused) {
+        return;
+      }
+
+      const key = event.key;
+      if (isValidNumpadButton(key)) {
+        onNumpadInput(key);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onNumpadInput]);
+
   return (
-    <span className="font-bold">
+    <div className="relative font-bold">
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className="pt-2 font-numeric text-6xl">
+
+      {/* Semantic input for accessibility - keyboard input handled by useEffect */}
+      <input
+        type="text"
+        inputMode="decimal"
+        id={inputId}
+        value={inputValue}
+        className="absolute inset-0 h-full w-full caret-transparent opacity-0"
+        aria-label={`Amount input in ${currency}`}
+        aria-describedby={ariaDescribedBy}
+        readOnly={true} // Prevent direct input, handled by keyboard listener
+        tabIndex={0} // Keep focusable for accessibility
+        autoComplete="off"
+      />
+
+      {/* Visual display */}
+      <span
+        className="pointer-events-none pt-2 font-numeric text-6xl"
+        aria-hidden="true"
+      >
         {integer}
         {(inputDecimals || needsPaddedZeros) && (
           <>
@@ -63,8 +120,9 @@ export function MoneyInputDisplay<C extends Currency>({
           </>
         )}
       </span>
+
       {currencySymbolPosition === 'suffix' && symbol}
-    </span>
+    </div>
   );
 }
 

--- a/app/components/numpad.tsx
+++ b/app/components/numpad.tsx
@@ -1,5 +1,4 @@
 import { Delete } from 'lucide-react';
-import { useEffect } from 'react';
 import { getLocaleDecimalSeparator } from '~/lib/locale';
 import { Button } from './ui/button';
 
@@ -20,7 +19,7 @@ const buttons = [
 
 export type NumpadButton = (typeof buttons)[number];
 
-const isValidButton = (button: string): button is NumpadButton => {
+export const isValidNumpadButton = (button: string): button is NumpadButton => {
   return (buttons as readonly string[]).includes(button);
 };
 
@@ -43,26 +42,26 @@ type NumpadProps = {
   showDecimal: boolean;
   /** Callback when a button is clicked */
   onButtonClick: (button: NumpadButton) => void;
+  /** ID of the input element this numpad controls */
+  ariaControls?: string;
+  /** ID for this numpad group */
+  id?: string;
 };
 
-/** A component that displays a numpad and handles keyboard input */
-export const Numpad = ({ showDecimal, onButtonClick }: NumpadProps) => {
-  useEffect(() => {
-    const handler = (event: KeyboardEvent) => {
-      const key = event.key;
-      if (isValidButton(key)) {
-        onButtonClick(key);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [onButtonClick]);
-
+/** A component that displays a numpad */
+export const Numpad = ({
+  showDecimal,
+  onButtonClick,
+  ariaControls,
+  id,
+}: NumpadProps) => {
   return (
-    <div
-      aria-label="Number pad"
-      className="flex w-full flex-col items-center gap-4 sm:hidden"
+    <fieldset
+      id={id}
+      aria-controls={ariaControls}
+      className="flex w-full flex-col items-center gap-4 border-0 p-0 sm:hidden"
     >
+      <legend className="sr-only">Number pad</legend>
       <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:w-auto">
         {buttons.map((button) => {
           if (button === 'Backspace') {
@@ -93,6 +92,6 @@ export const Numpad = ({ showDecimal, onButtonClick }: NumpadProps) => {
           );
         })}
       </div>
-    </div>
+    </fieldset>
   );
 };

--- a/app/features/receive/receive-input.tsx
+++ b/app/features/receive/receive-input.tsx
@@ -142,7 +142,17 @@ export default function ReceiveInput() {
               inputValue={rawInputValue}
               currency={inputValue.currency}
               unit={getDefaultUnit(inputValue.currency)}
+              onNumpadInput={(button) =>
+                handleNumberInput(button, startShakeAnimation)
+              }
+              inputId="receive-amount-input"
+              ariaDescribedBy="numpad-instructions"
             />
+          </div>
+
+          {/* Hidden instructions for screen readers */}
+          <div id="numpad-instructions" className="sr-only">
+            Use the number pad below or type directly to enter an amount
           </div>
 
           {!exchangeRateError && (
@@ -200,6 +210,8 @@ export default function ReceiveInput() {
             onButtonClick={(value) => {
               handleNumberInput(value, startShakeAnimation);
             }}
+            ariaControls="receive-amount-input"
+            id="receive-input-numpad"
           />
         </div>
       </PageContent>

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -206,7 +206,17 @@ export function SendInput() {
               inputValue={rawInputValue}
               currency={inputValue.currency}
               unit={getDefaultUnit(inputValue.currency)}
+              onNumpadInput={(button) =>
+                handleNumberInput(button, startShakeAnimation)
+              }
+              inputId="send-amount-input"
+              ariaDescribedBy="numpad-instructions"
             />
+          </div>
+
+          {/* Hidden instructions for screen readers */}
+          <div id="numpad-instructions" className="sr-only">
+            Use the number pad below or type directly to enter an amount
           </div>
 
           {!exchangeRateError && (
@@ -276,6 +286,8 @@ export function SendInput() {
             onButtonClick={(value) => {
               handleNumberInput(value, startShakeAnimation);
             }}
+            ariaControls="send-amount-input"
+            id="send-input-numpad"
           />
         </div>
       </PageContent>


### PR DESCRIPTION
- moved the key press handler from the numpad to the money input because it seemed like that input should own the keypresses 
       - I made this event handler be disabled if some other input (like lightning address / contact) is focused so that we don't type into the number input too
- I added an html input that stays invisible for screen readers
- made some other accessibility changes