### PR TITLE
Increase duration of the toast for auto claim error

### DIFF
--- a/app/routes/_protected.receive.cashu_.token.tsx
+++ b/app/routes/_protected.receive.cashu_.token.tsx
@@ -107,6 +107,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
         title: 'Failed to claim the token',
         description: result.message,
         variant: 'destructive',
+        duration: 8000,
       });
     }
     throw redirect('/');


### PR DESCRIPTION
Small ui change to make sure that user sees the error message. This is an edge case though and shouldn't be happening often.