### PR TITLE
indent settings nav buttons to fix highlight

### DIFF
--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -120,7 +120,7 @@ export default function Settings() {
           Contacts
         </SettingsNavButton>
 
-        <div className="flex w-full items-center justify-between">
+        <div className="flex w-full items-center justify-between pl-4">
           <div className="flex items-center gap-2">
             <SunMoon className="h-4 w-4" />
             <span className="text-sm">Theme</span>

--- a/app/features/settings/ui/settings-nav-button.tsx
+++ b/app/features/settings/ui/settings-nav-button.tsx
@@ -18,7 +18,7 @@ export function SettingsNavButton({
     <LinkWithViewTransition to={to} transition="slideLeft" applyTo="newView">
       <Button
         variant={variant === 'destructive' ? 'destructive' : 'ghost'}
-        className={'flex w-full items-center justify-between pl-0'}
+        className={'flex w-full items-center justify-between'}
       >
         <div className="flex items-center gap-2">{children}</div>
         <ChevronRight />


### PR DESCRIPTION
removing padding from the left of the button messed up the active state for the button so we decided to just revert the change I made in #544 