### PR TITLE
Signup as guest and claim bug fix

### DIFF
--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -55,7 +55,12 @@ export function useCashuTokenSourceAccountQuery(
   const tokenCurrency = tokenToMoney(token).currency;
 
   return useSuspenseQuery({
-    queryKey: ['token-source-account', token.mint, tokenCurrency],
+    queryKey: [
+      'token-source-account',
+      token.mint,
+      tokenCurrency,
+      existingAccount?.id,
+    ],
     queryFn: async (): Promise<{
       isValid: boolean;
       sourceAccount: ExtendedCashuAccount;

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -190,6 +190,16 @@ export function TransactionList() {
     status,
   } = useTransactions();
 
+  const allTransactions =
+    data?.pages.flatMap((page) => page.transactions) ?? [];
+
+  const {
+    pendingTransactions,
+    todayTransactions,
+    thisWeekTransactions,
+    olderTransactions,
+  } = usePartitionTransactions(allTransactions);
+
   if (status === 'error') {
     return (
       <div className="flex h-full flex-col items-center justify-center p-8">
@@ -211,8 +221,6 @@ export function TransactionList() {
     );
   }
 
-  const allTransactions = data.pages.flatMap((page) => page.transactions);
-
   if (!allTransactions.length) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 p-4 text-center">
@@ -220,13 +228,6 @@ export function TransactionList() {
       </div>
     );
   }
-
-  const {
-    pendingTransactions,
-    todayTransactions,
-    thisWeekTransactions,
-    olderTransactions,
-  } = usePartitionTransactions(allTransactions);
 
   return (
     <ScrollArea className="h-full min-h-0 " hideScrollbar>

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -60,7 +60,8 @@
         "useIsNan": "error",
         "useValidForDirection": "error",
         "useYield": "error",
-        "noUnusedImports": "error"
+        "noUnusedImports": "error",
+        "useHookAtTopLevel": "error"
       },
       "suspicious": {
         "noAssignInExpressions": "error",


### PR DESCRIPTION
This PR has two commits:
1. enables the useHookAtTopLevel in biome config which checks that hooks are not rendered inside conditionals (that should never be done as hooks rely on consistent ordering across renders to function normally) and fixes one offending case in transaction history list where we had a hook used after early returns

2. Fixes issue with signup as guest and claim token flow for case where the token being claimed belongs to the default account. The issue was that in this flow we first show public page where `useCashuTokenSourceAccountQuery` hook is used but without existing account and the result gets cached. Then when guest account is created and default accounts added, the hook gets executed again but this time with existing account, but since the result was cached with the key that doesn't depend on existing account we would get the previous result from the cache instead of running the query function again to get the existing account.