### PR TITLE
fix send swap recovery secret decoding error

### DIFF
--- a/app/features/send/cashu-send-swap-service.ts
+++ b/app/features/send/cashu-send-swap-service.ts
@@ -15,7 +15,6 @@ import {
   sumProofs,
 } from '~/lib/cashu';
 import { Money } from '~/lib/money';
-import { uint8ArrayToHex } from '~/lib/utils';
 import {
   type CashuTokenSwapService,
   useCashuTokenSwapService,
@@ -464,12 +463,17 @@ export class CashuSendSwapService {
           },
         );
 
+        const textDecoder = new TextDecoder();
         return {
           send: proofs.filter((o) =>
-            outputData.send.some((s) => uint8ArrayToHex(s.secret) === o.secret),
+            outputData.send.some(
+              (s) => textDecoder.decode(s.secret) === o.secret,
+            ),
           ),
           keep: proofs.filter((o) =>
-            outputData.keep.some((s) => uint8ArrayToHex(s.secret) === o.secret),
+            outputData.keep.some(
+              (s) => textDecoder.decode(s.secret) === o.secret,
+            ),
           ),
         };
       }


### PR DESCRIPTION
Fixes #587 

It looks like at some point cashu-ts change the way secrets are encoded. Now they are UTF-8 encoded, so our recovery logic was failing because we were decoding as a 64-byte UINT8-Array.

UPDATE: I searched for the commit that changed this and the only thing I can find is [this](https://github.com/cashubtc/cashu-ts/commit/94cea43e7fa3a52ab10168ac50312100de075960) from January so maybe it never worked. Regardless, you can see the current implementation encodes secrets as UTF-8 [here](https://github.com/cashubtc/cashu-ts/blob/main/src/model/OutputData.ts#L179)