### PR TITLE
fix: support all RFC 1918 private IP ranges for local dev

### DIFF
--- a/app/features/agicash-db/database.ts
+++ b/app/features/agicash-db/database.ts
@@ -23,7 +23,9 @@ const getSupabaseUrl = () => {
     typeof window !== 'undefined' &&
     window.location.protocol === 'https:' &&
     (window.location.hostname.endsWith('.local') ||
-      window.location.hostname.startsWith('192.168.'))
+      window.location.hostname.startsWith('192.168.') ||
+      window.location.hostname.startsWith('10.') ||
+      /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(window.location.hostname))
   ) {
     return supabaseUrl.replace('127.0.0.1', window.location.hostname);
   }

--- a/tools/devenv/generate-ssl-cert.sh
+++ b/tools/devenv/generate-ssl-cert.sh
@@ -3,8 +3,8 @@
 # Get the current hostname
 HOSTNAME=$(hostname)
 
-# Get the local IP address
-LOCAL_IP=$(ifconfig | grep "inet " | grep -v 127.0.0.1 | head -1 | awk '{print $2}')
+# Get the local IP address (excluding entire 127.x.x.x loopback range)
+LOCAL_IP=$(ifconfig | grep "inet " | awk '{print $2}' | grep -v "^127\." | head -1)
 
 # Check if SSL certificate already exist and cover current hostname and local IP
 if [ -f "certs/localhost-cert.pem" ] && [ -f "certs/localhost-key.pem" ]; then  


### PR DESCRIPTION
I was having trouble connecting to the database when connecting to the dev server from my phone. 

Fixes local HTTPS development when on 10.x.x.x or 172.16-31.x.x networks. The SSL cert script now properly excludes all 127.x.x.x loopback addresses (not just 127.0.0.1), and the Supabase URL rewrite logic covers all [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918#section-3) private ranges.