### PR TITLE
P2p transaction details with transaction joined with send quote

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -52,11 +52,13 @@ type CashuReceiveQuotePaymentResult = {
 type CreateCashuSendQuoteResult = {
   created_quote: AgicashDbCashuSendQuote;
   updated_account: AgicashDbAccount;
+  transaction: AgicashDbTransaction;
 };
 
 type UpdateCashuSendQuoteResult = {
   updated_quote: AgicashDbCashuSendQuote;
   updated_account: AgicashDbAccount;
+  updated_transaction: AgicashDbTransaction;
 };
 
 // Use when you need to fix/improve generated types

--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -11,6 +11,7 @@ import type { CashuAccount } from '../accounts/account';
 import { type CashuCryptography, useCashuCryptography } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
 import { DomainError } from '../shared/error';
+import type { CashuSendQuoteDestinationDetails } from '../transactions/transaction';
 import type { CashuSendQuote } from './cashu-send-quote';
 import {
   type CashuSendQuoteRepository,
@@ -203,6 +204,7 @@ export class CashuSendQuoteService {
     userId,
     account,
     sendQuote,
+    destinationDetails,
   }: {
     /**
      * ID of the sender.
@@ -216,6 +218,11 @@ export class CashuSendQuoteService {
      * The send quote to create.
      */
     sendQuote: SendQuoteRequest;
+    /**
+     * The destination details of the send, like the contact ID or lightning address used to fetch the payment request.
+     * This will be undefined if the send is directly paying a bolt11.
+     */
+    destinationDetails?: CashuSendQuoteDestinationDetails;
   }) {
     const meltQuote = sendQuote.meltQuote;
     const expiresAt = new Date(meltQuote.expiry * 1000);
@@ -294,6 +301,7 @@ export class CashuSendQuoteService {
       proofsToSend: proofs.send,
       accountVersion: account.version,
       proofsToKeep: proofs.keep,
+      destinationDetails,
     });
   }
 

--- a/app/features/send/cashu-send-quote.ts
+++ b/app/features/send/cashu-send-quote.ts
@@ -1,5 +1,10 @@
 import type { Proof } from '@cashu/cashu-ts';
 import type { Money } from '~/lib/money';
