### PR TITLE
fix: consider cashu fees for cross account swaps

### DIFF
--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -240,6 +240,10 @@ export function TransactionDetails({
         cashuReceiveFee: receiveSwapDetails.cashuReceiveFee?.toLocaleString({
           unit,
         }),
+        lightningFeeReserve:
+          receiveSwapDetails.lightningFeeReserve?.toLocaleString({
+            unit,
+          }),
         totalFees: receiveSwapDetails.totalFees?.toLocaleString({ unit }),
       },
     );

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -43,7 +43,13 @@ export type CashuTokenReceiveTransactionDetails = {
    */
   cashuReceiveFee: Money;
   /**
-   * The total fees for the transaction. This is the same as the `cashuReceiveFee`.
+   * The fee reserved for the lightning payment to melt the proofs to the account.
+   * This is defined when the token is melted from the source mint into this receiving account.
+   * This will be undefined when receiving proofs to the source account which just requires a swap.
+   */
+  lightningFeeReserve?: Money;
+  /**
+   * The total fees for the transaction. This is the sum of `cashuReceiveFee` and `lightningFeeReserve`.
    */
   totalFees: Money;
 };


### PR DESCRIPTION
I changed the target amount for fetching cross account quotes to subtract the cashu receive fee so that when the time comes to melt the token, there are sufficient proofs to cover the lightning fee and cashu fee on top of the amount to be received.

Then I added the lightning fee to the transaction details for cashu token receives. Note that the value stored here is the lightning `fee_reserve`, but I called it `lightningFee` because even if the mint returns some change our current logic just considers that as part of the fee and forgets the change. The reason we do this is that the change will be just a couple sats and there's nothing reasonable to do with that change