### PR TITLE
remove NWC account type

### DIFF
--- a/app/features/accounts/account-icons.tsx
+++ b/app/features/accounts/account-icons.tsx
@@ -1,10 +1,9 @@
-import { LandmarkIcon, Zap } from 'lucide-react';
+import { LandmarkIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { SparkIcon as SparkIconSvg } from '~/components/spark-icon';
 import type { AccountType } from './account';
 
 const CashuIcon = () => <LandmarkIcon className="h-4 w-4" />;
-const NWCIcon = () => <Zap className="h-4 w-4" />;
 const SparkIcon = () => (
   <div className="flex h-4 w-4 items-center justify-center">
     <SparkIconSvg className="h-3 w-3" />
@@ -12,7 +11,6 @@ const SparkIcon = () => (
 );
 const iconsByAccountType: Record<AccountType, ReactNode> = {
   cashu: <CashuIcon />,
-  nwc: <NWCIcon />,
   spark: <SparkIcon />,
 };
 

--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -133,9 +133,7 @@ export class AccountRepository {
         is_test_mint: accountInput.isTestMint,
         keyset_counters: accountInput.keysetCounters,
       };
-    } else if (accountInput.type === 'nwc') {
-      details = { nwc_url: accountInput.nwcUrl };
-    } else if (accountInput.type === 'spark') {
+    } else {
       details = { network: accountInput.network };
     }
     const accountsToCreate = {
@@ -198,15 +196,6 @@ export class AccountRepository {
         keysetCounters: details.keyset_counters,
         proofs,
         wallet,
-      } as T;
-    }
-
-    if (data.type === 'nwc') {
-      const details = data.details as { nwc_url: string };
-      return {
-        ...commonData,
-        type: 'nwc',
-        nwcUrl: details.nwc_url,
       } as T;
     }
 

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -6,7 +6,7 @@ import type { Proof } from '@cashu/cashu-ts';
 import { type ExtendedCashuWallet, getCashuUnit, sumProofs } from '~/lib/cashu';
 import { type Currency, Money } from '~/lib/money';
 
-export type AccountType = 'cashu' | 'nwc' | 'spark';
+export type AccountType = 'cashu' | 'spark';
 
 export type CashuProof = {
   id: string;
@@ -66,10 +66,6 @@ export type Account = {
       wallet: ExtendedCashuWallet;
     }
   | {
-      type: 'nwc';
-      nwcUrl: string;
-    }
-  | {
       type: 'spark';
       balance: Money | null;
       network: SparkNetwork;
@@ -99,9 +95,5 @@ export const getAccountBalance = (account: Account) => {
       unit: getCashuUnit(account.currency),
     });
   }
-  if (account.type === 'spark') {
-    return account.balance;
-  }
-  // TODO: implement balance logic for other account types
-  return new Money({ amount: 0, currency: account.currency });
+  return account.balance;
 };

--- a/app/features/receive/lightning-address-service.tsx
+++ b/app/features/receive/lightning-address-service.tsx
@@ -246,22 +246,18 @@ export class LightningAddressService {
         };
       }
 
-      if (account.type === 'spark') {
-        const sparkReceiveLightningService = new SparkLightningReceiveService();
-        const request = await sparkReceiveLightningService.create({
-          account,
-          amount: amountToReceive,
-          receiverIdentityPubkey: user.sparkIdentityPublicKey,
-        });
+      const sparkReceiveLightningService = new SparkLightningReceiveService();
+      const request = await sparkReceiveLightningService.create({
+        account,
+        amount: amountToReceive,
+        receiverIdentityPubkey: user.sparkIdentityPublicKey,
+      });
 
-        return {
-          pr: request.paymentRequest,
-          verify: `${this.baseUrl}/api/lnurlp/verify/${account.id}/${request.id}`,
-          routes: [],
-        };
-      }
-
-      throw new Error(`Account type not supported. Got ${account.type}`);
+      return {
+        pr: request.paymentRequest,
+        verify: `${this.baseUrl}/api/lnurlp/verify/${account.id}/${request.id}`,
+        routes: [],
+      };
     } catch (error) {
       console.error('Error processing LNURL-pay callback', { cause: error });
       return {
@@ -286,12 +282,7 @@ export class LightningAddressService {
       if (account.type === 'cashu') {
         return this.handleCashuLnurlpVerify(requestId);
       }
-      if (account.type === 'spark') {
-        return this.handleSparkLnurlpVerify(account, requestId);
-      }
-      throw new Error(
-        `Account type not supported. Got ${account.type} for account ${accountId}`,
-      );
+      return this.handleSparkLnurlpVerify(account, requestId);
     } catch (error) {
       console.error('Error processing LNURL-pay verify', { cause: error });
       const errorMessage =

--- a/app/features/receive/receive-input.tsx
+++ b/app/features/receive/receive-input.tsx
@@ -109,8 +109,7 @@ export default function ReceiveInput() {
         transition: 'slideLeft',
         applyTo: 'newView',
       });
-    }
-    if (receiveAccount.type === 'spark') {
+    } else {
       navigate('/receive/spark', {
         transition: 'slideLeft',
         applyTo: 'newView',

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -165,15 +165,7 @@ export class UserRepository {
             keyset_counters: {},
           };
         }
-        if (account.type === 'spark') {
-          return { network: account.network };
-        }
-        if (account.type === 'nwc') {
-          return {
-            nwc_url: account.nwcUrl,
-          };
-        }
-        throw new Error('Invalid account type');
+        return { network: account.network };
       })(),
     }));
 


### PR DESCRIPTION
It was kinda nice to have the `nwc` account type defined so we architected things considering there could be multiple account types, but now that we have spark it seems unnecessary to have nwc in our code. 