### PR TITLE
Add mint blocklist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,9 @@ SELF_SIGNED_CERT_KEY_PATH='../certs/localhost-key.pem'
 NODE_TLS_REJECT_UNAUTHORIZED=0
 LNURL_SERVER_SPARK_MNEMONIC='half vanish taxi again drill detail neglect park harsh setup involve dawn'
 
+# These mint + unit pairs cannot be added as an account. Set the unit to null to block the entire mint.
+# LNVoltz + USD: This mint has a bug that does not allow USD ecash to be melted. The current version is "Nutshell/0.18.1"
+VITE_CASHU_MINT_BLOCKLIST='[{"mintUrl":"https://mint.lnvoltz.com","unit":"usd"}]'
+
 # Feature Flags
 VITE_FF_GUEST_SIGNUP=true

--- a/.env.test
+++ b/.env.test
@@ -12,6 +12,7 @@ SELF_SIGNED_CERT_PATH='../certs/localhost-cert.pem'
 SELF_SIGNED_CERT_KEY_PATH='../certs/localhost-key.pem'
 NODE_TLS_REJECT_UNAUTHORIZED=0
 LNURL_SERVER_SPARK_MNEMONIC='half vanish taxi again drill detail neglect park harsh setup involve dawn'
+VITE_CASHU_MINT_BLOCKLIST='[{"mintUrl":"https://mint.lnvoltz.com","unit":"usd"}]'
 
 # Feature Flags
 VITE_FF_GUEST_SIGNUP=true

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -12,7 +12,10 @@ import {
 } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { checkIsTestMint, getCashuWallet, sumProofs } from '~/lib/cashu';
-import { buildMintValidator } from '~/lib/cashu/mint-validation';
+import {
+  MintBlocklistSchema,
+  buildMintValidator,
+} from '~/lib/cashu/mint-validation';
 import { type Currency, type CurrencyUnit, Money } from '~/lib/money';
 import { computeSHA256 } from '~/lib/sha256';
 import { getSeedPhraseDerivationPath } from '../accounts/account-cryptography';
@@ -138,9 +141,14 @@ export function getTokenHash(token: Token | string): Promise<string> {
   return computeSHA256(encodedToken);
 }
 
+const mintBlocklist = MintBlocklistSchema.parse(
+  JSON.parse(import.meta.env.VITE_CASHU_MINT_BLOCKLIST ?? '[]'),
+);
+
 export const cashuMintValidator = buildMintValidator({
   requiredNuts: [4, 5, 7, 8, 9, 10, 11, 12, 17, 20] as const,
   requiredWebSocketCommands: ['bolt11_melt_quote', 'proof_state'] as const,
+  blocklist: mintBlocklist,
 });
 
 export const mintInfoQueryKey = (mintUrl: string) => ['mint-info', mintUrl];

--- a/app/lib/cashu/types.ts
+++ b/app/lib/cashu/types.ts
@@ -147,13 +147,19 @@ export type P2PKSecret = NUT10Secret & { kind: 'P2PK' };
 export type MintInfo = Awaited<ReturnType<CashuWallet['getMintInfo']>>;
 
 /**
- * The units that are determined by the soft-consensus of cashu mints and wallets.
- * These units are not definite as they are not defined in NUTs directly.
- * The following units generally mean:
- * - `sat`: satoshis
- * - `usd`: cents in USD
+ * A subset of the supported currency units as defined by the Cashu protocol.
+ * ISO 4217 currencies (and stablecoins pegged to those currencies) represent an amount in the Minor Unit of that currency
+ *
+ * The following units are supported:
+ * - `sat`: Bitcoin's minor unit (1 BTC = 100,000,000 sat)
+ * - `usd`: USD (minor unit: 2 decimals)
+ *
+ * @see https://github.com/cashubtc/nuts/blob/main/01.md#supported-currency-units
  */
-export type CashuProtocolUnit = 'sat' | 'usd';
+export const CASHU_PROTOCOL_UNITS = ['sat', 'usd'] as const;
+
+/** @see {@link CASHU_PROTOCOL_UNITS} */
+export type CashuProtocolUnit = (typeof CASHU_PROTOCOL_UNITS)[number];
 
 /**
  * A subset of the cashu [NUTs](https://github.com/cashubtc/nuts).

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -17,6 +17,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN: string | undefined;
   readonly VITE_ENVIRONMENT: string | undefined;
   readonly VITE_LOCAL_DEV: string | undefined;
+  readonly VITE_CASHU_MINT_BLOCKLIST: string | undefined;
   // Feature flags
   readonly VITE_FF_GUEST_SIGNUP: string | undefined;
 }


### PR DESCRIPTION
I decided to make the blocklist configurable via a JSON string environment variable. Alternatives to JSON could be something like `https://mint.lnvoltz.com:usd;https://mint.example.com:sat`, but because we want to block specific units JSON seemed better to make the parsing easier rather than using the last colon as the delimiter. 

