### PR TITLE
feat: add transaction details page

### DIFF
--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -400,6 +400,30 @@ export class CashuReceiveQuoteRepository {
     return data ? CashuReceiveQuoteRepository.toQuote(data) : null;
   }
 
+  async getByTransactionId(
+    transactionId: string,
+    options?: Options,
+  ): Promise<CashuReceiveQuote | null> {
+    const query = this.db
+      .from('cashu_receive_quotes')
+      .select()
+      .eq('transaction_id', transactionId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      throw new Error('Failed to get cashu receive quote by transaction id', {
+        cause: error,
+      });
+    }
+
+    return data ? CashuReceiveQuoteRepository.toQuote(data) : null;
+  }
+
   /**
    * Gets all pending (unpaid or expired) cashu receive quotes for the given user.
    * @param userId - The id of the user to get the cashu receive quotes for.

--- a/app/features/receive/cashu-token-swap-repository.ts
+++ b/app/features/receive/cashu-token-swap-repository.ts
@@ -250,6 +250,32 @@ export class CashuTokenSwapRepository {
     }
   }
 
+  async getByTransactionId(
+    transactionId: string,
+    options?: Options,
+  ): Promise<CashuTokenSwap | null> {
+    const query = this.db
+      .from('cashu_token_swaps')
+      .select()
+      .eq('transaction_id', transactionId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      throw new Error('Failed to get cashu token swap by transaction id', {
+        cause: error,
+      });
+    }
+
+    return data
+      ? CashuTokenSwapRepository.toTokenSwap(data, this.encryption.decrypt)
+      : null;
+  }
+
   /**
    * Gets all pending token swaps for a given user.
    * @returns All token swaps in a PENDING state for the given user.

--- a/app/features/send/cashu-send-quote-repository.ts
+++ b/app/features/send/cashu-send-quote-repository.ts
@@ -464,6 +464,32 @@ export class CashuSendQuoteRepository {
       : null;
   }
 
+  async getByTransactionId(
+    transactionId: string,
+    options?: Options,
+  ): Promise<CashuSendQuote | null> {
+    const query = this.db
+      .from('cashu_send_quotes')
+      .select()
+      .eq('transaction_id', transactionId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      throw new Error('Failed to get cashu send quote by transaction id', {
+        cause: error,
+      });
+    }
+
+    return data
+      ? CashuSendQuoteRepository.toSend(data, this.encryption.decrypt)
+      : null;
+  }
+
   /**
    * Gets all unresolved (UNPAID or PENDING) cashu send quotes for the given user.
    * @param userId - The id of the user to get the cashu send quotes for.

--- a/app/features/transactions/transaction-additional-details.tsx
+++ b/app/features/transactions/transaction-additional-details.tsx
@@ -1,0 +1,231 @@
+import { CheckStateEnum, type Proof } from '@cashu/cashu-ts';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import {
+  Page,
+  PageBackButton,
+  PageContent,
+  PageHeader,
+  PageHeaderTitle,
+} from '~/components/page';
+import { ScrollArea } from '~/components/ui/scroll-area';
+import { proofToY } from '~/lib/cashu';
+import type { CashuAccount } from '../accounts/account';
+import { useAccount } from '../accounts/account-hooks';
+import { useCashuReceiveQuoteRepository } from '../receive/cashu-receive-quote-repository';
+import { useCashuTokenSwapRepository } from '../receive/cashu-token-swap-repository';
+import { useCashuSendQuoteRepository } from '../send/cashu-send-quote-repository';
+import { useCashuSendSwapRepository } from '../send/cashu-send-swap-repository';
+import type { Transaction } from './transaction';
+import { useSuspenseTransaction } from './transaction-hooks';
+
+const augmentProofsWithState = (
+  proofs: Proof[],
+  states: Map<string, CheckStateEnum>,
+) => {
+  return proofs.map((p) => ({
+    ...p,
+    state: states.get(proofToY(p)) ?? CheckStateEnum.PENDING,
+  }));
+};
+
+const useProofStates = (
+  transactionId: string,
+  account: CashuAccount,
+  proofs: Proof[],
+) => {
+  const { data: states } = useSuspenseQuery({
+    queryKey: ['transaction-proof-states', transactionId],
+    queryFn: () => account.wallet.checkProofsStates(proofs),
+    select: (states) => {
+      const map = new Map<string, CheckStateEnum>();
+      states.forEach((s) => map.set(s.Y, s.state));
+      return map;
+    },
+  });
+  return states;
+};
+
+function DetailsDisplay({ data }: { data: unknown }) {
+  return (
+    <div className="space-y-4">
+      <pre className="whitespace-pre-wrap break-all text-xs">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+function LightningSendDetails({
+  account,
+  transaction,
+}: { account: CashuAccount; transaction: Transaction }) {
+  const repository = useCashuSendQuoteRepository();
+
+  const { data: sendQuote } = useSuspenseQuery({
+    queryKey: ['transaction-details', transaction.id],
+    queryFn: async () => {
+      const quote = await repository.getByTransactionId(transaction.id);
+      if (!quote) {
+        throw new Error('No send quote found for transaction');
+      }
+      return quote;
+    },
+  });
+
+  const states = useProofStates(transaction.id, account, sendQuote.proofs);
+
+  const data = useMemo(() => {
+    return {
+      ...sendQuote,
+      proofs: augmentProofsWithState(sendQuote.proofs, states),
+    };
+  }, [sendQuote, states]);
+
+  return <DetailsDisplay data={data} />;
+}
+
+function LightningReceiveDetails({
+  transaction,
+}: { transaction: Transaction }) {
+  const repository = useCashuReceiveQuoteRepository();
+
+  const { data } = useSuspenseQuery({
+    queryKey: ['transaction-details', transaction.id],
+    queryFn: async () => {
+      const quote = await repository.getByTransactionId(transaction.id);
+      if (!quote) {
+        throw new Error('No receive quote found for transaction');
+      }
+      return quote;
+    },
+  });
+
+  return <DetailsDisplay data={data} />;
+}
+
+function CashuTokenSendDetails({
+  account,
+  transaction,
+}: { account: CashuAccount; transaction: Transaction }) {
+  const repository = useCashuSendSwapRepository();
+
+  const { data: swap } = useSuspenseQuery({
+    queryKey: ['transaction-details', transaction.id],
+    queryFn: async () => {
+      const swap = await repository.getByTransactionId(transaction.id);
+      if (!swap) {
+        throw new Error('No send swap found for transaction');
+      }
+      return swap;
+    },
+  });
+
+  const allProofs = swap.inputProofs.concat(
+    'proofsToSend' in swap ? swap.proofsToSend : [],
+  );
+  const states = useProofStates(transaction.id, account, allProofs);
+
+  const data = useMemo(() => {
+    return {
+      ...swap,
+      inputProofs: augmentProofsWithState(swap.inputProofs, states),
+      ...('proofsToSend' in swap
+        ? { proofsToSend: augmentProofsWithState(swap.proofsToSend, states) }
+        : {}),
+    };
+  }, [swap, states]);
+
+  return <DetailsDisplay data={data} />;
+}
+
+function CashuTokenReceiveDetails({
+  account,
+  transaction,
+}: { account: CashuAccount; transaction: Transaction }) {
+  const repository = useCashuTokenSwapRepository();
+
+  const { data: swap } = useSuspenseQuery({
+    queryKey: ['transaction-details', transaction.id],
+    queryFn: async () => {
+      const swap = await repository.getByTransactionId(transaction.id);
+      if (!swap) {
+        throw new Error('No token swap found for transaction');
+      }
+      return swap;
+    },
+  });
+
+  const states = useProofStates(transaction.id, account, swap.tokenProofs);
+
+  const data = useMemo(() => {
+    return {
+      ...swap,
+      tokenProofs: augmentProofsWithState(swap.tokenProofs, states),
+    };
+  }, [swap, states]);
+
+  return <DetailsDisplay data={data} />;
+}
+
+const getDetails = (transaction: Transaction, account: CashuAccount) => {
+  if (
+    transaction.type === 'CASHU_LIGHTNING' &&
+    transaction.direction === 'SEND'
+  ) {
+    return <LightningSendDetails account={account} transaction={transaction} />;
+  }
+  if (transaction.type === 'CASHU_TOKEN' && transaction.direction === 'SEND') {
+    return (
+      <CashuTokenSendDetails account={account} transaction={transaction} />
+    );
+  }
+  if (
+    transaction.type === 'CASHU_LIGHTNING' &&
+    transaction.direction === 'RECEIVE'
+  ) {
+    return <LightningReceiveDetails transaction={transaction} />;
+  }
+  if (
+    transaction.type === 'CASHU_TOKEN' &&
+    transaction.direction === 'RECEIVE'
+  ) {
+    return (
+      <CashuTokenReceiveDetails account={account} transaction={transaction} />
+    );
+  }
+  return <div>Unknown transaction type</div>;
+};
+
+export function TransactionAdditionalDetails({
+  transactionId,
+}: { transactionId: string }) {
+  const { data: transaction } = useSuspenseTransaction(transactionId);
+  const account = useAccount(transaction.accountId);
+
+  if (account.type !== 'cashu') {
+    return <div>Account is not a cashu account</div>;
+  }
+
+  const details = getDetails(transaction, account);
+
+  return (
+    <Page>
+      <PageHeader className="z-10">
+        <PageBackButton
+          to={`/transactions/${transactionId}`}
+          transition="slideRight"
+          applyTo="oldView"
+        />
+        <PageHeaderTitle>Txn Details</PageHeaderTitle>
+      </PageHeader>
+      <PageContent className="overflow-hidden">
+        <ScrollArea className="h-full">
+          <div className="mb-2 text-xs">type: {transaction.type}</div>
+          <div className="mb-2 text-xs">direction: {transaction.direction}</div>
+          {details}
+        </ScrollArea>
+      </PageContent>
+    </Page>
+  );
+}

--- a/app/routes/_protected.transactions.$transactionId.details.tsx
+++ b/app/routes/_protected.transactions.$transactionId.details.tsx
@@ -1,0 +1,8 @@
+import { TransactionAdditionalDetails } from '~/features/transactions/transaction-additional-details';
+import type { Route } from './+types/_protected.transactions.$transactionId.details';
+
+export default function TransactionDetailsPage({
+  params: { transactionId },
+}: Route.ComponentProps) {
+  return <TransactionAdditionalDetails transactionId={transactionId} />;
+}

--- a/app/routes/_protected.transactions.$transactionId_.tsx
+++ b/app/routes/_protected.transactions.$transactionId_.tsx
@@ -7,7 +7,7 @@ import {
 } from '~/components/page';
 import { TransactionDetails } from '~/features/transactions/transaction-details';
 import { useSuspenseTransaction } from '~/features/transactions/transaction-hooks';
-import type { Route } from './+types/_protected.transactions.$transactionId';
+import type { Route } from './+types/_protected.transactions.$transactionId_';
 
 export default function TransactionDetailsPage({
   params: { transactionId },


### PR DESCRIPTION
Adds transaction details page for debugging purposes. The page displays related send/receive entity and augments its proofs with the current mint state.


------
https://chatgpt.com/codex/tasks/task_b_68b73774e900832fb2903026de75e6c6