### PR TITLE
store transaction destination details

### DIFF
--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -11,8 +11,8 @@ import {
 import { getDefaultUnit } from '../shared/currencies';
 import { useEncryption } from '../shared/encryption';
 import type {
-  CashuReceiveQuoteTransactionDetails,
-  CashuReceiveSwapTransactionDetails,
+  CashuLightningReceiveTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
 } from '../transactions/transaction';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 
@@ -116,8 +116,8 @@ export class CashuReceiveQuoteRepository {
     const unit = getDefaultUnit(amount.currency);
 
     let details:
-      | CashuReceiveQuoteTransactionDetails
-      | CashuReceiveSwapTransactionDetails;
+      | CashuLightningReceiveTransactionDetails
+      | CashuTokenReceiveTransactionDetails;
 
     if (receiveType === 'TOKEN') {
       const { cashuReceiveFee, tokenAmount } = params;
@@ -133,13 +133,13 @@ export class CashuReceiveQuoteRepository {
         tokenAmount,
         cashuReceiveFee: cashuReceiveFeeMoney,
         totalFees: cashuReceiveFeeMoney,
-      } satisfies CashuReceiveSwapTransactionDetails;
+      } satisfies CashuTokenReceiveTransactionDetails;
     } else {
       details = {
         amountReceived: amount,
         paymentRequest,
         description,
-      } satisfies CashuReceiveQuoteTransactionDetails;
+      } satisfies CashuLightningReceiveTransactionDetails;
     }
 
     const encryptedTransactionDetails = await this.encryption.encrypt(details);

--- a/app/features/receive/cashu-token-swap-repository.ts
+++ b/app/features/receive/cashu-token-swap-repository.ts
@@ -10,7 +10,7 @@ import { getTokenHash, tokenToMoney } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
 import { useEncryption } from '../shared/encryption';
 import { UniqueConstraintError } from '../shared/error';
-import type { CashuReceiveSwapTransactionDetails } from '../transactions/transaction';
+import type { CashuTokenReceiveTransactionDetails } from '../transactions/transaction';
 import type { CashuTokenSwap } from './cashu-token-swap';
 
 type Options = {
@@ -101,7 +101,7 @@ export class CashuTokenSwapRepository {
       unit: getCashuUnit(amount.currency),
     });
 
