### PR TITLE
Improve exchange rate caching

### DIFF
--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -1,6 +1,6 @@
 import type { Token } from '@cashu/cashu-ts';
 import type { QueryClient } from '@tanstack/react-query';
-import { exchangeRateQueryOptions } from '~/hooks/use-exchange-rate';
+import { getExchangeRate } from '~/hooks/use-exchange-rate';
 import { areMintUrlsEqual } from '~/lib/cashu';
 import type { CashuAccount } from '../accounts/account';
 import { AccountsCache, accountsQueryOptions } from '../accounts/account-hooks';
@@ -138,10 +138,9 @@ export class ClaimCashuTokenService {
         this.accountsCache.upsert(result.account);
       }
     } else {
-      const exchangeRate = await this.queryClient.fetchQuery(
-        exchangeRateQueryOptions(
-          `${sourceAccount.currency}-${receiveAccount.currency}`,
-        ),
+      const exchangeRate = await getExchangeRate(
+        this.queryClient,
+        `${sourceAccount.currency}-${receiveAccount.currency}`,
       );
       const { cashuMeltQuote, cashuReceiveQuote } =
         await this.receiveCashuTokenQuoteService.createCrossAccountReceiveQuotes(

--- a/app/hooks/use-exchange-rate.ts
+++ b/app/hooks/use-exchange-rate.ts
@@ -1,35 +1,80 @@
-import { queryOptions, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  type QueryClient,
+  queryOptions,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { type Ticker, exchangeRateService } from '~/lib/exchange-rate';
 
-export const exchangeRateQueryOptions = (ticker: Ticker) =>
-  queryOptions({
-    queryKey: ['exchangeRate', ticker],
+/**
+ * Gets the normalized set of tickers to fetch.
+ * Always fetches both directions for each ticker pair to maximize cache sharing.
+ * For example, if 'BTC-USD' is requested, 'USD-BTC' will also be fetched.
+ */
+const getNormalizedTickers = (tickers: Ticker[]): Ticker[] => {
+  const tickerSet = new Set(tickers);
+
+  // For each ticker, add its reverse pair
+  for (const ticker of tickers) {
+    const [from, to] = ticker.split('-');
+    if (from && to) {
+      tickerSet.add(`${to}-${from}` as Ticker);
+    }
+  }
+
+  return Array.from(tickerSet).sort();
+};
+
+/**
+ * Query options for fetching multiple exchange rates.
+ * The query key is normalized by sorting tickers to ensure cache sharing.
+ * Always fetches both directions of each ticker pair (e.g., BTC-USD and USD-BTC).
+ */
+export const exchangeRatesQueryOptions = (tickers: Ticker[]) => {
+  const normalizedTickers = getNormalizedTickers(tickers);
+  return queryOptions({
+    queryKey: ['exchangeRate', normalizedTickers],
     queryFn: async ({ signal }) => {
-      return exchangeRateService
-        .getRates({
-          tickers: [ticker],
-          signal,
-        })
-        .then((rates) => rates[ticker]);
+      return exchangeRateService.getRates({
+        tickers: normalizedTickers,
+        signal,
+      });
     },
   });
+};
+
+/**
+ * Query options for fetching a single exchange rate.
+ * Internally uses exchangeRatesQueryOptions to ensure cache sharing.
+ * Note: This returns the full Rates object. Use with select or extract the ticker manually.
+ */
+const exchangeRateQueryOptions = (ticker: Ticker) => {
+  return exchangeRatesQueryOptions([ticker]);
+};
+
+/**
+ * Gets the exchange rate for the ticker.
+ * The function will check the cache and if not found, it will fetch the rate.
+ */
+export const getExchangeRate = async (
+  queryClient: QueryClient,
+  ticker: Ticker,
+) => {
+  const rates = await queryClient.fetchQuery(exchangeRateQueryOptions(ticker));
+  return rates[ticker];
+};
 
 export const useExchangeRate = (ticker: Ticker) => {
   return useQuery({
     ...exchangeRateQueryOptions(ticker),
+    select: (data) => data[ticker],
     refetchInterval: 15_000,
   });
 };
 
 export const useExchangeRates = (tickers: Ticker[]) => {
   return useQuery({
-    queryKey: ['exchangeRate', tickers],
-    queryFn: async ({ signal }) => {
-      return exchangeRateService.getRates({
-        tickers,
-        signal,
-      });
-    },
+    ...exchangeRatesQueryOptions(tickers),
     refetchInterval: 15_000,
   });
 };
@@ -40,8 +85,5 @@ export const useExchangeRates = (tickers: Ticker[]) => {
  */
 export const useGetExchangeRate = () => {
   const queryClient = useQueryClient();
-
-  return async (ticker: Ticker): Promise<string> => {
-    return queryClient.fetchQuery(exchangeRateQueryOptions(ticker));
-  };
+  return (ticker: Ticker) => getExchangeRate(queryClient, ticker);
 };

--- a/app/hooks/use-money-input.ts
+++ b/app/hooks/use-money-input.ts
@@ -87,9 +87,7 @@ export function useMoneyInput({
     `${state.converted.currency}-${state.input.currency}`,
   ];
 
-  const { data: rates, error: exchangeRateError } = useExchangeRates(
-    tickers.sort(),
-  );
+  const { data: rates, error: exchangeRateError } = useExchangeRates(tickers);
 
   const inputMoney = toMoney(state.input);
 

--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -20,7 +20,6 @@ import { InstallPwaPrompt } from '~/features/pwa/install-pwa-prompt';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
 import { useHasTransactionsPendingAck } from '~/features/transactions/transaction-hooks';
 import { useExchangeRates } from '~/hooks/use-exchange-rate';
-import type { Ticker } from '~/lib/exchange-rate';
 import { Money } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 
@@ -31,9 +30,7 @@ export const links: LinksFunction = () => [
 
 const Price = () => {
   const [showSatsPerDollar, setShowSatsPerDollar] = useState(false);
-  const { data: rates } = useExchangeRates(
-    (['BTC-USD', 'USD-BTC'] as Ticker[]).sort(),
-  );
+  const { data: rates } = useExchangeRates(['BTC-USD', 'USD-BTC']);
 
   if (!rates) return <Skeleton className="h-[24px] w-[81px]" />;
 


### PR DESCRIPTION
I noticed that our app currently makes two identical requests to get the rates every 15 seconds. It was because multiple components are using it but the cache wasn't used properly.