### PR TITLE
make currency symbol color the same as the number

### DIFF
--- a/app/components/money-display.tsx
+++ b/app/components/money-display.tsx
@@ -1,6 +1,52 @@
+import { type VariantProps, cva } from 'class-variance-authority';
 import type { Currency, CurrencyUnit } from '~/lib/money';
 import { Money } from '~/lib/money';
 import { cn } from '~/lib/utils';
+
+const textVariants = cva('', {
+  variants: {
+    variant: {
+      default: '',
+      muted: 'text-muted-foreground',
+    },
+    size: {
+      sm: 'font-semibold',
+      lg: 'font-bold',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    size: 'lg',
+  },
+});
+
+const symbolVariants = cva('', {
+  variants: {
+    size: {
+      sm: 'text-[1.33rem]',
+      lg: 'text-[3.45rem]',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+const valueVariants = cva('font-numeric', {
+  variants: {
+    size: {
+      sm: 'pt-1 text-2xl',
+      lg: 'pt-2 text-6xl',
+    },
+  },
+  defaultVariants: {
+    size: 'lg',
+  },
+});
+
+type Variants = VariantProps<typeof textVariants> &
+  VariantProps<typeof symbolVariants> &
+  VariantProps<typeof valueVariants>;
 
 interface MoneyInputDisplayProps<C extends Currency = Currency> {
   /** Raw input value from user (e.g., "1", "1.", "1.0") */
@@ -45,13 +91,13 @@ export function MoneyInputDisplay<C extends Currency>({
     : '';
 
   const symbol = (
-    <span className="text-[3.45rem] text-currencySymbol">{currencySymbol}</span>
+    <span className={symbolVariants({ size: 'lg' })}>{currencySymbol}</span>
   );
 
   return (
-    <span className="font-bold">
+    <span className={textVariants({ size: 'lg' })}>
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className="pt-2 font-numeric text-6xl">
+      <span className={valueVariants({ size: 'lg' })}>
         {integer}
         {(inputDecimals || needsPaddedZeros) && (
           <>
@@ -72,28 +118,15 @@ type MoneyDisplayProps<C extends Currency = Currency> = {
   money: Money<C>;
   locale?: string;
   unit?: CurrencyUnit<C>;
-  variant?: 'default' | 'secondary';
   className?: string;
-};
-
-const variants = {
-  default: {
-    symbol: 'text-[3.45rem] text-currencySymbol',
-    value: 'text-6xl pt-2',
-    wrapper: 'font-bold',
-  },
-  secondary: {
-    symbol: 'text-[1.33rem] text-foreground',
-    value: 'text-2xl pt-1 text-foreground',
-    wrapper: 'font-semibold',
-  },
-} as const;
+} & Variants;
 
 export function MoneyDisplay<C extends Currency>({
   money,
   locale,
   unit,
-  variant = 'default',
+  variant,
+  size,
   className,
 }: MoneyDisplayProps<C>) {
   const {
@@ -107,15 +140,13 @@ export function MoneyDisplay<C extends Currency>({
   const value = `${integer}${decimalSeparator}${fraction}`;
 
   const symbol = (
-    <span className={variants[variant].symbol}>{currencySymbol}</span>
+    <span className={symbolVariants({ size })}>{currencySymbol}</span>
   );
 
   return (
-    <span className={cn(variants[variant].wrapper, className)}>
+    <span className={cn(textVariants({ variant, size }), className)}>
       {currencySymbolPosition === 'prefix' && symbol}
-      <span className={cn('font-numeric', variants[variant].value)}>
-        {value}
-      </span>
+      <span className={valueVariants({ size })}>{value}</span>
       {currencySymbolPosition === 'suffix' && symbol}
     </span>
   );

--- a/app/features/receive/receive-input.tsx
+++ b/app/features/receive/receive-input.tsx
@@ -48,9 +48,10 @@ const ConvertedMoneySwitcher = ({
       <MoneyDisplay
         money={money}
         unit={getDefaultUnit(money.currency)}
-        variant="secondary"
+        size="sm"
+        variant="muted"
       />
-      <ArrowUpDown className="mb-1" />
+      <ArrowUpDown className="mb-1 text-muted-foreground" />
     </button>
   );
 };

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -173,7 +173,7 @@ export const PayBolt11Confirmation = ({
           label: 'Recipient gets',
           value: (
             <MoneyDisplay
-              variant="secondary"
+              size="sm"
               money={bolt11Quote.amountToReceive}
               unit={getDefaultUnit(bolt11Quote.amountToReceive.currency)}
             />
@@ -183,7 +183,7 @@ export const PayBolt11Confirmation = ({
           label: 'Estimated fee',
           value: (
             <MoneyDisplay
-              variant="secondary"
+              size="sm"
               money={bolt11Quote.estimatedTotalFee}
               unit={getDefaultUnit(bolt11Quote.estimatedTotalFee.currency)}
             />
@@ -259,7 +259,7 @@ export const CreateCashuTokenConfirmation = ({
           label: 'Recipient gets',
           value: (
             <MoneyDisplay
-              variant="secondary"
+              size="sm"
               money={quote.amountRequested}
               unit={getDefaultUnit(quote.amountRequested.currency)}
             />
@@ -269,7 +269,7 @@ export const CreateCashuTokenConfirmation = ({
           label: 'Estimated fee',
           value: (
             <MoneyDisplay
-              variant="secondary"
+              size="sm"
               money={quote.totalFee}
               unit={getDefaultUnit(quote.totalFee.currency)}
             />

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -69,9 +69,10 @@ const ConvertedMoneySwitcher = ({
       <MoneyDisplay
         money={money}
         unit={getDefaultUnit(money.currency)}
-        variant="secondary"
+        size="sm"
+        variant="muted"
       />
-      <ArrowUpDown className="mb-1" />
+      <ArrowUpDown className="mb-1 text-muted-foreground" />
     </button>
   );
 };

--- a/app/features/shared/money-with-converted-amount.tsx
+++ b/app/features/shared/money-with-converted-amount.tsx
@@ -79,7 +79,8 @@ export const MoneyWithConvertedAmount = ({
             <MoneyDisplay
               money={conversionData.convertedMoney}
               unit={conversionData.unit}
-              variant="secondary"
+              size="sm"
+              variant="muted"
             />
           )}
         </>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -42,7 +42,6 @@
     --border: 178 100% 21%;
     --muted-foreground: 178 30% 81%;
     --card: 178 100% 14%;
-    --currency-symbol: 177 42% 31%;
   }
 
   /* BTC theme - light mode */
@@ -57,7 +56,6 @@
     --border: 217 70% 45%;
     --muted-foreground: 217 30% 85%;
     --card: 217 68% 38%;
-    --currency-symbol: 217 44% 55%;
   }
 
   .dark,
@@ -87,7 +85,6 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --currency-symbol: 202 13% 30%;
   }
 }
 @layer base {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,7 +51,6 @@ export default {
           '4': 'hsl(var(--chart-4))',
           '5': 'hsl(var(--chart-5))',
         },
-        currencySymbol: 'hsl(var(--currency-symbol))',
       },
       fontFamily: {
         numeric: ['Teko', 'sans-serif'],


### PR DESCRIPTION
We decided to change the colors of our moneys to have the currency symbol be the same color as the number.

 we changed it because once we start making the backgrounds different, its much easier to see if its the same color. Otherwise we need to match 2 colors to the card backgrounds.

Now that we want different colors and different sizes I've added more variants to money-display