### PR TITLE
allow uppercase lightning address

### DIFF
--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -338,7 +338,7 @@ function SelectContactOrLud16Drawer({
         <div className="mx-auto flex h-full w-full max-w-sm flex-col gap-3 px-4 sm:px-0">
           <SearchBar
             placeholder="Username or Lightning Address"
-            onSearch={setInput}
+            onSearch={(value) => setInput(value.toLowerCase())}
           />
 
           {isLnAddressFormat && (


### PR DESCRIPTION
Some wallets like blitz give a lightning address with uppercase letters like `Lanepeafowl5@blitz-wallet.com`. Our current validation does not allow for this because LUD-16 says "the <username> is limited to a-z0-9-_. (and + if the SERVICE supports tags). Please note that this is way more strict than common email addresses as it allows fewer symbols and only lowercase characters."

This PR allows for uppercase letters to handle cases like blitz wallet