### PR TITLE
drop preimage from spark send quote table and encrypt it

### DIFF
--- a/app/features/send/spark-send-quote-repository.ts
+++ b/app/features/send/spark-send-quote-repository.ts
@@ -20,6 +20,7 @@ type EncryptedData = {
   estimatedFee: Money;
   paymentRequest: string;
   fee?: Money;
+  paymentPreimage?: string;
 };
 
 type CreateQuoteParams = {
@@ -229,6 +230,7 @@ export class SparkSendQuoteRepository {
       estimatedFee: quote.estimatedFee,
       paymentRequest: quote.paymentRequest,
       fee: quote.fee,
+      paymentPreimage,
     };
 
     const [encryptedTransactionDetails, encryptedData] =
@@ -236,7 +238,6 @@ export class SparkSendQuoteRepository {
 
     const query = this.db.rpc('complete_spark_send_quote', {
       p_quote_id: quote.id,
-      p_payment_preimage: paymentPreimage,
       p_encrypted_transaction_details: encryptedTransactionDetails,
       p_encrypted_data: encryptedData,
     });
@@ -368,7 +369,7 @@ export class SparkSendQuoteRepository {
           'Invalid spark send quote data. Fee is required for completed state.',
         );
       }
-      if (!data.payment_preimage) {
+      if (!decryptedData.paymentPreimage) {
         throw new Error(
           'Invalid spark send quote data. Payment preimage is required for completed state.',
         );
@@ -380,7 +381,7 @@ export class SparkSendQuoteRepository {
         sparkId: data.spark_id,
         sparkTransferId: data.spark_transfer_id,
         fee: decryptedData.fee,
-        paymentPreimage: data.payment_preimage,
+        paymentPreimage: decryptedData.paymentPreimage,
       };
     }
 

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -598,7 +598,6 @@ export type Database = {
           failure_reason: string | null
           id: string
           payment_hash: string
-          payment_preimage: string | null
           payment_request_is_amountless: boolean
           spark_id: string | null
           spark_transfer_id: string | null
@@ -615,7 +614,6 @@ export type Database = {
           failure_reason?: string | null
           id?: string
           payment_hash: string
-          payment_preimage?: string | null
           payment_request_is_amountless?: boolean
           spark_id?: string | null
           spark_transfer_id?: string | null
@@ -632,7 +630,6 @@ export type Database = {
           failure_reason?: string | null
           id?: string
           payment_hash?: string
-          payment_preimage?: string | null
           payment_request_is_amountless?: boolean
           spark_id?: string | null
           spark_transfer_id?: string | null
@@ -982,7 +979,6 @@ export type Database = {
         Args: {
           p_encrypted_data: string
           p_encrypted_transaction_details: string
-          p_payment_preimage: string
           p_quote_id: string
         }
         Returns: {
@@ -993,7 +989,6 @@ export type Database = {
           failure_reason: string | null
           id: string
           payment_hash: string
-          payment_preimage: string | null
           payment_request_is_amountless: boolean
           spark_id: string | null
           spark_transfer_id: string | null
@@ -1169,7 +1164,6 @@ export type Database = {
           failure_reason: string | null
           id: string
           payment_hash: string
-          payment_preimage: string | null
           payment_request_is_amountless: boolean
           spark_id: string | null
           spark_transfer_id: string | null
@@ -1361,7 +1355,6 @@ export type Database = {
           failure_reason: string | null
           id: string
           payment_hash: string
-          payment_preimage: string | null
           payment_request_is_amountless: boolean
           spark_id: string | null
           spark_transfer_id: string | null
@@ -1504,7 +1497,6 @@ export type Database = {
           failure_reason: string | null
           id: string
           payment_hash: string
-          payment_preimage: string | null
           payment_request_is_amountless: boolean
           spark_id: string | null
           spark_transfer_id: string | null

--- a/supabase/migrations/20260105191745_drop-preimage-from-spark-sends.sql
+++ b/supabase/migrations/20260105191745_drop-preimage-from-spark-sends.sql
@@ -1,0 +1,73 @@
+-- =============================================================================
+-- migration: drop-preimage-from-spark-sends
+-- purpose: removes the payment_preimage column from spark_send_quotes table
+-- affected tables: wallet.spark_send_quotes
+-- affected functions: wallet.complete_spark_send_quote
+--
+-- this is a follow-up fix to 20251223184411_encrypt-all-sensitive-data.sql.
+-- the payment_preimage column should have been dropped in that migration as
+-- part of encrypting sensitive data, but it was overlooked.
+-- =============================================================================
+
+-- drop the payment_preimage column which is no longer needed since preimage
+-- data is now stored encrypted in the encrypted_data column
+alter table wallet.spark_send_quotes drop column payment_preimage;
+
+-- drop the old function signature that included p_payment_preimage parameter
+drop function if exists wallet.complete_spark_send_quote(uuid, text, text, text);
+
+-- recreate the function without the payment_preimage parameter
+create or replace function wallet.complete_spark_send_quote(
+  p_quote_id uuid,
+  p_encrypted_transaction_details text,
+  p_encrypted_data text
+)
+returns wallet.spark_send_quotes
+language plpgsql
+as $function$
+declare
+  v_quote wallet.spark_send_quotes;
+begin
+  select * into v_quote
+  from wallet.spark_send_quotes
+  where id = p_quote_id
+  for update;
+
+  if v_quote is null then
+    raise exception
+      using
+        hint = 'NOT_FOUND',
+        message = format('Spark send quote with id %s not found.', p_quote_id);
+  end if;
+
+  if v_quote.state = 'COMPLETED' then
+    return v_quote;
+  end if;
+
+  if v_quote.state not in ('UNPAID', 'PENDING') then
+    raise exception
+      using
+        hint = 'INVALID_STATE',
+        message = format('Failed to complete spark send quote with id %s.', v_quote.id),
+        detail = format('Found state %s, but must be UNPAID or PENDING.', v_quote.state);
+  end if;
+
+  update wallet.spark_send_quotes
+  set
+    state = 'COMPLETED',
+    encrypted_data = p_encrypted_data,
+    version = version + 1
+  where id = p_quote_id
+  returning * into v_quote;
+
+  update wallet.transactions
+  set
+    state = 'COMPLETED',
+    acknowledgment_status = 'pending',
+    completed_at = now(),
+    encrypted_transaction_details = p_encrypted_transaction_details
+  where id = v_quote.transaction_id;
+
+  return v_quote;
+end;
+$function$;


### PR DESCRIPTION
I was looking at the tables and realized we still have the preimage in clear text for spark send quotes. In #727 we encrypted preimage spark receives and cashu sends (cashu receives don't have preimage). This PR just drop the payment_preimage column for spark sends and moves it to the encrypted data for the quote