### PR TITLE
Fix Supabase realtime reconnection issues

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -5,7 +5,7 @@ import type { Currency, CurrencyUnit } from '~/lib/money';
 import type { AccountType } from '../accounts/account';
 import type { CashuSendSwap } from '../send/cashu-send-swap';
 import type { Transaction } from '../transactions/transaction';
-import { supabaseSessionStore } from './supabse-session-store';
+import { supabaseSessionStore } from './supabase-session-store';
 
 const isLocalServer = (hostname: string) => {
   return (
@@ -218,12 +218,6 @@ export const agicashDb = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   accessToken: () => supabaseSessionStore.getState().getJwtWithRefresh(),
   db: {
     schema: 'wallet',
-  },
-  realtime: {
-    logger: (kind: unknown, msg: unknown, data: unknown) => {
-      console.log(`${kind}: ${msg}`, data);
-    },
-    worker: true,
   },
 });
 

--- a/app/features/agicash-db/supabase-session-store.ts
+++ b/app/features/agicash-db/supabase-session-store.ts
@@ -1,6 +1,5 @@
 import { jwtDecode } from 'jwt-decode';
 import { create } from 'zustand';
-import { agicashDb } from './database';
 
 type SupabaseSession = {
   jwt: string | null;
@@ -39,9 +38,6 @@ export const supabaseSessionStore = create<SupabaseSession>((set, get) => ({
     const jwt = await getJwt();
 
     set({ jwt });
-    // We need to set this manually on refresh becuuse otherwise the realtime connection will use the old jwt and connection will be closed
-    // I don't know why Supabase donesn't do that internally when accessToken method passed to the client returns a new jwt
-    agicashDb.realtime.setAuth(jwt);
 
     return jwt;
   },

--- a/app/features/user/auth.ts
+++ b/app/features/user/auth.ts
@@ -5,7 +5,7 @@ import { useCallback, useRef } from 'react';
 import { useLongTimeout } from '~/hooks/use-long-timeout';
 import { generateRandomPassword } from '~/lib/password-generator';
 import { computeSHA256 } from '~/lib/sha256';
-import { supabaseSessionStore } from '../agicash-db/supabse-session-store';
+import { supabaseSessionStore } from '../agicash-db/supabase-session-store';
 import { cashuSeedStore } from '../shared/cashu';
 import { guestAccountStorage } from './guest-account-storage';
 

--- a/app/features/wallet/wallet.tsx
+++ b/app/features/wallet/wallet.tsx
@@ -2,7 +2,7 @@ import { useOpenSecret } from '@opensecret/react';
 import { type PropsWithChildren, Suspense, useEffect } from 'react';
 import { useToast } from '~/hooks/use-toast';
 import { useTrackAccounts } from '../accounts/account-hooks';
-import { supabaseSessionStore } from '../agicash-db/supabse-session-store';
+import { supabaseSessionStore } from '../agicash-db/supabase-session-store';
 import { LoadingScreen } from '../loading/LoadingScreen';
 import { useTrackPendingCashuReceiveQuotes } from '../receive/cashu-receive-quote-hooks';
 import { useTrackPendingCashuTokenSwaps } from '../receive/cashu-token-swap-hooks';

--- a/app/lib/supabase/supabase-realtime.ts
+++ b/app/lib/supabase/supabase-realtime.ts
@@ -1,149 +1,271 @@
 import {
+  REALTIME_LISTEN_TYPES,
   REALTIME_SUBSCRIBE_STATES,
   type RealtimeChannel,
 } from '@supabase/supabase-js';
-import { useEffect, useRef, useState } from 'react';
+import { agicashDb } from 'app/features/agicash-db/database';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLatest } from '../use-latest';
-
-type SubscriptionState =
-  | {
-      status: 'subscribing' | 'subscribed' | 'closed';
-    }
-  | {
-      status: 'error';
-      error: Error;
-    };
-
-const ERROR_DELAY_MS = 20000;
 
 /**
  * Subscribes to a Supabase Realtime channel when the component mounts and unsubscribes when the component unmounts.
+ * Manages channel reconnection in case of errors and timeouts.
  * @param channelFactory - A function that returns the Supabase Realtime channel to subscribe to.
  * Note that the factory is called only when the component mounts so any changes to the function after the component mounts will not be reflected in the subscription.
  * If you have a callback for the channel that needs to be updated, you can use the `useLatest` hook to create a stable reference to the callback.
  * @returns The status of the subscription.
  */
+
+interface Options {
+  /**
+   *  A function that returns the Supabase Realtime channel to subscribe to.
+   */
+  channelFactory: () => RealtimeChannel;
+  /**
+   * A callback that is called when the channel is reconnected. Use if you need to refresh the data to catch up with the latest changes.
+   */
+  onReconnected?: () => void;
+  /**
+   * The timeout in seconds after which the channel is unsubscribed if the browser tab is inactive (in background).
+   */
+  inactiveTabTimeoutSeconds?: number;
+}
+
+/**
+ * The state of the subscription:
+ * - 'subscribing' - the channel is being initially subscribed to.
+ * - 'subscribed' - the channel is subscribed and the connection is fully established for postgres_changes.
+ * - 'reconnecting' - the channel is reconnecting after an error or timeout.
+ * - 'closed' - the channel is closed.
+ * - 'error' - the channel is in an error state (all reconnection attempts failed). The error is thrown.
+ */
+type SubscriptionState =
+  | {
+      status: 'subscribing' | 'subscribed' | 'closed';
+    }
+  | {
+      status: 'error' | 'reconnecting';
+      error: Error;
+    };
+
+const refreshSessionIfNeeded = async () => {
+  await agicashDb.realtime.setAuth();
+};
+
+const maxRetries = 3;
+
+/**
+ * Subscribes to a Supabase Realtime channel when the component mounts and unsubscribes when the component unmounts.
+ * Manages channel reconnection in case of errors and timeouts. The error is thrown if the subscription reconnection fails after the maximum number of retries.
+ * @param options - Subcription configuration.
+ * @returns The status of the subscription.
+ */
 export function useSupabaseRealtimeSubscription({
   channelFactory,
   onReconnected,
-}: {
-  channelFactory: () => RealtimeChannel;
-  onReconnected?: () => void;
-}) {
+  inactiveTabTimeoutSeconds = 60 * 10,
+}: Options) {
   const [state, setState] = useState<SubscriptionState>({
     status: 'subscribing',
   });
-  const channelFactoryRef = useLatest(channelFactory);
+  const channelRef = useRef<RealtimeChannel | null>(null);
+  const inactiveTimerRef = useRef<NodeJS.Timeout | null>(null);
   const onReconnectedRef = useLatest(onReconnected);
-  const errorTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  // Stores the error that occurred while the page was not visible so that it can be handled when the page becomes visible.
-  const pendingErrorRef = useRef<{
-    status: string;
-    error: Error | undefined;
-  } | null>(null);
+  const channelFactoryRef = useLatest(channelFactory);
+  const retryCountRef = useRef(0);
 
-  useEffect(() => {
-    const setErrorStateAfterDelay = (
-      status: string,
-      error: Error | undefined,
-    ) => {
-      return setTimeout(() => {
-        setState({
-          status: 'error',
-          error: new Error(
-            `Error with "${channel.topic}" channel subscription. Status: ${status}`,
-            { cause: error },
-          ),
+  const createChannel = useCallback(() => {
+    const channel = channelFactoryRef.current();
+    channelRef.current = channel;
+    return channel;
+  }, []);
+
+  /**
+   * Listens for the system postgres_changes ok message and sets the subscription state to 'subscribed' when it is received.
+   * Only when this message is received, we can be sure that the connection is fully established for postgres_changes.
+   * See https://github.com/supabase/realtime/issues/282 for details.
+   */
+  const setupSystemMessageListener = useCallback((channel: RealtimeChannel) => {
+    channel.on(REALTIME_LISTEN_TYPES.SYSTEM, {}, (payload) => {
+      if (payload.extension === 'postgres_changes' && payload.status === 'ok') {
+        const time = new Date();
+        console.debug('System postgres_changes ok message received', {
+          timestamp: time.getTime(),
+          time: time.toISOString(),
+          topic: channel.topic,
         });
-      }, ERROR_DELAY_MS);
-    };
-
-    const handleVisibilityChange = () => {
-      if (
-        document.visibilityState === 'visible' &&
-        pendingErrorRef.current &&
-        !errorTimeoutRef.current
-      ) {
-        const pendingError = pendingErrorRef.current;
-        errorTimeoutRef.current = setErrorStateAfterDelay(
-          pendingError.status,
-          pendingError.error,
-        );
-      }
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    const channel = channelFactoryRef.current().subscribe((status, error) => {
-      console.debug(
-        `${new Date().toISOString()}: Supabase realtime subscription for "${channel.topic}"`,
-        status,
-        error,
-      );
-
-      if (status === REALTIME_SUBSCRIBE_STATES.SUBSCRIBED) {
-        if (errorTimeoutRef.current) {
-          clearTimeout(errorTimeoutRef.current);
-          errorTimeoutRef.current = null;
-        }
-        pendingErrorRef.current = null;
-
         setState((curr) => {
           if (curr.status !== 'subscribing') {
             onReconnectedRef.current?.();
           }
-          return {
-            status: 'subscribed',
-          };
+          return { status: 'subscribed' };
         });
-      } else if (status === REALTIME_SUBSCRIBE_STATES.CLOSED) {
-        if (errorTimeoutRef.current) {
-          clearTimeout(errorTimeoutRef.current);
-          errorTimeoutRef.current = null;
-        }
-        pendingErrorRef.current = null;
+        retryCountRef.current = 0; // Reset retries on success
+      }
+    });
+  }, []);
 
+  const subscribe = useCallback(async () => {
+    await refreshSessionIfNeeded();
+    const channel = createChannel();
+
+    console.debug('Realtime channel subscribe called', {
+      time: new Date().toISOString(),
+      topic: channel.topic,
+    });
+
+    setupSystemMessageListener(channel);
+
+    channel.subscribe((status, err) =>
+      handleSubscriptionState(channel, status, err),
+    );
+  }, [createChannel, setupSystemMessageListener]);
+
+  const unsubscribe = useCallback(() => {
+    if (channelRef.current) {
+      console.debug('Realtime channel unsubscribe called', {
+        time: new Date().toISOString(),
+        topic: channelRef.current.topic,
+      });
+      agicashDb.removeChannel(channelRef.current);
+      channelRef.current = null;
+    }
+  }, []);
+
+  const resubscribe = useCallback(() => {
+    console.debug('Realtime channel resubscribe called', {
+      time: new Date().toISOString(),
+      topic: channelRef.current?.topic,
+    });
+    unsubscribe();
+    subscribe();
+  }, [unsubscribe, subscribe]);
+
+  const handleSubscriptionState = useCallback(
+    async (channel: RealtimeChannel, status: string, supabaseError?: Error) => {
+      const { topic } = channel;
+      console.debug('Realtime channel subscription status changed', {
+        time: new Date().toISOString(),
+        topic,
+        status,
+        error: supabaseError,
+      });
+
+      if (status === REALTIME_SUBSCRIBE_STATES.SUBSCRIBED) {
+        // We are doing nothing here because this doesn't really mean that the connection is fully established for postgres_changes.
+        // We need to wait for the system postgres_changes ok message to be received.
+        // See setupSystemMessageListener method above.
+      } else if (status === REALTIME_SUBSCRIBE_STATES.CLOSED) {
         setState({ status: 'closed' });
-      } else {
-        const isPageVisible = document.visibilityState === 'visible';
-        if (!isPageVisible) {
-          console.debug(
-            `${new Date().toISOString()}: Setting pending error for "${channel.topic}" because page is not visible`,
+      } else if (
+        status === REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR ||
+        status === REALTIME_SUBSCRIBE_STATES.TIMED_OUT
+      ) {
+        const event =
+          status === REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR
+            ? 'error'
+            : 'timeout';
+
+        if (document.hidden) {
+          console.debug(`Channel ${event}, but tab is hidden. Unsubscribing.`, {
+            time: new Date().toISOString(),
+            topic,
             status,
-            error,
-          );
-          // Store the error to handle when page becomes visible
-          pendingErrorRef.current = { status, error };
+            error: supabaseError,
+          });
+          unsubscribe();
           return;
         }
 
-        if (!errorTimeoutRef.current) {
-          errorTimeoutRef.current = setErrorStateAfterDelay(status, error);
+        if (retryCountRef.current < maxRetries) {
+          setState({
+            status: 'reconnecting',
+            error:
+              supabaseError ??
+              new Error(
+                `Error with "${channel.topic}" channel subscription. Status: ${status}`,
+              ),
+          });
+
+          retryCountRef.current += 1;
+          console.debug(`Retrying subscription after ${event}`, {
+            time: new Date().toISOString(),
+            topic,
+            status,
+            error: supabaseError,
+            attempt: `${retryCountRef.current}/${maxRetries}`,
+          });
+          resubscribe();
+        } else {
+          setState({
+            status: 'error',
+            error: new Error(
+              `Error with "${channel.topic}" channel subscription. Status: ${status}`,
+              { cause: supabaseError },
+            ),
+          });
         }
       }
-    });
-    console.debug(
-      `${new Date().toISOString()}: Subscribed to supabase realtime`,
-      channel.topic,
-    );
+    },
+    [resubscribe, unsubscribe],
+  );
 
-    return () => {
-      console.debug(
-        `${new Date().toISOString()}: Unsubscribing from supabase realtime`,
-        channel.topic,
-      );
+  const handleVisibilityChangeRef = useLatest(() => {
+    if (document.hidden) {
+      if (!inactiveTimerRef.current) {
+        console.debug('Tab went to background. Starting inactivity timer', {
+          time: new Date().toISOString(),
+          topic: channelRef.current?.topic,
+          inactiveTabTimeoutSeconds,
+          status: state.status,
+        });
 
-      if (errorTimeoutRef.current) {
-        clearTimeout(errorTimeoutRef.current);
-        errorTimeoutRef.current = null;
+        inactiveTimerRef.current = setTimeout(() => {
+          console.debug(
+            `Tab inactive for ${inactiveTabTimeoutSeconds} seconds. Unsubscribing.`,
+            {
+              time: new Date().toISOString(),
+              topic: channelRef.current?.topic,
+              status: state.status,
+            },
+          );
+          unsubscribe();
+        }, inactiveTabTimeoutSeconds * 1000);
+      }
+    } else {
+      console.debug('Tab is visible again', {
+        time: new Date().toISOString(),
+        topic: channelRef.current?.topic,
+        status: state.status,
+      });
+
+      if (inactiveTimerRef.current) {
+        clearTimeout(inactiveTimerRef.current);
+        inactiveTimerRef.current = null;
       }
 
-      pendingErrorRef.current = null;
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (state.status !== 'subscribed') {
+        resubscribe();
+      }
+    }
+  });
 
-      channel.unsubscribe();
+  useEffect(() => {
+    document.addEventListener('visibilitychange', () =>
+      handleVisibilityChangeRef.current(),
+    );
+    subscribe();
+
+    return () => {
+      document.removeEventListener('visibilitychange', () =>
+        handleVisibilityChangeRef.current(),
+      );
+      if (inactiveTimerRef.current) {
+        clearTimeout(inactiveTimerRef.current);
+      }
+      unsubscribe();
     };
-  }, []);
+  }, [subscribe, unsubscribe]);
 
   if (state.status === 'error') {
     throw state.error;


### PR DESCRIPTION
In this approach I am managing reconnection manually. What we do now is:
- when app goes to background, if the error doesn't happen with connection we manually unsubscribe it after 10 minutes (I think in practice error will happen lot sooner)
- when the error (or timeout does happen) if the app is in background we do nothing and if it is in foreground we try to reconnect up to 3 times
- when the app comes to foregorund we subscribe again

I also found out that you can't just wait for status subscribed and consider the connection to be established. that means that the socket is established but to know when the subscription is established for postgres_changes we have to listen for a system message of that type