+import type {
+  CompletedCashuSendQuoteTransactionDetails,
+  IncompleteCashuSendQuoteTransactionDetails,
+  Transaction,
+} from '../transactions/transaction';
 
 export type CashuSendQuote = {
   id: string;
@@ -90,6 +95,12 @@ export type CashuSendQuote = {
 } & (
   | {
       state: 'UNPAID' | 'PENDING' | 'EXPIRED';
+      /**
+       * The corresponding transaction.
+       */
+      transaction: Transaction & {
+        details: IncompleteCashuSendQuoteTransactionDetails;
+      };
     }
   | {
       state: 'FAILED';
@@ -97,6 +108,12 @@ export type CashuSendQuote = {
        * Reason for the failure of the send quote.
        */
       failureReason: string;
+      /**
+       * The corresponding transaction.
+       */
+      transaction: Transaction & {
+        details: IncompleteCashuSendQuoteTransactionDetails;
+      };
     }
   | {
       state: 'PAID';
@@ -110,5 +127,20 @@ export type CashuSendQuote = {
        * Currency will be the same as the currency of the account we are sending from.
        */
       amountSpent: Money;
+      /**
+       * The corresponding transaction.
+       */
+      transaction: Transaction & {
+        details: CompletedCashuSendQuoteTransactionDetails;
+      };
+    }
+  | {
+      state: 'EXPIRED';
+      /**
+       * The corresponding transaction.
+       */
+      transaction: Transaction & {
+        details: IncompleteCashuSendQuoteTransactionDetails;
+      };
     }
 );

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -8,7 +8,9 @@ import { PageContent } from '~/components/page';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
 import type { CashuAccount } from '~/features/accounts/account';
+import type { CashuLightningQuote } from '~/features/send/cashu-send-quote-service';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
+import type { CashuSendQuoteDestinationDetails } from '~/features/transactions/transaction';
 import { useToast } from '~/hooks/use-toast';
 import { decodeBolt11 } from '~/lib/bolt11';
 import type { Money } from '~/lib/money';
@@ -19,17 +21,9 @@ import {
   useInitiateCashuSendQuote,
   useTrackCashuSendQuote,
 } from './cashu-send-quote-hooks';
-import type { CashuLightningQuote } from './cashu-send-quote-service';
 import { useCreateCashuSendSwap } from './cashu-send-swap-hooks';
 import { useTrackCashuSendSwap } from './cashu-send-swap-hooks';
 import type { CashuSwapQuote } from './cashu-send-swap-service';
-
-const formatDestination = (destination: string) => {
-  if (destination && destination.length > 20) {
-    return `${destination.slice(0, 5)}...${destination.slice(-5)}`;
-  }
-  return destination;
-};
 
 const ConfirmationRow = ({
   label,
@@ -94,12 +88,13 @@ const BaseConfirmation = ({
 };
 
 type PayBolt11ConfirmationProps = {
-  /** The bolt11 invoice to pay */
-  destination: string;
   /** The account to send from */
   account: CashuAccount;
+  /** The bolt11 invoice to pay */
+  destination: string;
   /** The destination to display in the UI. For sends to bolt11 this will be the same as the bolt11, for ln addresses it will be the ln address. */
   destinationDisplay: string;
+  destinationDetails?: CashuSendQuoteDestinationDetails;
   /** The quote to display in the UI. */
   quote: CashuLightningQuote;
 };
@@ -116,6 +111,7 @@ export const PayBolt11Confirmation = ({
   quote: bolt11Quote,
   destination,
   destinationDisplay,
+  destinationDetails,
 }: PayBolt11ConfirmationProps) => {
   const { toast } = useToast();
   const navigate = useNavigateWithViewTransition();
@@ -156,7 +152,11 @@ export const PayBolt11Confirmation = ({
   });
 
   const handleConfirm = () =>
-    initiateSend({ accountId: account.id, sendQuote: bolt11Quote });
+    initiateSend({
+      accountId: account.id,
+      sendQuote: bolt11Quote,
+      destinationDetails,
+    });
 
   const paymentInProgress =
     ['LOADING', 'UNPAID', 'PENDING'].includes(quoteStatus) ||
@@ -192,7 +192,7 @@ export const PayBolt11Confirmation = ({
           ),
         },
         { label: 'From', value: account.name },
-        { label: 'Paying', value: formatDestination(destinationDisplay) },
+        { label: 'Paying', value: destinationDisplay },
       ].map((row) => (
         <ConfirmationRow key={row.label} label={row.label} value={row.value} />
       ))}

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -176,6 +176,7 @@ export function TransactionDetails({
             unit,
           }),
           paymentRequest: incompleteDetails.paymentRequest,
+          destinationDetails: incompleteDetails.destinationDetails,
         },
       );
     }
@@ -215,6 +216,7 @@ export function TransactionDetails({
 
   if (type === 'CASHU_TOKEN' && direction === 'RECEIVE') {
     const receiveSwapDetails = details as CashuReceiveSwapTransactionDetails;
+    const tokenUnit = getDefaultUnit(receiveSwapDetails.tokenAmount.currency);
     console.debug(
       `TX ${transaction.id.slice(0, 8)} [${type}_${direction}_${state}]:`,
       {
@@ -223,7 +225,9 @@ export function TransactionDetails({
         }),
         // NOTE: these should never be undefined, but there's a bug we need to fix
         // see https://github.com/MakePrisms/boardwalkcash/pull/541
-        tokenAmount: receiveSwapDetails.tokenAmount?.toLocaleString({ unit }),
+        tokenAmount: receiveSwapDetails.tokenAmount?.toLocaleString({
+          unit: tokenUnit,
+        }),
         cashuReceiveFee: receiveSwapDetails.cashuReceiveFee?.toLocaleString({
           unit,
         }),

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, BanknoteIcon, ZapIcon } from 'lucide-react';
+import { AlertCircle, BanknoteIcon, UserIcon, ZapIcon } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { Card } from '~/components/ui/card';
 import { ScrollArea } from '~/components/ui/scroll-area';
@@ -94,10 +94,23 @@ const getTransactionDescription = (transaction: Transaction) => {
   return transaction.direction === 'RECEIVE' ? 'Received' : 'Sent';
 };
 
-const transactionTypeIcons: Record<Transaction['type'], React.ReactNode> = {
+const transactionTypeIconMap = {
   CASHU_LIGHTNING: <ZapIcon className="h-4 w-4" />,
   CASHU_TOKEN: <BanknoteIcon className="h-4 w-4" />,
+  AGICASH_CONTACT: <UserIcon className="h-4 w-4" />,
 };
+
+const getTransactionTypeIcon = (transaction: Transaction) => {
+  if (
+    transaction.type === 'CASHU_LIGHTNING' &&
+    transaction.direction === 'SEND' &&
+    transaction.details.destinationDetails?.sendType === 'AGICASH_CONTACT'
+  ) {
+    return transactionTypeIconMap.AGICASH_CONTACT;
+  }
+  return transactionTypeIconMap[transaction.type];
+};
+
 function TransactionRow({ transaction }: { transaction: Transaction }) {
   return (
     <LinkWithViewTransition
@@ -106,7 +119,7 @@ function TransactionRow({ transaction }: { transaction: Transaction }) {
       applyTo="newView"
       className="flex w-full items-center justify-start gap-4"
     >
-      {transactionTypeIcons[transaction.type]}
+      {getTransactionTypeIcon(transaction)}
       <div className="flex w-full flex-grow flex-col gap-0">
         <div className="flex items-center justify-between">
           <p className="text-sm">

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -48,6 +48,21 @@ export type CashuReceiveSwapTransactionDetails = {
   totalFees: Money;
 };
 
+/**
+ * Additional details of the transaction.
+ */
+export type CashuSendQuoteDestinationDetails =
+  | {
+      sendType: 'AGICASH_CONTACT';
+      /** The ID of the contact that the invoice was fetched from. */
+      contactId: string;
+    }
+  | {
+      sendType: 'LN_ADDRESS';
+      /** The lightning address that the invoice was fetched from. */
+      lnAddress: string;
+    };
+
 type BaseCashuSendQuoteTransactionDetails = {
   /**
    * The sum of all proofs used as inputs to the cashu melt operation
@@ -79,6 +94,12 @@ type BaseCashuSendQuoteTransactionDetails = {
    * The bolt11 payment request.
    */
   paymentRequest: string;
+  /**
+   * Additional details of the transaction.
+   *
+   * This will be undefined if the send is directly paying a bolt11.
+   */
+  destinationDetails?: CashuSendQuoteDestinationDetails;
 };
 
 /**

--- a/app/routes/_protected.send.confirm.tsx
+++ b/app/routes/_protected.send.confirm.tsx
@@ -12,6 +12,7 @@ export default function SendConfirmationPage() {
     amount: sendAmount,
     destination,
     destinationDisplay,
+    destinationDetails,
     quote,
   } = useSendStore();
   const sendAccount = getSourceAccount();
@@ -33,12 +34,26 @@ export default function SendConfirmationPage() {
       return <Redirect to="/send" logMessage="Missing destination data" />;
     }
 
+    const details =
+      sendType === 'LN_ADDRESS'
+        ? ({
+            sendType,
+            lnAddress: destinationDetails.lnAddress,
+          } as const)
+        : sendType === 'AGICASH_CONTACT'
+          ? ({
+              sendType,
+              contactId: destinationDetails.id,
+            } as const)
+          : undefined;
+
     return (
       <PayBolt11Confirmation
         account={sendAccount}
         quote={quote}
         destination={destination}
         destinationDisplay={destinationDisplay}
+        destinationDetails={details}
       />
     );
   }

--- a/supabase/migrations/20250807005754_return-transaction-with-send-quotes.sql
+++ b/supabase/migrations/20250807005754_return-transaction-with-send-quotes.sql
@@ -1,0 +1,185 @@
+create or replace function wallet.create_cashu_send_quote(
+    p_user_id uuid,
+    p_account_id uuid,
+    p_currency text,
+    p_unit text,
+    p_payment_request text,
+    p_expires_at timestamp with time zone,
+    p_amount_requested numeric,
+    p_currency_requested text,
+    p_amount_requested_in_msat bigint,
+    p_amount_to_receive numeric,
+    p_lightning_fee_reserve numeric,
+    p_cashu_fee numeric,
+    p_quote_id text,
+    p_keyset_id text,
+    p_keyset_counter integer,
+    p_number_of_change_outputs integer,
+    p_proofs_to_send text,
+    p_account_version integer,
+    p_proofs_to_keep text,
+    p_encrypted_transaction_details text
+) returns wallet.create_cashu_send_quote_result
+language plpgsql
+as $function$
+declare
+    v_created_quote wallet.cashu_send_quotes;
+    v_updated_account wallet.accounts;
+    v_updated_counter integer;
+    v_transaction_id uuid;
+begin
+    -- calculate new counter value
+    v_updated_counter := p_keyset_counter + p_number_of_change_outputs;
+
+    -- create transaction record
+    insert into wallet.transactions (
+        user_id,
+        account_id,
+        direction,
+        type,
+        state,
+        currency,
+        encrypted_transaction_details
+    ) values (
+        p_user_id,
+        p_account_id,
+        'SEND',
+        'CASHU_LIGHTNING',
+        'PENDING',
+        p_currency,
+        p_encrypted_transaction_details
+    ) returning id into v_transaction_id;
+
+    -- insert the new cashu send quote
+    insert into wallet.cashu_send_quotes (
+        user_id,
+        account_id,
+        currency,
+        unit,
+        payment_request,
+        expires_at,
+        amount_requested,
+        currency_requested,
+        amount_requested_in_msat,
+        amount_to_receive,
+        lightning_fee_reserve,
+        cashu_fee,
+        quote_id,
+        proofs,
+        keyset_id,
+        keyset_counter,
+        number_of_change_outputs,
+        transaction_id
+    ) values (
+        p_user_id,
+        p_account_id,
+        p_currency,
+        p_unit,
+        p_payment_request,
+        p_expires_at,
+        p_amount_requested,
+        p_currency_requested,
+        p_amount_requested_in_msat,
+        p_amount_to_receive,
+        p_lightning_fee_reserve,
+        p_cashu_fee,
+        p_quote_id,
+        p_proofs_to_send,
+        p_keyset_id,
+        p_keyset_counter,
+        p_number_of_change_outputs,
+        v_transaction_id
+    )
+    returning * into v_created_quote;
+
+    -- update the account with optimistic concurrency check
+    update wallet.accounts
+    set details = jsonb_set(
+            jsonb_set(details, '{proofs}', to_jsonb(p_proofs_to_keep)),
+            array['keyset_counters', p_keyset_id],
+            to_jsonb(v_updated_counter),
+            true
+        ),
+        version = version + 1
+    where id = v_created_quote.account_id
+      and version = p_account_version
+    returning * into v_updated_account;
+
+    -- check if account was updated
+    if v_updated_account is null then
+        raise exception 'Concurrency error: Account % was modified by another transaction. Expected version %, but found different one.', v_created_quote.account_id, p_account_version;
+    end if;
+
+    return (v_created_quote, v_updated_account);
+end;
+$function$;
+
+create or replace function wallet.complete_cashu_send_quote(
+    p_quote_id uuid,
+    p_quote_version integer,
+    p_payment_preimage text,
+    p_amount_spent numeric,
+    p_account_proofs text,
+    p_account_version integer,
+    p_encrypted_transaction_details text
+) returns wallet.update_cashu_send_quote_result
+language plpgsql
+as $function$
+declare
+    v_updated_quote wallet.cashu_send_quotes;
+    v_updated_account wallet.accounts;
+    v_quote wallet.cashu_send_quotes;
+begin
+    -- Get the quote and check if it exists and its state
+    select * into v_quote
+    from wallet.cashu_send_quotes
+    where id = p_quote_id
+    for update;
+
+    if v_quote is null then
+        raise exception 'Cashu send quote with id % not found', p_quote_id;
+    end if;
+
+    if v_quote.state not in ('UNPAID', 'PENDING') then
+        raise exception 'Cannot complete cashu send quote with id %. Current state is %, but must be UNPAID or PENDING', p_quote_id, v_quote.state;
+    end if;
+
+    -- Update the quote with optimistic concurrency check
+    update wallet.cashu_send_quotes
+    set state = 'PAID',
+        payment_preimage = p_payment_preimage,
+        amount_spent = p_amount_spent,
+        version = version + 1
+    where id = p_quote_id
+      and version = p_quote_version
+    returning * into v_updated_quote;
+
+    -- Check if quote was updated
+    if v_updated_quote is null then
+        raise exception 'Concurrency error: Cashu send quote % was modified by another transaction. Expected version %, but found different one.', p_quote_id, p_quote_version;
+    end if;
+
+    -- Update the account with optimistic concurrency check
+    update wallet.accounts
+    set details = jsonb_set(details, '{proofs}', to_jsonb(p_account_proofs)),
+        version = version + 1
+    where id = v_quote.account_id
+      and version = p_account_version
+    returning * into v_updated_account;
+
+    -- Check if account was updated
+    if v_updated_account is null then
+        raise exception 'Concurrency error: Account % was modified by another transaction. Expected version %, but found different one.', v_quote.account_id, p_account_version;
+    end if;
+
+    -- Update the transaction state to COMPLETED
+    update wallet.transactions
+    set state = 'COMPLETED',
+        completed_at = now(),
+        encrypted_transaction_details = p_encrypted_transaction_details
+    where id = v_quote.transaction_id;
+
+    return (v_updated_quote, v_updated_account);
+end;
+$function$;
+


### PR DESCRIPTION
I started to update #538 to include the transaction on the send quote when we read the send quote, but then I realized the the realtime updates don't include the transaction. I think we will need to track transactions using realtime, then wait for latest transaction from the cache to create or update the send quote with the related transaction. For now I just refetch the send quote but this isn't ideal