### PR TITLE
handle offline mints in the UI

### DIFF
--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -1,7 +1,13 @@
-import type { Proof } from '@cashu/cashu-ts';
+import {
+  type MintActiveKeys,
+  type MintAllKeysets,
+  NetworkError,
+  type Proof,
+} from '@cashu/cashu-ts';
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
 import {
+  type MintInfo,
   getCashuProtocolUnit,
   getCashuUnit,
   getCashuWallet,
@@ -24,7 +30,10 @@ import type { Account, CashuAccount } from './account';
 type AccountOmit<
   T extends Account,
   AdditionalOmit extends keyof T = never,
-> = DistributedOmit<T, 'id' | 'createdAt' | 'version' | AdditionalOmit>;
+> = DistributedOmit<
+  T,
+  'id' | 'createdAt' | 'version' | 'isOnline' | AdditionalOmit
+>;
 
 type AccountInput<T extends Account> = {
   userId: string;
@@ -155,13 +164,14 @@ export class AccountRepository {
         proofs: string;
       };
 
-      const wallet = await this.getPreloadedWallet(
+      const { wallet, isOnline } = await this.getPreloadedWallet(
         details.mint_url,
         data.currency,
       );
 
       return {
         ...commonData,
+        isOnline,
         type: 'cashu',
         mintUrl: details.mint_url,
         isTestMint: details.is_test_mint,
@@ -186,13 +196,26 @@ export class AccountRepository {
   private async getPreloadedWallet(mintUrl: string, currency: Currency) {
     const seed = await this.getCashuWalletSeed?.();
 
-    // TODO: handle fetching errors. If the mint is unreachable these will throw,
-    // and the error will bubble up to the user and brick the app.
-    const [mintInfo, allMintKeysets, mintActiveKeys] = await Promise.all([
-      this.queryClient.fetchQuery(mintInfoQueryOptions(mintUrl)),
-      this.queryClient.fetchQuery(allMintKeysetsQueryOptions(mintUrl)),
-      this.queryClient.fetchQuery(mintKeysQueryOptions(mintUrl)),
-    ]);
+    let mintInfo: MintInfo;
+    let allMintKeysets: MintAllKeysets;
+    let mintActiveKeys: MintActiveKeys;
+
+    try {
+      [mintInfo, allMintKeysets, mintActiveKeys] = await Promise.all([
+        this.queryClient.fetchQuery(mintInfoQueryOptions(mintUrl)),
+        this.queryClient.fetchQuery(allMintKeysetsQueryOptions(mintUrl)),
+        this.queryClient.fetchQuery(mintKeysQueryOptions(mintUrl)),
+      ]);
+    } catch (error) {
+      if (error instanceof NetworkError) {
+        const wallet = getCashuWallet(mintUrl, {
+          unit: getCashuUnit(currency),
+          bip39seed: seed ?? undefined,
+        });
+        return { wallet, isOnline: false };
+      }
+      throw error;
+    }
 
     const unitKeysets = allMintKeysets.keysets.filter(
       (ks) => ks.unit === getCashuProtocolUnit(currency),
@@ -224,7 +247,7 @@ export class AccountRepository {
     // The constructor does not set the keysetId, so we need to set it manually
     wallet.keysetId = activeKeyset.id;
 
-    return wallet;
+    return { wallet, isOnline: true };
   }
 }
 

--- a/app/features/accounts/account-selector.tsx
+++ b/app/features/accounts/account-selector.tsx
@@ -14,14 +14,33 @@ import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount'
 import { type Account, getAccountBalance } from './account';
 import { AccountTypeIcon } from './account-icons';
 
-export type AccountWithBadges<T extends Account = Account> = T & {
+export type AccountSelectorOption<T extends Account = Account> = T & {
   /** Text to display as a badge in the account selector */
   badges?: string[];
   /** Whether the account is selectable */
   isSelectable?: boolean;
 };
 
-function AccountItem({ account }: { account: AccountWithBadges }) {
+/**
+ * Converts an account to an account selector option.
+ * @param account - The account to convert.
+ * @param options - The options to convert the account to an account selector option.
+ * @param options.badges - The badges to display in the account selector. If not provided, the account's online status will be used to determine if the 'Offline' badge should be displayed.
+ * @param options.isSelectable - Whether the account is selectable. If not provided, the account's online status will be used.
+ * @returns The account selector option.
+ */
+export function toAccountSelectorOption<T extends Account = Account>(
+  account: T,
+  options: { badges?: string[]; isSelectable?: boolean } = {},
+): AccountSelectorOption<T> {
+  return {
+    ...account,
+    badges: options.badges ?? (account.isOnline ? ['Offline'] : []),
+    isSelectable: options.isSelectable ?? account.isOnline,
+  };
+}
+
+function AccountItem({ account }: { account: AccountSelectorOption }) {
   const balance = getAccountBalance(account);
 
   return (
@@ -50,8 +69,8 @@ function AccountItem({ account }: { account: AccountWithBadges }) {
 }
 
 type AccountSelectorProps<T extends Account> = {
-  accounts: AccountWithBadges<T>[];
-  selectedAccount: AccountWithBadges<T>;
+  accounts: AccountSelectorOption<T>[];
+  selectedAccount: AccountSelectorOption<T>;
   onSelect?: (account: T) => void;
   disabled?: boolean;
 };

--- a/app/features/accounts/account-service.ts
+++ b/app/features/accounts/account-service.ts
@@ -6,6 +6,7 @@ import {
   type AccountRepository,
   useAccountRepository,
 } from './account-repository';
+
 export class AccountService {
   constructor(private readonly accountRepository: AccountRepository) {}
 
@@ -52,6 +53,7 @@ export class AccountService {
       | 'proofs'
       | 'version'
       | 'wallet'
+      | 'isOnline'
     >;
   }) {
     const isTestMint = await checkIsTestMint(account.mintUrl);

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -8,6 +8,7 @@ export type Account = {
   id: string;
   name: string;
   type: AccountType;
+  isOnline: boolean;
   currency: Currency;
   createdAt: string;
   /**

--- a/app/features/accounts/utils.ts
+++ b/app/features/accounts/utils.ts
@@ -1,0 +1,6 @@
+export const accountOfflineToast = {
+  title: 'Account Offline',
+  description:
+    'This account is currently offline. Please select a different account.',
+  variant: 'destructive' as const,
+};

--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -24,6 +24,7 @@ import type { CashuAccount } from '../accounts/account';
 import {
   useAccountsCache,
   useGetLatestCashuAccount,
+  useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbCashuReceiveQuote } from '../agicash-db/database';
 import { useUser } from '../user/user-hooks';
@@ -255,6 +256,8 @@ export function useCashuReceiveQuoteChangeHandler() {
 const usePendingCashuReceiveQuotes = () => {
   const cashuReceiveQuoteRepository = useCashuReceiveQuoteRepository();
   const userId = useUser((user) => user.id);
+  const selectReceiveQuotesWithOnlineAccount =
+    useSelectItemsWithOnlineAccount();
 
   const { data } = useQuery({
     queryKey: [PendingCashuReceiveQuotesCache.Key],
@@ -263,6 +266,7 @@ const usePendingCashuReceiveQuotes = () => {
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
     throwOnError: true,
+    select: selectReceiveQuotesWithOnlineAccount,
   });
 
   return data ?? [];

--- a/app/features/receive/cashu-token-swap-hooks.ts
+++ b/app/features/receive/cashu-token-swap-hooks.ts
@@ -8,7 +8,10 @@ import {
 } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import { useLatest } from '~/lib/use-latest';
-import { useGetLatestCashuAccount } from '../accounts/account-hooks';
+import {
+  useGetLatestCashuAccount,
+  useSelectItemsWithOnlineAccount,
+} from '../accounts/account-hooks';
 import type { AgicashDbCashuTokenSwap } from '../agicash-db/database';
 import { useEncryption } from '../shared/encryption';
 import { useUser } from '../user/user-hooks';
@@ -181,6 +184,7 @@ export function useTokenSwap({
 function usePendingCashuTokenSwaps() {
   const userId = useUser((user) => user.id);
   const tokenSwapRepository = useCashuTokenSwapRepository();
+  const selectReceiveSwapsWithOnlineAccount = useSelectItemsWithOnlineAccount();
 
   const { data } = useQuery({
     queryKey: [PendingCashuTokenSwapsCache.Key],
@@ -189,6 +193,7 @@ function usePendingCashuTokenSwaps() {
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
     throwOnError: true,
+    select: selectReceiveSwapsWithOnlineAccount,
   });
 
   return data ?? [];

--- a/app/features/receive/receive-cashu-token-models.ts
+++ b/app/features/receive/receive-cashu-token-models.ts
@@ -5,6 +5,6 @@ export type CashuAccountWithTokenFlags = ExtendedCashuAccount & {
   isSource: boolean;
   /** Whether the account is unknown to the user */
   isUnknown: boolean;
-  /** Whether the account is selectable to receive the token */
-  isSelectable: boolean;
+  /** Whether the account is selectable can receive the token */
+  canReceive: boolean;
 };

--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -44,7 +44,7 @@ export class ReceiveCashuTokenService {
         ...existingAccount,
         isSource: true,
         isUnknown: false,
-        isSelectable: true,
+        canReceive: true,
       };
       return {
         sourceAccount,
@@ -115,7 +115,8 @@ export class ReceiveCashuTokenService {
       isDefault: false,
       isSource: true,
       isUnknown: true,
-      isSelectable: isValid,
+      canReceive: isValid,
+      isOnline: true,
       wallet,
     } satisfies CashuAccountWithTokenFlags;
 
@@ -144,7 +145,7 @@ export class ReceiveCashuTokenService {
     preferredReceiveAccountId?: string,
   ): CashuAccountWithTokenFlags | null {
     if (sourceAccount.isTestMint) {
-      if (!sourceAccount.isSelectable) {
+      if (!sourceAccount.canReceive) {
         return null;
       }
       // Tokens sourced from test mint can only be claimed to the same mint
@@ -155,11 +156,11 @@ export class ReceiveCashuTokenService {
       (account) => account.id === preferredReceiveAccountId,
     );
 
-    if (preferredReceiveAccount?.isSelectable) {
+    if (preferredReceiveAccount?.canReceive) {
       return preferredReceiveAccount;
     }
 
-    if (sourceAccount.isSelectable) {
+    if (sourceAccount.canReceive) {
       return sourceAccount;
     }
 
@@ -168,8 +169,8 @@ export class ReceiveCashuTokenService {
         account.isDefault && account.currency === sourceAccount.currency,
     );
 
-    if (!defaultAccount?.isSelectable) {
-      // This should not be possible because the default account must be selectable and every user must have a default account for each currency.
+    if (!defaultAccount?.canReceive) {
+      // This should not be possible because the default account must be able to receive and every user must have a default account for each currency.
       return null;
     }
 
@@ -183,7 +184,7 @@ export class ReceiveCashuTokenService {
       ...account,
       isSource: false,
       isUnknown: false,
-      isSelectable: !account.isTestMint,
+      canReceive: !account.isTestMint,
     }));
   }
 
@@ -200,10 +201,10 @@ export class ReceiveCashuTokenService {
   ): CashuAccountWithTokenFlags[] {
     if (sourceAccount.isTestMint) {
       // Tokens sourced from test mint can only be claimed to the same mint
-      return sourceAccount.isSelectable ? [sourceAccount] : [];
+      return sourceAccount.canReceive ? [sourceAccount] : [];
     }
     return [sourceAccount, ...otherAccounts].filter(
-      (account) => account.isSelectable,
+      (account) => account.canReceive,
     );
   }
 }

--- a/app/features/receive/receive-input.tsx
+++ b/app/features/receive/receive-input.tsx
@@ -11,7 +11,11 @@ import {
 } from '~/components/page';
 import { Button } from '~/components/ui/button';
 import { Skeleton } from '~/components/ui/skeleton';
-import { AccountSelector } from '~/features/accounts/account-selector';
+import {
+  AccountSelector,
+  toAccountSelectorOption,
+} from '~/features/accounts/account-selector';
+import { accountOfflineToast } from '~/features/accounts/utils';
 import { getDefaultUnit } from '~/features/shared/currencies';
 import useAnimation from '~/hooks/use-animation';
 import { useMoneyInput } from '~/hooks/use-money-input';
@@ -85,6 +89,11 @@ export default function ReceiveInput() {
   });
 
   const handleContinue = async () => {
+    if (!receiveAccount.isOnline) {
+      toast(accountOfflineToast);
+      return;
+    }
+
     if (inputValue.currency === receiveAccount.currency) {
       setReceiveAmount(inputValue);
     } else {
@@ -167,8 +176,10 @@ export default function ReceiveInput() {
 
         <div className="w-full max-w-sm sm:max-w-none">
           <AccountSelector
-            accounts={accounts}
-            selectedAccount={receiveAccount}
+            accounts={accounts.map((account) =>
+              toAccountSelectorOption(account),
+            )}
+            selectedAccount={toAccountSelectorOption(receiveAccount)}
             onSelect={(account) => {
               setReceiveAccount(account);
               if (account.currency !== inputValue.currency) {

--- a/app/features/send/cashu-send-quote-hooks.ts
+++ b/app/features/send/cashu-send-quote-hooks.ts
@@ -21,6 +21,7 @@ import {
   useAccount,
   useAccountsCache,
   useGetLatestCashuAccount,
+  useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbCashuSendQuote } from '../agicash-db/database';
 import { useEncryption } from '../shared/encryption';
@@ -291,6 +292,7 @@ export function useCashuSendQuote(sendQuoteId: string) {
 function useUnresolvedCashuSendQuotes() {
   const cashuSendQuoteRepository = useCashuSendQuoteRepository();
   const userId = useUser((user) => user.id);
+  const selectSendQuotesWithOnlineAccount = useSelectItemsWithOnlineAccount();
 
   const { data } = useQuery({
     queryKey: [UnresolvedCashuSendQuotesCache.Key],
@@ -299,6 +301,7 @@ function useUnresolvedCashuSendQuotes() {
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
     throwOnError: true,
+    select: selectSendQuotesWithOnlineAccount,
   });
 
   return data ?? [];

--- a/app/features/send/cashu-send-swap-hooks.ts
+++ b/app/features/send/cashu-send-swap-hooks.ts
@@ -13,6 +13,7 @@ import {
   useAccount,
   useAccountsCache,
   useGetLatestCashuAccount,
+  useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbCashuSendSwap } from '../agicash-db/database';
 import { useEncryption } from '../shared/encryption';
@@ -169,6 +170,7 @@ export function useCreateCashuSendSwap({
 export function useUnresolvedCashuSendSwaps() {
   const cashuSendSwapRepository = useCashuSendSwapRepository();
   const userId = useUser((user) => user.id);
+  const selectSendSwapsWithOnlineAccount = useSelectItemsWithOnlineAccount();
 
   const { data = [] } = useQuery({
     queryKey: [UnresolvedCashuSendSwapsCache.Key],
@@ -176,6 +178,7 @@ export function useUnresolvedCashuSendSwaps() {
     staleTime: Number.POSITIVE_INFINITY,
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
+    select: selectSendSwapsWithOnlineAccount,
   });
 
   return useMemo(() => {

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -28,7 +28,11 @@ import { DrawerTrigger } from '~/components/ui/drawer';
 import { Drawer } from '~/components/ui/drawer';
 import { Skeleton } from '~/components/ui/skeleton';
 import { useAccounts } from '~/features/accounts/account-hooks';
-import { AccountSelector } from '~/features/accounts/account-selector';
+import {
+  AccountSelector,
+  toAccountSelectorOption,
+} from '~/features/accounts/account-selector';
+import { accountOfflineToast } from '~/features/accounts/utils';
 import useAnimation from '~/hooks/use-animation';
 import { useMoneyInput } from '~/hooks/use-money-input';
 import { useToast } from '~/hooks/use-toast';
@@ -117,12 +121,8 @@ export function SendInput() {
     inputValue: Money,
     convertedValue: Money | undefined,
   ) => {
-    if (sendAccount.type !== 'cashu') {
-      toast({
-        title: 'Not implemented',
-        description: 'Only sends from the cashu accounts are supported',
-        variant: 'destructive',
-      });
+    if (!sendAccount.isOnline) {
+      toast(accountOfflineToast);
       return;
     }
 
@@ -234,8 +234,10 @@ export function SendInput() {
 
         <div className="w-full max-w-sm sm:max-w-none">
           <AccountSelector
-            accounts={accounts}
-            selectedAccount={sendAccount}
+            accounts={accounts.map((account) =>
+              toAccountSelectorOption(account),
+            )}
+            selectedAccount={toAccountSelectorOption(sendAccount)}
             onSelect={(account) => {
               selectSourceAccount(account);
               if (account.currency !== inputValue.currency) {

--- a/app/features/settings/accounts/$accountId.tsx
+++ b/app/features/settings/accounts/$accountId.tsx
@@ -51,8 +51,10 @@ function CashuAccount({ account }: { account: ExtendedCashuAccount }) {
         </div>
 
         <div className="w-full space-y-8 sm:max-w-sm">
-          <div className="h-[24px]">
+          <div className="flex h-[24px] gap-2">
             {account.isDefault && <Badge>Default</Badge>}
+
+            {!account.isOnline && <Badge>Offline</Badge>}
           </div>
           {[
             { label: 'Type', value: account.type },

--- a/app/features/settings/accounts/all-accounts.tsx
+++ b/app/features/settings/accounts/all-accounts.tsx
@@ -34,9 +34,10 @@ function CurrencyAccounts({ currency }: { currency: Currency }) {
                 variant="inline"
               />
             </div>
-            {account.isDefault && (
-              <div className="mt-1">
-                <Badge>Default</Badge>
+            {(account.isDefault || !account.isOnline) && (
+              <div className="mt-1 flex gap-2">
+                {account.isDefault && <Badge>Default</Badge>}
+                {!account.isOnline && <Badge>Offline</Badge>}
               </div>
             )}
           </Card>

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -16,6 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from '~/components/ui/card';
+import { accountOfflineToast } from '~/features/accounts/utils';
 import type {
   CashuLightningReceiveTransactionDetails,
   CashuTokenReceiveTransactionDetails,
@@ -299,7 +300,13 @@ export function TransactionDetails({
         <PageFooter className="pb-14">
           <Button
             className="w-[100px]"
-            onClick={() => reverseTransaction({ transaction })}
+            onClick={() => {
+              if (!account.isOnline) {
+                toast(accountOfflineToast);
+                return;
+              }
+              reverseTransaction({ transaction });
+            }}
             loading={isReclaimInProgress}
           >
             Reclaim

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -123,7 +123,13 @@ export class UserRepository {
        */
       accounts: DistributedOmit<
         Account,
-        'id' | 'createdAt' | 'version' | 'proofs' | 'keysetCounters' | 'wallet'
+        | 'id'
+        | 'createdAt'
+        | 'version'
+        | 'proofs'
+        | 'keysetCounters'
+        | 'wallet'
+        | 'isOnline'
       >[];
       /**
        * The extended public key used for locking proofs and mint quotes.


### PR DESCRIPTION
closes #595 

If fetching any of the mint data fails with a `NetworkError`, we flag the account as offline. Now the account will be loaded into the app with `isOnline: false`, so we can handle offline mints in the UI by adding "Offline" badges and disabling usage of the account. 

I also filter out any pending token-swaps, send-swaps, receive-quotes, and send-quotes where the accounId is offline.