-    const details: CashuReceiveSwapTransactionDetails = {
+    const details: CashuTokenReceiveTransactionDetails = {
       amountReceived: amount.subtract(cashuReceiveFeeMoney),
       cashuReceiveFee: cashuReceiveFeeMoney,
       totalFees: cashuReceiveFeeMoney,

--- a/app/features/send/cashu-send-quote-hooks.ts
+++ b/app/features/send/cashu-send-quote-hooks.ts
@@ -30,7 +30,7 @@ import {
 } from '../agicash-db/database';
 import { useCashuCryptography } from '../shared/cashu';
 import { DomainError, NotFoundError } from '../shared/error';
-import type { CashuSendQuoteDestinationDetails } from '../transactions/transaction';
+import type { DestinationDetails } from '../transactions/transaction';
 import { useUser } from '../user/user-hooks';
 import type { CashuSendQuote } from './cashu-send-quote';
 import {
@@ -155,7 +155,7 @@ export function useInitiateCashuSendQuote({
     }: {
       accountId: string;
       sendQuote: SendQuoteRequest;
-      destinationDetails?: CashuSendQuoteDestinationDetails;
+      destinationDetails?: DestinationDetails;
     }) => {
       const account = await getCashuAccount(accountId);
       return cashuSendQuoteService.createSendQuote({

--- a/app/features/send/cashu-send-quote-hooks.ts
+++ b/app/features/send/cashu-send-quote-hooks.ts
@@ -30,6 +30,7 @@ import {
 } from '../agicash-db/database';
 import { useCashuCryptography } from '../shared/cashu';
 import { DomainError, NotFoundError } from '../shared/error';
+import type { CashuSendQuoteDestinationDetails } from '../transactions/transaction';
 import { useUser } from '../user/user-hooks';
 import type { CashuSendQuote } from './cashu-send-quote';
 import {
@@ -150,12 +151,18 @@ export function useInitiateCashuSendQuote({
     mutationFn: async ({
       accountId,
       sendQuote,
-    }: { accountId: string; sendQuote: SendQuoteRequest }) => {
+      destinationDetails,
+    }: {
+      accountId: string;
+      sendQuote: SendQuoteRequest;
+      destinationDetails?: CashuSendQuoteDestinationDetails;
+    }) => {
       const account = await getCashuAccount(accountId);
       return cashuSendQuoteService.createSendQuote({
         userId,
         account,
         sendQuote,
+        destinationDetails,
       });
     },
     onSuccess: (data) => {

--- a/app/features/send/cashu-send-quote-repository.ts
+++ b/app/features/send/cashu-send-quote-repository.ts
@@ -9,9 +9,9 @@ import {
 import { getDefaultUnit } from '../shared/currencies';
 import { useEncryption } from '../shared/encryption';
 import type {
-  CashuSendQuoteDestinationDetails,
-  CompletedCashuSendQuoteTransactionDetails,
-  IncompleteCashuSendQuoteTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  DestinationDetails,
+  IncompleteCashuLightningSendTransactionDetails,
 } from '../transactions/transaction';
 import {
   type TransactionRepository,
@@ -96,7 +96,7 @@ type CreateSendQuote = {
   /**
    * Destination details of the send. This will be undefined if the send is directly paying a bolt11.
    */
-  destinationDetails?: CashuSendQuoteDestinationDetails;
+  destinationDetails?: DestinationDetails;
 };
 
 export class CashuSendQuoteRepository {
@@ -134,7 +134,7 @@ export class CashuSendQuoteRepository {
   ): Promise<CashuSendQuote> {
     const unit = getDefaultUnit(amountToReceive.currency);
 
-    const details: IncompleteCashuSendQuoteTransactionDetails = {
+    const details: IncompleteCashuLightningSendTransactionDetails = {
       amountToReceive,
       cashuSendFee: cashuFee,
       lightningFeeReserve,
@@ -248,10 +248,10 @@ export class CashuSendQuoteRepository {
       transaction.direction !== 'SEND' ||
       transaction.state !== 'PENDING'
     ) {
-      throw new Error('Transaction not found.');
+      throw new Error(`Transaction not found for quote ${quote.id}.`);
     }
 
-    const updatedTransactionDetails: CompletedCashuSendQuoteTransactionDetails =
+    const updatedTransactionDetails: CompletedCashuLightningSendTransactionDetails =
       {
         ...transaction.details,
         preimage: paymentPreimage,

--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -11,6 +11,7 @@ import type { CashuAccount } from '../accounts/account';
 import { type CashuCryptography, useCashuCryptography } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
 import { DomainError } from '../shared/error';
+import type { CashuSendQuoteDestinationDetails } from '../transactions/transaction';
 import type { CashuSendQuote } from './cashu-send-quote';
 import {
   type CashuSendQuoteRepository,
@@ -203,6 +204,7 @@ export class CashuSendQuoteService {
     userId,
     account,
     sendQuote,
+    destinationDetails,
   }: {
     /**
      * ID of the sender.
@@ -216,6 +218,11 @@ export class CashuSendQuoteService {
      * The send quote to create.
      */
     sendQuote: SendQuoteRequest;
+    /**
+     * The destination details of the send, like the contact ID or lightning address used to fetch the payment request.
+     * This will be undefined if the send is directly paying a bolt11.
+     */
+    destinationDetails?: CashuSendQuoteDestinationDetails;
   }) {
     const meltQuote = sendQuote.meltQuote;
     const expiresAt = new Date(meltQuote.expiry * 1000);
@@ -294,6 +301,7 @@ export class CashuSendQuoteService {
       proofsToSend: proofs.send,
       accountVersion: account.version,
       proofsToKeep: proofs.keep,
+      destinationDetails,
     });
   }
 

--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -11,7 +11,7 @@ import type { CashuAccount } from '../accounts/account';
 import { type CashuCryptography, useCashuCryptography } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
 import { DomainError } from '../shared/error';
-import type { CashuSendQuoteDestinationDetails } from '../transactions/transaction';
+import type { DestinationDetails } from '../transactions/transaction';
 import type { CashuSendQuote } from './cashu-send-quote';
 import {
   type CashuSendQuoteRepository,
@@ -222,7 +222,7 @@ export class CashuSendQuoteService {
      * The destination details of the send, like the contact ID or lightning address used to fetch the payment request.
      * This will be undefined if the send is directly paying a bolt11.
      */
-    destinationDetails?: CashuSendQuoteDestinationDetails;
+    destinationDetails?: DestinationDetails;
   }) {
     const meltQuote = sendQuote.meltQuote;
     const expiresAt = new Date(meltQuote.expiry * 1000);

--- a/app/features/send/cashu-send-swap-repository.ts
+++ b/app/features/send/cashu-send-swap-repository.ts
@@ -8,7 +8,7 @@ import {
 } from '../agicash-db/database';
 import { useCashuCryptography } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
-import type { CashuSendSwapTransactionDetails } from '../transactions/transaction';
+import type { CashuTokenSendTransactionDetails } from '../transactions/transaction';
 import type { CashuSendSwap } from './cashu-send-swap';
 
 type Options = {
@@ -116,7 +116,7 @@ export class CashuSendSwapRepository {
   ) {
     const unit = getDefaultUnit(amountToSend.currency);
 
-    const details: CashuSendSwapTransactionDetails = {
+    const details: CashuTokenSendTransactionDetails = {
       amountSpent: totalAmount,
       cashuSendFee: cashuSendFee,
       cashuReceiveFee: cashuReceiveFee,

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent } from '~/components/ui/card';
 import type { CashuAccount } from '~/features/accounts/account';
 import type { CashuLightningQuote } from '~/features/send/cashu-send-quote-service';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
-import type { CashuSendQuoteDestinationDetails } from '~/features/transactions/transaction';
+import type { DestinationDetails } from '~/features/transactions/transaction';
 import { useToast } from '~/hooks/use-toast';
 import { decodeBolt11 } from '~/lib/bolt11';
 import type { Money } from '~/lib/money';
@@ -94,7 +94,7 @@ type PayBolt11ConfirmationProps = {
   destination: string;
   /** The destination to display in the UI. For sends to bolt11 this will be the same as the bolt11, for ln addresses it will be the ln address. */
   destinationDisplay: string;
-  destinationDetails?: CashuSendQuoteDestinationDetails;
+  destinationDetails?: DestinationDetails;
   /** The quote to display in the UI. */
   quote: CashuLightningQuote;
 };

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -176,6 +176,7 @@ export function TransactionDetails({
             unit,
           }),
           paymentRequest: incompleteDetails.paymentRequest,
+          destinationDetails: incompleteDetails.destinationDetails,
         },
       );
     }
@@ -215,6 +216,7 @@ export function TransactionDetails({
 
   if (type === 'CASHU_TOKEN' && direction === 'RECEIVE') {
     const receiveSwapDetails = details as CashuReceiveSwapTransactionDetails;
+    const tokenUnit = getDefaultUnit(receiveSwapDetails.tokenAmount.currency);
     console.debug(
       `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
       {
@@ -223,7 +225,9 @@ export function TransactionDetails({
         }),
         // NOTE: these should never be undefined, but there's a bug we need to fix
         // see https://github.com/MakePrisms/boardwalkcash/pull/541
-        tokenAmount: receiveSwapDetails.tokenAmount?.toLocaleString({ unit }),
+        tokenAmount: receiveSwapDetails.tokenAmount?.toLocaleString({
+          unit: tokenUnit,
+        }),
         cashuReceiveFee: receiveSwapDetails.cashuReceiveFee?.toLocaleString({
           unit,
         }),

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -17,11 +17,11 @@ import {
   CardTitle,
 } from '~/components/ui/card';
 import type {
-  CashuReceiveQuoteTransactionDetails,
-  CashuReceiveSwapTransactionDetails,
-  CashuSendSwapTransactionDetails,
-  CompletedCashuSendQuoteTransactionDetails,
-  IncompleteCashuSendQuoteTransactionDetails,
+  CashuLightningReceiveTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
+  CashuTokenSendTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  IncompleteCashuLightningSendTransactionDetails,
   Transaction,
 } from '~/features/transactions/transaction';
 import { useToast } from '~/hooks/use-toast';
@@ -134,7 +134,7 @@ export function TransactionDetails({
   if (type === 'CASHU_LIGHTNING' && direction === 'SEND') {
     if (state === 'COMPLETED') {
       const completedDetails =
-        details as CompletedCashuSendQuoteTransactionDetails;
+        details as CompletedCashuLightningSendTransactionDetails;
       console.debug(
         `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
         {
@@ -160,7 +160,7 @@ export function TransactionDetails({
       );
     } else {
       const incompleteDetails =
-        details as IncompleteCashuSendQuoteTransactionDetails;
+        details as IncompleteCashuLightningSendTransactionDetails;
       console.debug(
         `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
         {
@@ -183,7 +183,7 @@ export function TransactionDetails({
   }
 
   if (type === 'CASHU_LIGHTNING' && direction === 'RECEIVE') {
-    const receiveDetails = details as CashuReceiveQuoteTransactionDetails;
+    const receiveDetails = details as CashuLightningReceiveTransactionDetails;
     console.debug(
       `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
       {
@@ -195,7 +195,7 @@ export function TransactionDetails({
   }
 
   if (type === 'CASHU_TOKEN' && direction === 'SEND') {
-    const sendSwapDetails = details as CashuSendSwapTransactionDetails;
+    const sendSwapDetails = details as CashuTokenSendTransactionDetails;
     console.debug(
       `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
       {
@@ -215,7 +215,7 @@ export function TransactionDetails({
   }
 
   if (type === 'CASHU_TOKEN' && direction === 'RECEIVE') {
-    const receiveSwapDetails = details as CashuReceiveSwapTransactionDetails;
+    const receiveSwapDetails = details as CashuTokenReceiveTransactionDetails;
     const tokenUnit = getDefaultUnit(receiveSwapDetails.tokenAmount.currency);
     console.debug(
       `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, BanknoteIcon, ZapIcon } from 'lucide-react';
+import { AlertCircle, BanknoteIcon, UserIcon, ZapIcon } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { Card } from '~/components/ui/card';
 import { ScrollArea } from '~/components/ui/scroll-area';
@@ -94,10 +94,23 @@ const getTransactionDescription = (transaction: Transaction) => {
   return transaction.direction === 'RECEIVE' ? 'Received' : 'Sent';
 };
 
-const transactionTypeIcons: Record<Transaction['type'], React.ReactNode> = {
+const transactionTypeIconMap = {
   CASHU_LIGHTNING: <ZapIcon className="h-4 w-4" />,
   CASHU_TOKEN: <BanknoteIcon className="h-4 w-4" />,
+  AGICASH_CONTACT: <UserIcon className="h-4 w-4" />,
 };
+
+const getTransactionTypeIcon = (transaction: Transaction) => {
+  if (
+    transaction.type === 'CASHU_LIGHTNING' &&
+    transaction.direction === 'SEND' &&
+    transaction.details.destinationDetails?.sendType === 'AGICASH_CONTACT'
+  ) {
+    return transactionTypeIconMap.AGICASH_CONTACT;
+  }
+  return transactionTypeIconMap[transaction.type];
+};
+
 function TransactionRow({ transaction }: { transaction: Transaction }) {
   return (
     <LinkWithViewTransition
@@ -106,7 +119,7 @@ function TransactionRow({ transaction }: { transaction: Transaction }) {
       applyTo="newView"
       className="flex w-full items-center justify-start gap-4"
     >
-      {transactionTypeIcons[transaction.type]}
+      {getTransactionTypeIcon(transaction)}
       <div className="flex w-full flex-grow flex-col gap-0">
         <div className="flex items-center justify-between">
           <p className="text-sm">

--- a/app/features/transactions/transaction-repository.ts
+++ b/app/features/transactions/transaction-repository.ts
@@ -6,11 +6,11 @@ import {
 } from '../agicash-db/database';
 import { useEncryption } from '../shared/encryption';
 import type {
-  CashuReceiveQuoteTransactionDetails,
-  CashuReceiveSwapTransactionDetails,
-  CashuSendSwapTransactionDetails,
-  CompletedCashuSendQuoteTransactionDetails,
-  IncompleteCashuSendQuoteTransactionDetails,
+  CashuLightningReceiveTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
+  CashuTokenSendTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  IncompleteCashuLightningSendTransactionDetails,
   Transaction,
 } from './transaction';
 
@@ -36,11 +36,11 @@ type ListOptions = Options & {
 };
 
 type UnifiedTransactionDetails =
-  | CashuReceiveSwapTransactionDetails
-  | CashuSendSwapTransactionDetails
-  | CashuReceiveQuoteTransactionDetails
-  | IncompleteCashuSendQuoteTransactionDetails
-  | CompletedCashuSendQuoteTransactionDetails;
+  | CashuTokenReceiveTransactionDetails
+  | CashuTokenSendTransactionDetails
+  | CashuLightningReceiveTransactionDetails
+  | IncompleteCashuLightningSendTransactionDetails
+  | CompletedCashuLightningSendTransactionDetails;
 
 export class TransactionRepository {
   constructor(
@@ -141,14 +141,14 @@ export class TransactionRepository {
     if (type === 'CASHU_LIGHTNING' && direction === 'SEND') {
       if (state === 'COMPLETED') {
         const completedDetails =
-          details as CompletedCashuSendQuoteTransactionDetails;
+          details as CompletedCashuLightningSendTransactionDetails;
         return createTransaction(
           completedDetails.amountSpent,
           completedDetails,
         );
       }
       const incompleteDetails =
-        details as IncompleteCashuSendQuoteTransactionDetails;
+        details as IncompleteCashuLightningSendTransactionDetails;
       return createTransaction(
         incompleteDetails.amountReserved,
         incompleteDetails,
@@ -156,17 +156,17 @@ export class TransactionRepository {
     }
 
     if (type === 'CASHU_LIGHTNING' && direction === 'RECEIVE') {
-      const receiveDetails = details as CashuReceiveQuoteTransactionDetails;
+      const receiveDetails = details as CashuLightningReceiveTransactionDetails;
       return createTransaction(receiveDetails.amountReceived, receiveDetails);
     }
 
     if (type === 'CASHU_TOKEN' && direction === 'SEND') {
-      const sendDetails = details as CashuSendSwapTransactionDetails;
+      const sendDetails = details as CashuTokenSendTransactionDetails;
       return createTransaction(sendDetails.amountSpent, sendDetails);
     }
 
     if (type === 'CASHU_TOKEN' && direction === 'RECEIVE') {
-      const receiveDetails = details as CashuReceiveSwapTransactionDetails;
+      const receiveDetails = details as CashuTokenReceiveTransactionDetails;
       return createTransaction(receiveDetails.amountReceived, receiveDetails);
     }
 

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -48,6 +48,21 @@ export type CashuReceiveSwapTransactionDetails = {
   totalFees: Money;
 };
 
+/**
+ * Additional details related to the transaction.
+ */
+export type CashuSendQuoteDestinationDetails =
+  | {
+      sendType: 'AGICASH_CONTACT';
+      /** The ID of the contact that the invoice was fetched from. */
+      contactId: string;
+    }
+  | {
+      sendType: 'LN_ADDRESS';
+      /** The lightning address that the invoice was fetched from. */
+      lnAddress: string;
+    };
+
 type BaseCashuSendQuoteTransactionDetails = {
   /**
    * The sum of all proofs used as inputs to the cashu melt operation
@@ -79,6 +94,12 @@ type BaseCashuSendQuoteTransactionDetails = {
    * The bolt11 payment request.
    */
   paymentRequest: string;
+  /**
+   * Additional details related to the transaction.
+   *
+   * This will be undefined if the send is directly paying a bolt11.
+   */
+  destinationDetails?: CashuSendQuoteDestinationDetails;
 };
 
 /**

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -3,7 +3,7 @@ import type { Money } from '~/lib/money';
 /**
  * Transacion details for sending cashu proofs from an account.
  */
-export type CashuSendSwapTransactionDetails = {
+export type CashuTokenSendTransactionDetails = {
   /**
    * This is the sum of `amountToReceive` and `totalFees`, and is the amount deducted from the account.
    */
@@ -29,7 +29,7 @@ export type CashuSendSwapTransactionDetails = {
 /**
  * Transacion details for receiving cashu proofs to an account.
  */
-export type CashuReceiveSwapTransactionDetails = {
+export type CashuTokenReceiveTransactionDetails = {
   /**
    * This is the token amount minus the cashuReceiveFee, and is the amount added to the account.
    */
@@ -49,9 +49,9 @@ export type CashuReceiveSwapTransactionDetails = {
 };
 
 /**
- * Additional details related to the transaction.
+ * Additional details related to the transaction destination.
  */
-export type CashuSendQuoteDestinationDetails =
+export type DestinationDetails =
   | {
       sendType: 'AGICASH_CONTACT';
       /** The ID of the contact that the invoice was fetched from. */
@@ -63,7 +63,7 @@ export type CashuSendQuoteDestinationDetails =
       lnAddress: string;
     };
 
-type BaseCashuSendQuoteTransactionDetails = {
+type BaseCashuLightningSendTransactionDetails = {
   /**
    * The sum of all proofs used as inputs to the cashu melt operation
    * converted from a number to Money in the currency of the account.
@@ -99,20 +99,20 @@ type BaseCashuSendQuoteTransactionDetails = {
    *
    * This will be undefined if the send is directly paying a bolt11.
    */
-  destinationDetails?: CashuSendQuoteDestinationDetails;
+  destinationDetails?: DestinationDetails;
 };
 
 /**
  * Transacion details for a cashu lightning send transaction that is not yet completed.
  */
-export type IncompleteCashuSendQuoteTransactionDetails =
-  BaseCashuSendQuoteTransactionDetails;
+export type IncompleteCashuLightningSendTransactionDetails =
+  BaseCashuLightningSendTransactionDetails;
 
 /**
  * Transacion details for a cashu lightning send transaction that is completed.
  */
-export type CompletedCashuSendQuoteTransactionDetails =
-  BaseCashuSendQuoteTransactionDetails & {
+export type CompletedCashuLightningSendTransactionDetails =
+  BaseCashuLightningSendTransactionDetails & {
     /**
      * This is the sum of `amountToReceive` and `totalFees`. This is the amount deducted from the account.
      */
@@ -138,7 +138,7 @@ export type CompletedCashuSendQuoteTransactionDetails =
 /**
  * Transacion details for receiving cashu lightning payments to an account.
  */
-export type CashuReceiveQuoteTransactionDetails = {
+export type CashuLightningReceiveTransactionDetails = {
   /**
    * The amount of the bolt11 payment request.
    * This amount is added to the account.
@@ -223,28 +223,28 @@ export type Transaction = {
   | {
       type: 'CASHU_TOKEN';
       direction: 'SEND';
-      details: CashuSendSwapTransactionDetails;
+      details: CashuTokenSendTransactionDetails;
     }
   | {
       type: 'CASHU_TOKEN';
       direction: 'RECEIVE';
-      details: CashuReceiveSwapTransactionDetails;
+      details: CashuTokenReceiveTransactionDetails;
     }
   | {
       type: 'CASHU_LIGHTNING';
       direction: 'SEND';
       state: 'DRAFT' | 'PENDING' | 'FAILED';
-      details: IncompleteCashuSendQuoteTransactionDetails;
+      details: IncompleteCashuLightningSendTransactionDetails;
     }
   | {
       type: 'CASHU_LIGHTNING';
       direction: 'SEND';
       state: 'COMPLETED';
-      details: CompletedCashuSendQuoteTransactionDetails;
+      details: CompletedCashuLightningSendTransactionDetails;
     }
   | {
       type: 'CASHU_LIGHTNING';
       direction: 'RECEIVE';
-      details: CashuReceiveQuoteTransactionDetails;
+      details: CashuLightningReceiveTransactionDetails;
     }
 );

--- a/app/routes/_protected.send.confirm.tsx
+++ b/app/routes/_protected.send.confirm.tsx
@@ -12,6 +12,7 @@ export default function SendConfirmationPage() {
     amount: sendAmount,
     destination,
     destinationDisplay,
+    destinationDetails,
     quote,
   } = useSendStore();
   const sendAccount = getSourceAccount();
@@ -33,12 +34,26 @@ export default function SendConfirmationPage() {
       return <Redirect to="/send" logMessage="Missing destination data" />;
     }
 
+    const details =
+      sendType === 'LN_ADDRESS'
+        ? ({
+            sendType,
+            lnAddress: destinationDetails.lnAddress,
+          } as const)
+        : sendType === 'AGICASH_CONTACT'
+          ? ({
+              sendType,
+              contactId: destinationDetails.id,
+            } as const)
+          : undefined;
+
     return (
       <PayBolt11Confirmation
         account={sendAccount}
         quote={quote}
         destination={destination}
         destinationDisplay={destinationDisplay}
+        destinationDetails={details}
       />
     );
   }


### PR DESCRIPTION
When sending to contact or lightning address we now store the contact id or lightning address in the transaction details.

For now this is just used to show a user icon in the transaction list if the transaction was to a contact.

Alternative approach is here #552 