### PR TITLE
fix receive flash by not triggering unnecessary source account query

### DIFF
--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -63,7 +63,7 @@ export function useCashuTokenSourceAccountQuery(
       'token-source-account',
       token.mint,
       tokenCurrency,
-      existingCashuAccounts,
+      existingCashuAccounts.map((a) => a.id).sort(),
     ],
     queryFn: async () =>
       receiveCashuTokenService.getSourceAndDestinationAccounts(


### PR DESCRIPTION
This should fix the receive flash and allow us to close #668 

In our receive/cashu/token route we have a suspense boundary around the ReceiveCashuToken component. When the user starts to claim and the cashu token swap is created, the account's keyset counters get updated. This causes the existing accounts to change a retriggers the suspense query for the token source account, which then flashes the skeleton.