### PR TITLE
add share button to share-cashu-token

### DIFF
--- a/app/features/send/share-cashu-token.tsx
+++ b/app/features/send/share-cashu-token.tsx
@@ -1,5 +1,5 @@
 import { type Token, getEncodedToken } from '@cashu/cashu-ts';
-import { Banknote, Link } from 'lucide-react';
+import { Banknote, Link, Share } from 'lucide-react';
 import { useCopyToClipboard } from 'usehooks-ts';
 import {
   ClosePageButton,
@@ -17,6 +17,7 @@ import {
 } from '~/components/ui/carousel';
 import useLocationData from '~/hooks/use-location';
 import { useToast } from '~/hooks/use-toast';
+import { canShare, shareContent } from '~/lib/share';
 import { tokenToMoney } from '../shared/cashu';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 
@@ -40,6 +41,18 @@ export function ShareCashuToken({ token }: Props) {
       <PageHeader>
         <ClosePageButton to="/" transition="slideDown" applyTo="oldView" />
         <PageHeaderTitle>Send</PageHeaderTitle>
+        {canShare() && (
+          <button
+            type="button"
+            onClick={() => {
+              shareContent({
+                url: shareableLink,
+              });
+            }}
+          >
+            <Share />
+          </button>
+        )}
       </PageHeader>
       <PageContent className="animate-in items-center gap-0 overflow-x-hidden overflow-y-hidden duration-300">
         <MoneyWithConvertedAmount money={amount} />


### PR DESCRIPTION
Adds a share button that shows the devices native share interface so that you can easily text or airdrop shareable links

<img width="650" alt="image" src="https://github.com/user-attachments/assets/3b06effb-2aaf-493c-8563-277eded30709" />
