### PR TITLE
add a landing page with route handling

### DIFF
--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -347,11 +347,7 @@ export function PublicReceiveCashuToken({ token }: { token: Token }) {
   return (
     <>
       <PageHeader className="z-10">
-        <ClosePageButton
-          to="/signup"
-          transition="slideDown"
-          applyTo="oldView"
-        />
+        <ClosePageButton to="/home" transition="slideDown" applyTo="oldView" />
         <PageHeaderTitle>Receive</PageHeaderTitle>
       </PageHeader>
       <PageContent className="flex flex-col items-center">

--- a/app/features/user/auth.ts
+++ b/app/features/user/auth.ts
@@ -293,7 +293,7 @@ export const useSignOut = () => {
 
   const handleSignOut = async () => {
     setLoading(true);
-    await signOut({ redirectTo: '/signup' });
+    await signOut({ redirectTo: '/home' });
     setLoading(false);
   };
   return { isSigningOut: loading, signOut: handleSignOut };

--- a/app/routes/_protected.tsx
+++ b/app/routes/_protected.tsx
@@ -156,7 +156,7 @@ const routeGuardMiddleware: Route.unstable_ClientMiddlewareFunction = async (
       search = `?${searchParams.toString()}`;
     }
 
-    throw redirect(`/signup${search}${hash}`);
+    throw redirect(`/home${search}${hash}`);
   }
 
   await ensureUserData(queryClient, authUser);

--- a/app/routes/_public.home.tsx
+++ b/app/routes/_public.home.tsx
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { Link, useLocation } from 'react-router';
+import { useTimeout } from 'usehooks-ts';
+import DiscordLogo from '~/assets/discord_logo.svg';
+import { Page, PageContent } from '~/components/page';
+import { Button } from '~/components/ui/button';
+import { authQueryOptions } from '~/features/user/auth';
+
+const TAP_THRESHOLD_MS = 500;
+
+/** This hook is used for the login and signup button easter egg. */
+function useShowAuthButtons() {
+  const [tapCount, setTapCount] = useState(0);
+  const [showAuthButtons, setShowAuthButtons] = useState(false);
+
+  useTimeout(
+    () => {
+      setTapCount(0);
+    },
+    tapCount > 0 ? TAP_THRESHOLD_MS : null,
+  );
+
+  const handleTap = () => {
+    setTapCount((prev) => {
+      const newCount = prev + 1;
+      if (newCount >= 3) {
+        setShowAuthButtons(true);
+        return 0;
+      }
+      return newCount;
+    });
+  };
+
+  return { showAuthButtons, handleTap };
+}
+
+export default function HomePage() {
+  const location = useLocation();
+  const { showAuthButtons, handleTap } = useShowAuthButtons();
+  const { data: authState } = useQuery(authQueryOptions());
+
+  const isLoggedIn = authState?.isLoggedIn ?? false;
+
+  return (
+    <Page onClick={handleTap}>
+      <PageContent className="flex flex-col items-center">
+        <div className="absolute top-0 right-0 bottom-0 left-0 mx-auto flex max-w-sm items-center justify-center">
+          <div className="relative text-center">
+            <h1 className="mb-8 font-bold text-[clamp(3rem,10vw,4rem)] leading-none tracking-tight drop-shadow-lg">
+              Coming Soon
+            </h1>
+
+            <a
+              href="https://discord.gg/e2TSCfXxhd"
+              className="inline-flex"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img
+                src={DiscordLogo}
+                alt="Discord"
+                className="size-8"
+                style={{
+                  filter:
+                    'invert(38%) sepia(95%) saturate(1817%) hue-rotate(218deg) brightness(100%) contrast(93%)',
+                }}
+              />
+            </a>
+
+            {isLoggedIn ? (
+              <div className="-translate-x-1/2 absolute top-full left-1/2 mt-8">
+                <Button asChild size="sm">
+                  <Link to="/">Go to Wallet</Link>
+                </Button>
+              </div>
+            ) : (
+              showAuthButtons && (
+                <div className="-translate-x-1/2 absolute top-full left-1/2 mt-8 flex gap-4">
+                  <Button asChild variant="outline" size="sm">
+                    <Link to={{ ...location, pathname: '/login' }}>Log In</Link>
+                  </Button>
+                  <Button asChild size="sm">
+                    <Link to={{ ...location, pathname: '/signup' }}>
+                      Sign Up
+                    </Link>
+                  </Button>
+                </div>
+              )
+            )}
+          </div>
+        </div>
+      </PageContent>
+    </Page>
+  );
+}

--- a/app/routes/_public.receive-cashu-token.tsx
+++ b/app/routes/_public.receive-cashu-token.tsx
@@ -23,7 +23,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const token = extractCashuToken(hash);
 
   if (!token) {
-    throw redirect('/signup');
+    throw redirect('/home');
   }
 
   return { token };

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -24,7 +24,7 @@ export default {
     (preset): preset is Preset => Boolean(preset),
   ),
   async prerender() {
-    return ['/terms', '/privacy', '/mint-risks'];
+    return ['/terms', '/privacy', '/mint-risks', '/home'];
   },
   future: {
     unstable_middleware: true,


### PR DESCRIPTION
I added a new public route at `/home` that shows "Coming Soon" with a link to our Discord. If the user triple-clicks, then the login and signup buttons appear.

When the user is not logged, everywhere that used to redirect to `/signup` now redirects to `/home`.

A note on pre-rendering this page:

I recall that we discussed this landing page should be pre-rendered. The problem is that we need to check if the user is logged in to determine whether or not they should be redirected from `/home` to `/`. I'm not sure if this is something we should try to solve now because the page is so small. 

What do you think @jbojcic1? Is it even possible to pre-render this? Would removing the client loader in favor of a useEffect do what we want?