### PR TITLE
Clear tanstack query and cashu seed store caches on logout

### DIFF
--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -60,12 +60,13 @@ type CashuSeedStore = {
   setSeedPromise: (
     promise: ReturnType<ReturnType<typeof useCashuCryptography>['getSeed']>,
   ) => void;
+  clear: () => void;
 };
 
-// TODO: needs to be cleared when the user logs out
-const cashuSeedStore = create<CashuSeedStore>((set) => ({
+export const cashuSeedStore = create<CashuSeedStore>((set) => ({
   seedPromise: null,
   setSeedPromise: (promise) => set({ seedPromise: promise }),
+  clear: () => set({ seedPromise: null }),
 }));
 
 /**

--- a/app/features/transactions/transaction-hooks.ts
+++ b/app/features/transactions/transaction-hooks.ts
@@ -15,7 +15,7 @@ import { useLatest } from '~/lib/use-latest';
 import { useGetLatestCashuAccount } from '../accounts/account-hooks';
 import { useCashuSendSwapRepository } from '../send/cashu-send-swap-repository';
 import { useCashuSendSwapService } from '../send/cashu-send-swap-service';
-import { useUserRef } from '../user/user-hooks';
+import { useUser } from '../user/user-hooks';
 import type { Transaction } from './transaction';
 import {
   type Cursor,
@@ -63,15 +63,15 @@ export function useSuspenseTransaction(id: string) {
 const PAGE_SIZE = 25;
 
 export function useTransactions() {
-  const userRef = useUserRef();
+  const userId = useUser((user) => user.id);
   const transactionRepository = useTransactionRepository();
 
   const result = useInfiniteQuery({
-    queryKey: [allTransactionsQueryKey, userRef.current.id],
+    queryKey: [allTransactionsQueryKey],
     initialPageParam: null,
     queryFn: async ({ pageParam }: { pageParam: Cursor | null }) => {
       const result = await transactionRepository.list({
-        userId: userRef.current.id,
+        userId,
         cursor: pageParam,
         pageSize: PAGE_SIZE,
       });

--- a/app/features/user/auth.ts
+++ b/app/features/user/auth.ts
@@ -1,10 +1,12 @@
 import { type UserResponse, useOpenSecret } from '@opensecret/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { jwtDecode } from 'jwt-decode';
 import { useCallback, useRef } from 'react';
 import { useLongTimeout } from '~/hooks/use-long-timeout';
 import { generateRandomPassword } from '~/lib/password-generator';
 import { computeSHA256 } from '~/lib/sha256';
 import { supabaseSessionStore } from '../agicash-db/supabse-session-store';
+import { cashuSeedStore } from '../shared/cashu';
 import { guestAccountStorage } from './guest-account-storage';
 
 export type AuthUser = UserResponse['user'];
@@ -119,6 +121,7 @@ type AuthActions = {
  */
 export const useAuthActions = (): AuthActions => {
   const openSecret = useOpenSecret();
+  const queryClient = useQueryClient();
 
   // We are doing this to keep references for these actions constant. Open secret implementation currently creates a new
   // reference for each render. See https://github.com/OpenSecretCloud/OpenSecret-SDK/blob/master/src/lib/main.tsx#L350
@@ -175,7 +178,9 @@ export const useAuthActions = (): AuthActions => {
   const signOut = useCallback(async () => {
     await signOutRef.current();
     supabaseSessionStore.getState().clear();
-  }, []);
+    cashuSeedStore.getState().clear();
+    queryClient.clear();
+  }, [queryClient]);
 
   return {
     signUp: signUpRef.current,

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -14,7 +14,7 @@ import { guestAccountStorage } from './guest-account-storage';
 import type { User } from './user';
 import { type UpdateUser, useUserRepository } from './user-repository';
 
-const usersQueryKey = 'users';
+const userQueryKey = 'user';
 
 /**
  * This hook returns the logged in user data.
@@ -33,7 +33,7 @@ export const useUser = <TData = User>(
   const userRepository = useUserRepository();
 
   const response = useSuspenseQuery({
-    queryKey: [usersQueryKey, authUser.id],
+    queryKey: [userQueryKey],
     queryFn: () => userRepository.get(authUser.id),
     select,
   });
@@ -116,7 +116,7 @@ export const useUpsertUser = () => {
       id: 'user-upsert',
     },
     onSuccess: (user) => {
-      queryClient.setQueryData<User>([usersQueryKey, user.id], user);
+      queryClient.setQueryData<User>([userQueryKey], user);
     },
     throwOnError: true,
   });
@@ -209,15 +209,14 @@ export const useVerifyEmail = (): ((code: string) => Promise<void>) => {
 
 const useUpdateUser = () => {
   const queryClient = useQueryClient();
-  const userRef = useUserRef();
+  const userId = useUser((user) => user.id);
   const userRepository = useUserRepository();
 
   return useMutation({
-    mutationFn: (updates: UpdateUser) =>
-      userRepository.update(userRef.current.id, updates),
+    mutationFn: (updates: UpdateUser) => userRepository.update(userId, updates),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [usersQueryKey, userRef.current.id],
+        queryKey: [userQueryKey],
       });
     },
   });

--- a/app/features/wallet/task-processing.ts
+++ b/app/features/wallet/task-processing.ts
@@ -30,7 +30,7 @@ export const useTakeTaskProcessingLead = () => {
 
   const { data: takeLeadResult, error } = useQuery({
     enabled: !!clientId,
-    queryKey: ['take-lead', userId, clientId],
+    queryKey: ['take-lead', clientId],
     queryFn: () => {
       return taskProcessingLockRepository.takeLead(userId, clientId);
     },


### PR DESCRIPTION
Closes https://github.com/MakePrisms/boardwalkcash/issues/431

In this PR, besides clearing the caches, I also removed unnecessary user id from the query keys. Id is unnecessary because only one user can use the app at the time. If you logout and login with another account that is fine because logout now clears the cache.