### PR TITLE
simple-notifications alternative: join notifications onto each transaction

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -208,7 +208,9 @@ export type Database = MergeDeep<
             p_cursor_id?: string | null;
             p_page_size?: number;
           };
-          Returns: AgicashDbTransaction[];
+          Returns: (AgicashDbTransaction & {
+            notifications: AgicashDbNotification[];
+          })[];
         };
       };
       CompositeTypes: {

--- a/app/features/notifications/notification-hooks.ts
+++ b/app/features/notifications/notification-hooks.ts
@@ -14,38 +14,6 @@ import { useNotificationRepository } from './notification-repository';
 
 const notificationsQueryKey = 'notifications';
 
-/**
- * Returns a suspense query that returns all notifications of the given type.
- */
-export function useNotifications<
-  T extends NotificationType = NotificationType,
->(select: { type: T }): UseSuspenseQueryResult<Notification<T>[]> {
-  const notificationRepository = useNotificationRepository();
-  const userRef = useUserRef();
-
-  return useSuspenseQuery({
-    queryKey: [notificationsQueryKey, select.type],
-    queryFn: () =>
-      notificationRepository.list({
-        userId: userRef.current.id,
-        type: select.type,
-      }),
-    staleTime: 0,
-    refetchOnMount: 'always',
-    select: (data) =>
-      data.filter((n): n is Notification<T> => n.type === select.type),
-  });
-}
-
-export function useNotificationByTransactionId(transactionId: string) {
-  const notificationRepository = useNotificationRepository();
-
-  return useSuspenseQuery({
-    queryKey: [notificationsQueryKey, 'byTransactionId', transactionId],
-    queryFn: () => notificationRepository.getByTransactionId(transactionId),
-  });
-}
-
 export function useHasNotifications(select: {
   type: NotificationType;
 }): UseSuspenseQueryResult<boolean> {

--- a/app/features/notifications/notification-repository.ts
+++ b/app/features/notifications/notification-repository.ts
@@ -9,64 +9,8 @@ type Options = {
   abortSignal?: AbortSignal;
 };
 
-class NotificationRepository {
+export class NotificationRepository {
   constructor(private readonly db: AgicashDb) {}
-
-  /**
-   * Lists all notifications of the given type in descending order of creation date.
-   * If no type is provided, all notifications are returned.
-   */
-  async list(
-    { userId, type }: { userId: string; type?: NotificationType },
-    options?: Options,
-  ): Promise<Notification[]> {
-    const query = this.db
-      .from('notifications')
-      .select('*')
-      .eq('user_id', userId)
-      .order('created_at', { ascending: false });
-    if (type) {
-      query.eq('type', type);
-    }
-
-    if (options?.abortSignal) {
-      query.abortSignal(options.abortSignal);
-    }
-
-    const { data, error } = await query;
-    if (error) {
-      throw new Error('Failed to list notifications.', { cause: error });
-    }
-
-    return data.map(this.toNotification);
-  }
-
-  async getByTransactionId(
-    transactionId: string,
-    options?: Options,
-  ): Promise<Notification | null> {
-    const query = this.db
-      .from('notifications')
-      .select('*')
-      .limit(1)
-      .eq('transaction_id', transactionId);
-    if (options?.abortSignal) {
-      query.abortSignal(options.abortSignal);
-    }
-
-    const { data, error } = await query;
-    if (error) {
-      throw new Error('Failed to get notification by transaction id.', {
-        cause: error,
-      });
-    }
-
-    if (data.length === 0) {
-      return null;
-    }
-
-    return this.toNotification(data[0]);
-  }
 
   /**
    * Checks if the user has any notifications of the given type.

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -28,10 +28,7 @@ import type {
 import { useToast } from '~/hooks/use-toast';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { useAccount } from '../accounts/account-hooks';
-import {
-  useDeleteNotification,
-  useNotificationByTransactionId,
-} from '../notifications/notification-hooks';
+import { useDeleteNotification } from '../notifications/notification-hooks';
 import { getDefaultUnit } from '../shared/currencies';
 import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
@@ -120,14 +117,19 @@ export function TransactionDetails({
     },
   });
 
-  const { data: notification } = useNotificationByTransactionId(transaction.id);
   const { mutate: deleteNotification } = useDeleteNotification();
+  const paymentReceivedNotification = transaction.notifications.find(
+    (notification) => notification.type === 'PAYMENT_RECEIVED',
+  );
 
   useEffect(() => {
-    if (notification && ['COMPLETED', 'REVERSED'].includes(transaction.state)) {
-      deleteNotification({ notificationId: notification.id });
+    if (
+      paymentReceivedNotification &&
+      ['COMPLETED', 'REVERSED'].includes(transaction.state)
+    ) {
+      deleteNotification({ notificationId: paymentReceivedNotification.id });
     }
-  }, [notification, transaction.state, deleteNotification]);
+  }, [paymentReceivedNotification, transaction.state, deleteNotification]);
 
   const isWaitingForStateUpdate =
     didReclaimMutationSucceed &&

--- a/app/features/transactions/transaction-hooks.ts
+++ b/app/features/transactions/transaction-hooks.ts
@@ -169,8 +169,25 @@ function useOnTransactionChange({
           payload: RealtimePostgresChangesPayload<AgicashDbTransaction>,
         ) => {
           if (payload.eventType === 'UPDATE') {
+            // TODO: can we get the notification from the event object instead?
+            const { data: notifications, error } = await agicashDb
+              .from('notifications')
+              .select('*')
+              .eq('transaction_id', payload.new.id);
+            if (error) {
+              throw new Error(
+                'Failed to get notifications by transaction id.',
+                {
+                  cause: error,
+                },
+              );
+            }
+
             const updatedTransaction =
-              await transactionRepository.toTransaction(payload.new);
+              await transactionRepository.toTransaction({
+                ...payload.new,
+                notifications,
+              });
             onUpdatedRef.current(updatedTransaction);
           }
         },

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -3,10 +3,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { Card } from '~/components/ui/card';
 import { ScrollArea } from '~/components/ui/scroll-area';
 import { LinkWithViewTransition } from '~/lib/transitions';
-import {
-  useDeleteAllNotificationsByType,
-  useNotifications,
-} from '../notifications/notification-hooks';
+import { useDeleteAllNotificationsByType } from '../notifications/notification-hooks';
 import { getDefaultUnit } from '../shared/currencies';
 import type { Transaction } from './transaction';
 import { useTransactions } from './transaction-hooks';
@@ -229,9 +226,6 @@ export function TransactionList() {
     status,
   } = useTransactions();
 
-  const { data: notifications } = useNotifications({
-    type: 'PAYMENT_RECEIVED',
-  });
   const { mutate: deleteAllNotifications } = useDeleteAllNotificationsByType({
     type: 'PAYMENT_RECEIVED',
   });
@@ -245,16 +239,22 @@ export function TransactionList() {
   const allTransactions =
     data?.pages.flatMap((page) => page.transactions) ?? [];
 
-  const notificationTransactionIds = new Set(
-    notifications.map((notification) => notification.transactionId),
+  const paymentReceivedTransactionIds = new Set(
+    allTransactions
+      .filter((transaction) =>
+        transaction.notifications.some(
+          (notification) => notification.type === 'PAYMENT_RECEIVED',
+        ),
+      )
+      .map((transaction) => transaction.id),
   );
 
   const extendedTransactions = useMemo(() => {
     return allTransactions.map((transaction) => ({
       ...transaction,
-      hasNotification: notificationTransactionIds.has(transaction.id),
+      hasNotification: paymentReceivedTransactionIds.has(transaction.id),
     }));
-  }, [allTransactions, notificationTransactionIds]);
+  }, [allTransactions, paymentReceivedTransactionIds]);
 
   const {
     pendingTransactions,

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -1,4 +1,5 @@
 import type { Money } from '~/lib/money';
+import type { Notification } from '../notifications/notification';
 
 /**
  * Transacion details for sending cashu proofs from an account.
@@ -195,6 +196,10 @@ export type Transaction = {
    * Transaction details.
    */
   details: object;
+  /**
+   * Notifications for the transaction.
+   */
+  notifications: Notification[];
   /**
    * ID of the transaction that is reversed by this transaction.
    */

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -972,23 +972,7 @@ export type Database = {
           p_page_size?: number
           p_user_id: string
         }
-        Returns: {
-          account_id: string
-          completed_at: string | null
-          created_at: string
-          currency: string
-          direction: string
-          encrypted_transaction_details: string
-          failed_at: string | null
-          id: string
-          pending_at: string | null
-          reversed_at: string | null
-          reversed_transaction_id: string | null
-          state: string
-          state_sort_order: number | null
-          type: string
-          user_id: string
-        }[]
+        Returns: Database["wallet"]["CompositeTypes"]["transaction_with_notifications"][]
       }
       process_cashu_receive_quote_payment: {
         Args: {
@@ -1032,6 +1016,26 @@ export type Database = {
           | Database["wallet"]["Tables"]["cashu_send_quotes"]["Row"]
           | null
         updated_account: Database["wallet"]["Tables"]["accounts"]["Row"] | null
+      }
+      transaction_with_notifications: {
+        id: string | null
+        user_id: string | null
+        direction: string | null
+        type: string | null
+        state: string | null
+        account_id: string | null
+        currency: string | null
+        created_at: string | null
+        pending_at: string | null
+        completed_at: string | null
+        failed_at: string | null
+        reversed_transaction_id: string | null
+        reversed_at: string | null
+        state_sort_order: number | null
+        encrypted_transaction_details: string | null
+        notifications:
+          | Database["wallet"]["Tables"]["notifications"]["Row"][]
+          | null
       }
       update_cashu_send_quote_result: {
         updated_quote:

--- a/supabase/migrations/20250805212400_add_notifications.sql
+++ b/supabase/migrations/20250805212400_add_notifications.sql
@@ -98,3 +98,120 @@ when (
   and new.direction = 'RECEIVE'
 )
 execute function wallet.fn_create_notification_on_receive_completed();
+
+-- add index for lookup by transaction_id used during reversals
+create index idx_notifications_transaction_id on wallet.notifications (transaction_id);
+
+-- Create a composite type to return transaction with its notifications
+-- This uses the actual column types from the transactions table
+create type wallet.transaction_with_notifications as (
+  id uuid,
+  user_id uuid,
+  direction text,
+  type text,
+  state text,
+  account_id uuid,
+  currency text,
+  created_at timestamptz,
+  pending_at timestamptz,
+  completed_at timestamptz,
+  failed_at timestamptz,
+  reversed_transaction_id uuid,
+  reversed_at timestamptz,
+  state_sort_order integer,
+  encrypted_transaction_details text,
+  notifications wallet.notifications[] -- Array of notification records (null if no notifications)
+);
+
+-- Drop the existing function since we're changing its return type
+drop function if exists wallet.list_transactions(uuid, integer, timestamptz, uuid, integer);
+
+-- Function to list user transactions with pagination and notifications
+-- Updated to return both transactions and their associated notifications in a single query
+create or replace function wallet.list_transactions(
+  p_user_id uuid,
+  p_cursor_state_sort_order integer default null,
+  p_cursor_created_at timestamptz default null,
+  p_cursor_id uuid default null,
+  p_page_size integer default 25
+)
+returns setof wallet.transaction_with_notifications
+language plpgsql
+stable
+security definer
+as $$
+begin
+  -- Check if cursor data is provided
+  if p_cursor_created_at is null then
+    -- Initial page load (no cursor)
+    return query
+          select 
+        -- Return individual transaction fields to match composite type
+        t.id,
+        t.user_id,
+        t.direction,
+        t.type,
+        t.state,
+        t.account_id,
+        t.currency,
+        t.created_at,
+        t.pending_at,
+        t.completed_at,
+        t.failed_at,
+        t.reversed_transaction_id,
+        t.reversed_at,
+        t.state_sort_order,
+        t.encrypted_transaction_details,
+        -- Aggregate all notifications for this transaction into an array
+        -- Uses filter to exclude null notifications (when no notifications exist)
+        array_agg(n.*::wallet.notifications) filter (where n.id is not null) as notifications
+    from wallet.transactions t
+    -- LEFT JOIN ensures we get transactions even if they have no notifications
+    left join wallet.notifications n on t.id = n.transaction_id
+    where t.user_id = p_user_id
+      and t.state in ('PENDING', 'COMPLETED', 'REVERSED')
+          -- GROUP BY all transaction fields to enable aggregation of notifications
+      group by t.id, t.user_id, t.direction, t.type, t.state, t.account_id, t.currency, 
+               t.created_at, t.pending_at, t.completed_at, t.failed_at, t.reversed_transaction_id, 
+               t.reversed_at, t.state_sort_order, t.encrypted_transaction_details
+    order by t.state_sort_order desc, t.created_at desc, t.id desc
+    limit p_page_size;
+  else
+    -- Subsequent pages (with cursor)
+    return query
+          select 
+        -- Same structure as above but with cursor filtering
+        t.id,
+        t.user_id,
+        t.direction,
+        t.type,
+        t.state,
+        t.account_id,
+        t.currency,
+        t.created_at,
+        t.pending_at,
+        t.completed_at,
+        t.failed_at,
+        t.reversed_transaction_id,
+        t.reversed_at,
+        t.state_sort_order,
+        t.encrypted_transaction_details,
+        array_agg(n.*::wallet.notifications) filter (where n.id is not null) as notifications
+    from wallet.transactions t
+    left join wallet.notifications n on t.id = n.transaction_id
+    where t.user_id = p_user_id
+      and t.state in ('PENDING', 'COMPLETED', 'REVERSED')
+      -- Cursor-based pagination using composite comparison for consistent ordering
+      and (t.state_sort_order, t.created_at, t.id) < (
+        p_cursor_state_sort_order,
+        p_cursor_created_at,
+        p_cursor_id
+      )
+          group by t.id, t.user_id, t.direction, t.type, t.state, t.account_id, t.currency, 
+               t.created_at, t.pending_at, t.completed_at, t.failed_at, t.reversed_transaction_id, 
+               t.reversed_at, t.state_sort_order, t.encrypted_transaction_details
+    order by t.state_sort_order desc, t.created_at desc, t.id desc
+    limit p_page_size;
+  end if;
+end;
+$$;


### PR DESCRIPTION
   Here's an alternative to #558 where I try to read the notifications for each transaction when we read the transaction. This way all transactions have all related notifications.

   I'm not sure if we want to couple transactions with notifications like this; however, I am thinking most other notifications will be related to some other entity.

   For example, a stuck send. If we flag a send as stuck, then we can trigger a notification referencing that send's id. Then when the user views the stuck send, they would see the send transactions data and a notification  with some instructions. They would also see this notification in a notification list feature.

   A notification that would not be related to another entity might be something like a new feature announcement.