### PR TITLE
fix: perform mint melt when same mint and different currency

### DIFF
--- a/app/features/receive/cashu-token-swap-service.ts
+++ b/app/features/receive/cashu-token-swap-service.ts
@@ -47,6 +47,11 @@ export class CashuTokenSwapService {
     }
 
     const amount = tokenToMoney(token);
+
+    if (amount.currency !== account.currency) {
+      throw new Error('Cannot swap a token to a different currency.');
+    }
+
     const cashuUnit = getCashuUnit(amount.currency);
     const seed = await this.cryptography.getSeed();
 

--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -346,9 +346,11 @@ export function useReceiveCashuToken({
     account: CashuAccount;
   }) => {
     try {
-      const isSourceMint = areMintUrlsEqual(account.mintUrl, token.mint);
+      const isSameMintAndCurrency =
+        account.currency === tokenToMoney(token).currency &&
+        areMintUrlsEqual(account.mintUrl, token.mint);
 
-      if (isSourceMint) {
+      if (isSameMintAndCurrency) {
         await createCashuTokenSwap({ token, accountId: account.id });
       } else {
         await meltTokenToCashuAccount({ token, account });


### PR DESCRIPTION
Fixes bugs with cross account claims within the same mint. We were trying to do a swap if the mint urls matched, but we were not checking the currencies