### PR TITLE
Concurrency improvements - lightning transactions

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -613,7 +613,7 @@ const useOnMintQuoteStateChange = ({
 
   const processMintQuote = useCallback(
     async (mintQuote: MintQuoteResponse) => {
-      console.debug('Processing mint quote', mintQuote);
+      console.debug('Mint quote updated', mintQuote);
 
       const relatedReceiveQuote = pendingQuotesCache.getByMintQuoteId(
         mintQuote.quote,
@@ -693,20 +693,61 @@ export function useTrackPendingCashuReceiveQuotes() {
 export function useProcessCashuReceiveQuoteTasks() {
   const cashuReceiveQuoteService = useCashuReceiveQuoteService();
   const pendingQuotes = usePendingCashuReceiveQuotes();
+  const getCashuAccount = useGetLatestCashuAccount();
+
+  const { mutate: completeReceiveQuote } = useMutation({
+    mutationFn: async (receiveQuoteId: string) => {
+      const quote = pendingQuotes.find((q) => q.id === receiveQuoteId);
+      if (!quote) {
+        // This means that the quote is not pending anymore so it was removed from the cache.
+        // This can happen if the quote was completed or failed in the meantime.
+        return;
+      }
+      const account = await getCashuAccount(quote.accountId);
+
+      return cashuReceiveQuoteService.completeReceive(account, quote);
+    },
+    retry: 3,
+    throwOnError: true,
+    onError: (error, receiveQuoteId) => {
+      console.error('Complete receive quote error', {
+        cause: error,
+        receiveQuoteId,
+      });
+    },
+  });
+
+  const { mutate: expireReceiveQuote } = useMutation({
+    mutationFn: async (receiveQuoteId: string) => {
+      const quote = pendingQuotes.find((q) => q.id === receiveQuoteId);
+      if (!quote) {
+        // This means that the quote is not pending anymore so it was removed from the cache.
+        // This can happen if the quote was completed or failed in the meantime.
+        return;
+      }
+
+      await cashuReceiveQuoteService.expire(quote);
+    },
+    retry: 3,
+    throwOnError: true,
+    onError: (error, receiveQuoteId) => {
+      console.error('Expire receive quote error', {
+        cause: error,
+        receiveQuoteId,
+      });
+    },
+  });
 
   useOnMintQuoteStateChange({
     quotes: pendingQuotes,
-    onPaid: (account, quote) => {
-      // TODO: this should probaby trigger mutation that will then call related service method. That way mutation will be responsible for errors and retries.
-      cashuReceiveQuoteService.completeReceive(account, quote);
+    onPaid: (_, quote) => {
+      completeReceiveQuote(quote.id);
     },
-    onIssued: (account, quote) => {
-      // TODO: this should probaby trigger mutation that will then call related service method. That way mutation will be responsible for errors and retries.
-      cashuReceiveQuoteService.completeReceive(account, quote);
+    onIssued: (_, quote) => {
+      completeReceiveQuote(quote.id);
     },
     onExpired: (quote) => {
-      // TODO: this should probaby trigger mutation that will then call related service method. That way mutation will be responsible for errors and retries.
-      cashuReceiveQuoteService.expire(quote);
+      expireReceiveQuote(quote.id);
     },
   });
 }

--- a/app/features/receive/cashu-token-swap-service.ts
+++ b/app/features/receive/cashu-token-swap-service.ts
@@ -94,6 +94,10 @@ export class CashuTokenSwapService {
   }
 
   async completeSwap(account: CashuAccount, tokenSwap: CashuTokenSwap) {
+    if (tokenSwap.state === 'COMPLETED') {
+      return;
+    }
+
     if (tokenSwap.state !== 'PENDING') {
       throw new Error('Token swap is not pending');
     }


### PR DESCRIPTION
This is temporary improvement for self resolution of concurrency errors. It's a pretty dumb approach where it just retries and uses the latest data on each retry. All mutations were set to use 3 retries.

Proper solution will most likely use queues to make sure operations for single account are never executed in parallel, plus it will have better retries were num of retries will depend on type of the error (e.g. concurrency error should probably be retried until it resolves and shouldn't even increment the attempt counter). Also irrecoverable errors should fail without retries and move the related entity to error state which would then be displayed somewhere (e.g. on history page where user could do manual intervention to retry maybe or undo the action and recover reserved proofs).