### PR TITLE
fix drawer height to account for software keyboard

### DIFF
--- a/app/features/contacts/add-contact-drawer.tsx
+++ b/app/features/contacts/add-contact-drawer.tsx
@@ -47,7 +47,7 @@ export function AddContactDrawer() {
           <Plus className="h-4 w-4" />
         </Button>
       </DrawerTrigger>
-      <DrawerContent className="h-[75dvh] pb-14 font-primary">
+      <DrawerContent className="h-[75vh] pb-14 font-primary">
         <DrawerHeader className="space-y-2">
           <DrawerTitle className="text-center">Add Contact</DrawerTitle>
         </DrawerHeader>

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -330,7 +330,7 @@ function SelectContactOrLud16Drawer({
           <AtSign />
         </button>
       </DrawerTrigger>
-      <DrawerContent className="h-[75dvh] pb-14 font-primary">
+      <DrawerContent className="h-[75vh] pb-14 font-primary">
         <DrawerHeader className="flex items-center justify-between">
           <DrawerTitle>Send to User</DrawerTitle>
           <AddContactDrawer />


### PR DESCRIPTION
using `dvh` only considers the visible space so when a software keyboard pops up the total `dvh` decreases and would move the drawer up. Using `vh` allows us to maintian a fixed total height that includes the space under the keyboard.

This PR makes the drawer height fixed even when a keyboard is openeed

https://github.com/user-attachments/assets/82817749-fdf1-4c67-a18d-13e46718ebfe



