### PR TITLE
Don't take lead if in background

### DIFF
--- a/app/features/wallet/task-processing.ts
+++ b/app/features/wallet/task-processing.ts
@@ -35,7 +35,7 @@ export const useTakeTaskProcessingLead = () => {
       return taskProcessingLockRepository.takeLead(userId, clientId);
     },
     refetchInterval: 5000,
-    refetchIntervalInBackground: true,
+    refetchIntervalInBackground: false,
   });
 
   useEffect(() => {


### PR DESCRIPTION
We need to stop trying to take a lead to make sure current lead yields when in background. This is needed because while in background the lead will not be getting updates from the db because supabase socket connection gets closed. Thus lead can work fine only when in foreground.