### PR TITLE
transition after realtime updates are received

### DIFF
--- a/app/features/receive/cashu-token-swap-hooks.ts
+++ b/app/features/receive/cashu-token-swap-hooks.ts
@@ -102,7 +102,6 @@ export function useCashuTokenSwapCache() {
 export function useCreateCashuTokenSwap() {
   const userId = useUser((user) => user.id);
   const tokenSwapService = useCashuTokenSwapService();
-  const tokenSwapCache = useCashuTokenSwapCache();
   const getLatestAccount = useGetLatestCashuAccount();
 
   return useMutation({
@@ -117,9 +116,6 @@ export function useCreateCashuTokenSwap() {
         token,
         account,
       });
-    },
-    onSuccess: async ({ tokenSwap }) => {
-      tokenSwapCache.add(tokenSwap);
     },
   });
 }

--- a/app/features/receive/receive-cashu.tsx
+++ b/app/features/receive/receive-cashu.tsx
@@ -18,7 +18,8 @@ import {
   useNavigateWithViewTransition,
 } from '~/lib/transitions';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
-import type { CashuReceiveQuote } from './cashu-receive-quote';
+import type { Transaction } from '../transactions/transaction';
+import { useTrackTransaction } from '../transactions/transaction-hooks';
 import {
   useCashuReceiveQuote,
   useCreateCashuReceiveQuote,
@@ -27,7 +28,7 @@ import {
 type MintQuoteProps = {
   account: CashuAccount;
   amount: Money;
-  onPaid: (quote: CashuReceiveQuote) => void;
+  onPaid: (quote: Transaction) => void;
   onCopy?: (paymentRequest: string) => void;
 };
 
@@ -46,7 +47,11 @@ function MintQuoteCarouselItem({
 
   const { quote, status: quotePaymentStatus } = useCashuReceiveQuote({
     quoteId: createdQuote?.id,
-    onPaid: onPaid,
+  });
+
+  useTrackTransaction({
+    transactionId: createdQuote?.transactionId,
+    onCompleted: onPaid,
   });
 
   const isExpired = quotePaymentStatus === 'EXPIRED';
@@ -112,9 +117,9 @@ export default function ReceiveCashu({ amount, account }: Props) {
         <MintQuoteCarouselItem
           account={account}
           amount={amount}
-          onPaid={(quote) => {
-            navigate(`/transactions/${quote.transactionId}?redirectTo=/`, {
-              transition: 'fade',
+          onPaid={(transaction) => {
+            navigate(`/transactions/${transaction.id}?redirectTo=/`, {
+              transition: 'slideLeft',
               applyTo: 'newView',
             });
           }}

--- a/app/features/send/cashu-send-quote-hooks.ts
+++ b/app/features/send/cashu-send-quote-hooks.ts
@@ -150,7 +150,6 @@ export function useInitiateCashuSendQuote({
 }: { onError: (error: Error) => void }) {
   const userId = useUser((user) => user.id);
   const cashuSendQuoteService = useCashuSendQuoteService();
-  const cashuSendQuoteCache = useCashuSendQuoteCache();
   const getCashuAccount = useGetLatestCashuAccount();
 
   return useMutation({
@@ -174,9 +173,6 @@ export function useInitiateCashuSendQuote({
         sendQuote,
         destinationDetails,
       });
-    },
-    onSuccess: (data) => {
-      cashuSendQuoteCache.add(data);
     },
     onError: onError,
     retry: (failureCount, error) => {

--- a/app/features/send/cashu-send-swap-hooks.ts
+++ b/app/features/send/cashu-send-swap-hooks.ts
@@ -129,16 +129,13 @@ export function useGetCashuSendSwapQuote() {
 }
 
 export function useCreateCashuSendSwap({
-  onSuccess,
   onError,
 }: {
-  onSuccess: (swap: CashuSendSwap) => void;
-  onError: (error: Error) => void;
+  onError?: (error: Error) => void;
 }) {
   const cashuSendSwapService = useCashuSendSwapService();
   const userId = useUser((user) => user.id);
   const getLatestCashuAccount = useGetLatestCashuAccount();
-  const cashuSendSwapCache = useCashuSendSwapCache();
 
   return useMutation({
     mutationFn: async ({
@@ -157,10 +154,6 @@ export function useCreateCashuSendSwap({
         account,
         senderPaysFee,
       });
-    },
-    onSuccess: (swap) => {
-      cashuSendSwapCache.add(swap);
-      onSuccess(swap);
     },
     onError: onError,
   });
@@ -259,7 +252,7 @@ export function useTrackCashuSendSwap({
 
   const { data } = useQuery({
     queryKey: [CashuSendSwapCache.Key, id],
-    queryFn: () => cashuSendSwapCache.get(id),
+    queryFn: () => cashuSendSwapCache.get(id) ?? null,
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
@@ -352,6 +345,7 @@ export function useCashuSendSwapChangeHandler() {
         encryption.decrypt,
       );
       unresolvedSwapsCache.add(swap);
+      cashuSendSwapCache.add(swap);
     },
     onUpdate: async (payload: AgicashDbCashuSendSwap) => {
       const swap = await CashuSendSwapRepository.toSwap(


### PR DESCRIPTION
# Fixes: 
## "When Receiving, the screen quickly flashes when you claim (not the first time, but after a few times it starts flashing)" 

### What was happening

There would occasionally be a glitch in the navigation when going from the receive-cashu-token view to the pending transaction details due to us transitioning the the tx details as soon as the creation mutation completed rather than waiting for us to get a realtime update that the transaction was created.

### What I changed

- I made it so that we do not navigate to the transaction details page until our realtime update adds the new row to our cache.  
- We no longer add new items to our cache on mutation success because we now expect to get the item from the cache after the realtime INSERT event comes
- I then did this same thing to all send and receive types so that by the time navigation occurs we know everything is loaded before trying to show that item