### PR TITLE
use correct source wallet for cross account claims

### DIFF
--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -332,7 +332,7 @@ export function useReceiveCashuTokenAccounts(
     selectableAccounts,
     receiveAccount,
     isCrossMintSwapDisabled,
-    sourceAccount: selectableAccounts.find((a) => a.id === sourceAccount.id),
+    sourceAccount: selectableAccounts[0],
     setReceiveAccount,
     addAndSetReceiveAccount,
   };
@@ -343,6 +343,11 @@ type CreateCrossAccountReceiveQuotesProps = {
   token: Token;
   /** The account to claim the token to */
   account: CashuAccount;
+  /**
+   * The account to claim the token from.
+   * This may be a placeholder account if the token is from a mint that we do not have an account for.
+   */
+  sourceAccount: CashuAccount;
 };
 
 /**
@@ -359,6 +364,7 @@ export function useCreateCrossAccountReceiveQuotes() {
     mutationFn: async ({
       token,
       account,
+      sourceAccount,
     }: CreateCrossAccountReceiveQuotesProps) => {
       const tokenCurrency = tokenToMoney(token).currency;
       const accountCurrency = account.currency;
@@ -370,7 +376,8 @@ export function useCreateCrossAccountReceiveQuotes() {
         await receiveCashuTokenService.createCrossAccountReceiveQuotes({
           userId,
           token,
-          account,
+          sourceAccount,
+          destinationAccount: account,
           exchangeRate,
         });
 

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -172,7 +172,11 @@ export default function ReceiveToken({
         onTransactionCreated(transactionId);
       } else {
         const { sourceWallet, cashuMeltQuote, cashuReceiveQuote } =
-          await createCrossAccountReceiveQuotes({ token, account });
+          await createCrossAccountReceiveQuotes({
+            token,
+            account,
+            sourceAccount,
+          });
         onTransactionCreated(cashuReceiveQuote.transactionId);
         await sourceWallet.meltProofs(cashuMeltQuote, token.proofs);
       }


### PR DESCRIPTION
I introduced a bug when we refactored the accounts to include the cashu wallet on them. When doing a cross account claim we were trying to get fees for for proofs using the wallet to claim the proofs to when we should have been using a wallet with the mint the proofs were from.