### PR TITLE
fix: make contact lists and privacy and terms pages scrollable

### DIFF
--- a/app/features/accounts/account-selector.tsx
+++ b/app/features/accounts/account-selector.tsx
@@ -8,6 +8,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '~/components/ui/drawer';
+import { ScrollArea } from '~/components/ui/scroll-area';
 import { cn } from '~/lib/utils';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import { type Account, getAccountBalance } from './account';
@@ -84,32 +85,34 @@ export function AccountSelector<T extends Account>({
             ))}
         </button>
       </DrawerTrigger>
-      <DrawerContent className="font-primary">
-        <div className="mx-auto w-full max-w-sm">
+      <DrawerContent className="h-[90dvh] font-primary">
+        <div className="mx-auto flex h-full w-full max-w-sm flex-col overflow-hidden">
           <DrawerHeader>
             <DrawerTitle>Select account</DrawerTitle>
           </DrawerHeader>
-          <div className="flex flex-col gap-2 p-2">
-            {[
-              selectedAccount,
-              ...accounts.filter((a) => a.id !== selectedAccount.id),
-            ].map((account) => (
-              <button
-                disabled={account.selectable === false}
-                type="button"
-                key={account.id}
-                onClick={() => handleAccountSelect(account)}
-                className={cn(
-                  'rounded-lg hover:bg-muted',
-                  selectedAccount.id === account.id && 'bg-muted',
-                  account.selectable === false &&
-                    'pointer-events-none cursor-not-allowed opacity-50',
-                )}
-              >
-                <AccountItem account={account} />
-              </button>
-            ))}
-          </div>
+          <ScrollArea hideScrollbar>
+            <div className="flex flex-col gap-2 p-2">
+              {[
+                selectedAccount,
+                ...accounts.filter((a) => a.id !== selectedAccount.id),
+              ].map((account) => (
+                <button
+                  disabled={account.selectable === false}
+                  type="button"
+                  key={account.id}
+                  onClick={() => handleAccountSelect(account)}
+                  className={cn(
+                    'rounded-lg hover:bg-muted',
+                    selectedAccount.id === account.id && 'bg-muted',
+                    account.selectable === false &&
+                      'pointer-events-none cursor-not-allowed opacity-50',
+                  )}
+                >
+                  <AccountItem account={account} />
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
         </div>
       </DrawerContent>
     </Drawer>

--- a/app/features/contacts/add-contact-drawer.tsx
+++ b/app/features/contacts/add-contact-drawer.tsx
@@ -8,6 +8,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '~/components/ui/drawer';
+import { ScrollArea } from '~/components/ui/scroll-area';
 import { useToast } from '~/hooks/use-toast';
 import { SearchBar } from '../../components/search-bar';
 import { getErrorMessage } from '../shared/error';
@@ -83,29 +84,34 @@ function SearchResults({
   }
 
   return (
-    <div className="relative h-full py-6">
-      <div className="flex flex-col gap-6 pb-16">
-        {results.map((searchResult) => (
-          <button
-            key={searchResult.username}
-            className="flex w-full items-center gap-3 rounded-lg"
-            onClick={() =>
-              setSelectedContact(
-                selectedContact?.username === searchResult.username
-                  ? null
-                  : searchResult,
-              )
-            }
-            type="button"
-          >
-            <ContactAvatar username={searchResult.username} size="sm" />
-            <span className="font-medium">{searchResult.username}</span>
-            {selectedContact?.username === searchResult.username && (
-              <Check className="ml-auto h-4 w-4 text-foreground" />
-            )}
-          </button>
-        ))}
-      </div>
+    <>
+      <ScrollArea
+        className="relative flex h-full flex-1 flex-col py-6"
+        hideScrollbar
+      >
+        <div className="flex flex-col gap-6 pb-16">
+          {results.map((searchResult) => (
+            <button
+              key={searchResult.username}
+              className="flex w-full items-center gap-3 rounded-lg"
+              onClick={() =>
+                setSelectedContact(
+                  selectedContact?.username === searchResult.username
+                    ? null
+                    : searchResult,
+                )
+              }
+              type="button"
+            >
+              <ContactAvatar username={searchResult.username} size="sm" />
+              <span className="font-medium">{searchResult.username}</span>
+              {selectedContact?.username === searchResult.username && (
+                <Check className="ml-auto h-4 w-4 text-foreground" />
+              )}
+            </button>
+          ))}
+        </div>
+      </ScrollArea>
       {selectedContact && (
         <Button
           onClick={() => onAddContact(selectedContact.username)}
@@ -114,6 +120,6 @@ function SearchResults({
           Add
         </Button>
       )}
-    </div>
+    </>
   );
 }

--- a/app/features/contacts/contacts-list.tsx
+++ b/app/features/contacts/contacts-list.tsx
@@ -1,5 +1,6 @@
 import { LoaderCircle } from 'lucide-react';
 import { useState } from 'react';
+import { ScrollArea } from '~/components/ui/scroll-area';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import type { Contact } from './contact';
 import { ContactAvatar } from './contact-avatar';
@@ -22,49 +23,51 @@ export function ContactsList({ contacts, onSelect }: ContactsListProps) {
   };
 
   return (
-    <div className="flex flex-col gap-6 py-6">
-      {hasContacts ? (
-        contacts.map((contact) =>
-          onSelect ? (
-            <button
-              key={contact.id}
-              className="flex w-full items-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
-              onClick={() => handleClick(contact)}
-              type="button"
-              disabled={state.status === 'selecting'}
-            >
-              <div className="flex w-full cursor-pointer items-center gap-3">
-                {state.status === 'selecting' &&
-                state.selected.id === contact.id ? (
-                  <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
-                ) : (
-                  <ContactAvatar username={contact.username} size="sm" />
-                )}
-                <span className="font-medium">{contact.username}</span>
-              </div>
-            </button>
-          ) : (
-            <div
-              key={contact.id}
-              className=" flex items-center rounded-lg transition-colors"
-            >
-              <LinkWithViewTransition
-                to={`/settings/contacts/${contact.id}`}
-                transition="slideLeft"
-                applyTo="oldView"
-                className="flex w-full items-center gap-3"
+    <ScrollArea className="flex h-full flex-1 flex-col" hideScrollbar>
+      <div className="flex flex-col gap-6 py-6">
+        {hasContacts ? (
+          contacts.map((contact) =>
+            onSelect ? (
+              <button
+                key={contact.id}
+                className="flex w-full items-center rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
+                onClick={() => handleClick(contact)}
+                type="button"
+                disabled={state.status === 'selecting'}
               >
-                <ContactAvatar username={contact.username} size="sm" />
-                <span className="font-medium">{contact.username}</span>
-              </LinkWithViewTransition>{' '}
-            </div>
-          ),
-        )
-      ) : (
-        <div className="text-center text-muted-foreground">
-          No contacts found
-        </div>
-      )}
-    </div>
+                <div className="flex w-full cursor-pointer items-center gap-3">
+                  {state.status === 'selecting' &&
+                  state.selected.id === contact.id ? (
+                    <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
+                  ) : (
+                    <ContactAvatar username={contact.username} size="sm" />
+                  )}
+                  <span className="font-medium">{contact.username}</span>
+                </div>
+              </button>
+            ) : (
+              <div
+                key={contact.id}
+                className=" flex items-center rounded-lg transition-colors"
+              >
+                <LinkWithViewTransition
+                  to={`/settings/contacts/${contact.id}`}
+                  transition="slideLeft"
+                  applyTo="oldView"
+                  className="flex w-full items-center gap-3"
+                >
+                  <ContactAvatar username={contact.username} size="sm" />
+                  <span className="font-medium">{contact.username}</span>
+                </LinkWithViewTransition>{' '}
+              </div>
+            ),
+          )
+        ) : (
+          <div className="text-center text-muted-foreground">
+            No contacts found
+          </div>
+        )}
+      </div>
+    </ScrollArea>
   );
 }

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -331,7 +331,7 @@ function SelectContactOrLud16Drawer({
           <DrawerTitle>Send to User</DrawerTitle>
           <AddContactDrawer />
         </DrawerHeader>
-        <div className="mx-auto flex w-full max-w-sm flex-col gap-3 px-4 sm:px-0">
+        <div className="mx-auto flex h-full w-full max-w-sm flex-col gap-3 px-4 sm:px-0">
           <SearchBar
             placeholder="Username or Lightning Address"
             onSearch={setInput}

--- a/app/features/settings/contacts.tsx
+++ b/app/features/settings/contacts.tsx
@@ -26,7 +26,7 @@ export default function Contacts() {
       >
         <AddContactDrawer />
       </SettingsViewHeader>
-      <PageContent>
+      <PageContent className="overflow-hidden">
         <SearchBar onSearch={setSearchQuery} placeholder="Search contacts..." />
 
         <ContactsList contacts={contacts} />

--- a/app/routes/_public.privacy.tsx
+++ b/app/routes/_public.privacy.tsx
@@ -1,10 +1,11 @@
 import logo from '~/assets/full_logo.png';
 import privacyContent from '~/assets/privacy-policy.md?raw';
 import { Markdown } from '~/components/markdown';
+import { ScrollArea } from '~/components/ui/scroll-area';
 
 export default function PrivacyPage() {
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <ScrollArea className="mx-auto h-dvh max-w-4xl px-4 py-8" hideScrollbar>
       <header className="mb-8 flex items-center justify-start">
         <a href="/">
           <img src={logo} alt="Agicash Logo" className="mr-4 h-16" />
@@ -13,6 +14,6 @@ export default function PrivacyPage() {
       <main>
         <Markdown content={privacyContent} />
       </main>
-    </div>
+    </ScrollArea>
   );
 }

--- a/app/routes/_public.terms.tsx
+++ b/app/routes/_public.terms.tsx
@@ -1,10 +1,11 @@
 import logo from '~/assets/full_logo.png';
 import termsContent from '~/assets/terms-of-use.md?raw';
 import { Markdown } from '~/components/markdown';
+import { ScrollArea } from '~/components/ui/scroll-area';
 
 export default function TermsPage() {
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <ScrollArea className=" mx-auto h-dvh max-w-4xl px-4 py-8" hideScrollbar>
       <header className="mb-8 flex items-center justify-start">
         <a href="/">
           <img src={logo} alt="Agicash Logo" className="mr-4 h-16" />
@@ -14,6 +15,6 @@ export default function TermsPage() {
       <main>
         <Markdown content={termsContent} />
       </main>
-    </div>
+    </ScrollArea>
   );
 }


### PR DESCRIPTION
closes #485 and fixes scrolling in other places.
 This PR add the ScrollArea to places that should be scrollable and then makes sure that the containers the scrollable areas are in have overflow-hidden and are set to sufficient height so that the inner container becomes scrollable