### PR TITLE
slower transition and apply styles synchronously

### DIFF
--- a/app/lib/transitions/transitions.css
+++ b/app/lib/transitions/transitions.css
@@ -89,11 +89,11 @@
 }
 
 ::view-transition-old(root) {
-  animation: var(--direction-out) 0.08s ease-in both; /* This duration value is repeated in view-transition.tsx. When changing make sure to keep them in sync! */
+  animation: var(--direction-out) 0.18s ease-in both; /* This duration value is repeated in view-transition.tsx. When changing make sure to keep them in sync! */
   z-index: var(--view-transition-out-z-index);
 }
 
 ::view-transition-new(root) {
-  animation: var(--direction-in) 0.08s ease-in both; /* This duration value is repeated in view-transition.tsx. When changing make sure to keep them in sync! */
+  animation: var(--direction-in) 0.18s ease-in both; /* This duration value is repeated in view-transition.tsx. When changing make sure to keep them in sync! */
   z-index: var(--view-transition-in-z-index);
 }


### PR DESCRIPTION
This changes the view transition speed from 80ms to 180ms.

Also, while testing this I found that a lot of the time the transition styles were not even being applied. For some reason the way that we originally built this had the transition styles get set when we detected that the navigation state changed to `loading`. There seemed to be a race condition with that setup where navigation would start and the styles would not be applied in time. I changed things so that now the transition styles are applied synchronously when navigation is initiated by the user. This made it so I could remove a lot of code. This should fix some of the bugs we've been seeing with navigation.