### PR TITLE
disable keyboard listener if an input is focused

### DIFF
--- a/app/components/numpad.tsx
+++ b/app/components/numpad.tsx
@@ -49,6 +49,19 @@ type NumpadProps = {
 export const Numpad = ({ showDecimal, onButtonClick }: NumpadProps) => {
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
+      // Don't handle keyboard event if user is focused on an input element
+      const activeElement = document.activeElement;
+      const isInputFocused =
+        activeElement &&
+        (activeElement.tagName === 'INPUT' ||
+          activeElement.tagName === 'TEXTAREA' ||
+          activeElement.tagName === 'SELECT' ||
+          activeElement.getAttribute('contenteditable') === 'true');
+
+      if (isInputFocused) {
+        return;
+      }
+
       const key = event.key;
       if (isValidButton(key)) {
         onButtonClick(key);


### PR DESCRIPTION
This solves the bug described as "If you type in a lightning address without putting in an amount, then try to type an amount, it won’t let you"

This is a PR with a more limited scope than #466 