### PR TITLE
enable bypassing invoice amount validation

### DIFF
--- a/app/lib/exchange-rate/exchange-rate-service.ts
+++ b/app/lib/exchange-rate/exchange-rate-service.ts
@@ -72,6 +72,15 @@ export class ExchangeRateService {
     throw new Error(errorMessage);
   }
 
+  /**
+   * Gets a single rate for a specific ticker.
+   * This is a convenience method for getting individual rates.
+   */
+  async getRate(ticker: Ticker, signal?: AbortSignal): Promise<string> {
+    const rates = await this.getRates({ tickers: [ticker], signal });
+    return rates[ticker];
+  }
+
   private getProvidersForTickers(tickers: Ticker[]): ExchangeRateProvider[] {
     const matchingProviders: ExchangeRateProvider[] = [];
     for (const provider of this.providers) {

--- a/app/lib/lnurl/index.ts
+++ b/app/lib/lnurl/index.ts
@@ -59,7 +59,11 @@ export const getInvoiceFromLud16 = async (
     }
 
     const callbackRes = await ky
-      .get(`${callback}?amount=${amountMsat}`)
+      .get(`${callback}?amount=${amountMsat}`, {
+        headers: {
+          'X-Bypass-Amount-Validation': 'true',
+        },
+      })
       .json<LNURLPayResult | LNURLError>();
 
     if (isLNURLError(callbackRes)) return callbackRes;


### PR DESCRIPTION
Set an X-Bypass-Amount-Validation header to signal that the client is okay with imprecise invoice amounts.
This is a hack and needs to be improved later, but this is the simplest way I could think to get around this specific issue. Larter I think we should have better multi-currency support in ourl lnurl server.

The hard problem is that receivers should be able to choose their receive currency, but for BTC to USD conversions our exchange rate does not match with the mint's so invoices don't get checked for exact amounts. I think we can come up with a way to improve exchange rate coordinations and currency exchange between sender and receivers and reference other existing protocols like LUD21 draft (see #532 ) or maybe something lIke UMA. Ideally a sender could try to pick the most efficient currency (ie. no lightning payment) 