### PR TITLE
merge encrypted data and encrypted transaction details

### DIFF
--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -24,23 +24,37 @@ type Options = {
   abortSignal?: AbortSignal;
 };
 
-type EncryptedData = {
-  amount: Money;
-  quoteId: string;
-  paymentRequest: string;
-  description?: string;
-  mintingFee?: Money;
-  outputAmounts?: number[];
+type EncryptedQuoteData = {
   /**
-   * Data related to cross-account cashu token receives.
-   * Present only for CASHU_TOKEN type quotes.
+   * The mint quote ID.
    */
-  tokenReceiveData?: {
-    sourceMintUrl: string;
-    tokenProofs: Proof[];
-    meltQuoteId: string;
-  };
+  quoteId: string;
+  /**
+   * The bolt11 payment request.
+   * For CASHU_TOKEN quotes, this is the internal invoice used for melt/mint.
+   * For LIGHTNING quotes, this is the same as the paymentRequest in CashuLightningReceiveTransactionDetails.
+   */
+  paymentRequest: string;
+  /**
+   * Amounts for each blinded message created for this receive.
+   * Populated after payment is processed (PAID/COMPLETED states).
+   */
+  outputAmounts?: number[];
 };
+
+type EncryptedDataLightning = CashuLightningReceiveTransactionDetails &
+  EncryptedQuoteData;
+type EncryptedDataToken = CashuTokenReceiveTransactionDetails &
+  EncryptedQuoteData & {
+    /**
+     * Data related to cross-account cashu token receives.
+     */
+    tokenReceiveData: {
+      sourceMintUrl: string;
+      tokenProofs: Proof[];
+      meltQuoteId: string;
+    };
+  };
 
 type CreateQuote = {
   /**
@@ -152,9 +166,7 @@ export class CashuReceiveQuoteRepository {
       mintingFee,
     } = params;
 
-    let details:
-      | CashuLightningReceiveTransactionDetails
-      | CashuTokenReceiveTransactionDetails;
+    let dataToEncrypt: EncryptedDataLightning | EncryptedDataToken;
 
     if (receiveType === 'CASHU_TOKEN') {
       const { cashuReceiveFee, tokenAmount, lightningFeeReserve } = params;
@@ -163,44 +175,37 @@ export class CashuReceiveQuoteRepository {
         ? cashuReceiveFee.add(lightningFeeReserve).add(mintingFee)
         : cashuReceiveFee.add(lightningFeeReserve);
 
-      details = {
+      dataToEncrypt = {
         amountReceived: amount,
         tokenAmount,
         cashuReceiveFee,
         lightningFeeReserve,
         mintingFee,
         totalFees,
-      } satisfies CashuTokenReceiveTransactionDetails;
+        quoteId,
+        paymentRequest,
+        tokenReceiveData: {
+          sourceMintUrl: params.sourceMintUrl,
+          tokenProofs: params.tokenProofs,
+          meltQuoteId: params.meltQuoteId,
+        },
+      } satisfies EncryptedDataToken;
     } else {
-      details = {
+      dataToEncrypt = {
         amountReceived: amount,
         paymentRequest,
         description,
         mintingFee,
-      } satisfies CashuLightningReceiveTransactionDetails;
+        quoteId,
+      } satisfies EncryptedDataLightning;
     }
 
-    const dataToEncrypt: EncryptedData = {
-      amount,
-      quoteId,
-      paymentRequest,
-      description,
-      mintingFee,
-    };
-
-    if (receiveType === 'CASHU_TOKEN') {
-      dataToEncrypt.tokenReceiveData = {
-        sourceMintUrl: params.sourceMintUrl,
-        tokenProofs: params.tokenProofs,
-        meltQuoteId: params.meltQuoteId,
-      };
-    }
-
-    const [[encryptedTransactionDetails, encryptedData], quoteIdHash] =
-      await Promise.all([
-        this.encryption.encryptBatch([details, dataToEncrypt]),
-        computeSHA256(quoteId),
-      ]);
+    const [encryptedData, quoteIdHash] = await Promise.all([
+      this.encryption.encrypt<EncryptedDataLightning | EncryptedDataToken>(
+        dataToEncrypt,
+      ),
+      computeSHA256(quoteId),
+    ]);
 
     const query = this.db.rpc('create_cashu_receive_quote', {
       p_user_id: userId,
@@ -209,7 +214,7 @@ export class CashuReceiveQuoteRepository {
       p_expires_at: expiresAt,
       p_locking_derivation_path: lockingDerivationPath,
       p_receive_type: receiveType,
-      p_encrypted_transaction_details: encryptedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
       p_encrypted_data: encryptedData,
       p_quote_id_hash: quoteIdHash,
       p_payment_hash: paymentHash,
@@ -356,21 +361,34 @@ export class CashuReceiveQuoteRepository {
      */
     account: CashuAccount;
   }> {
-    const dataToEncrypt: EncryptedData = {
-      amount: quote.amount,
-      quoteId: quote.quoteId,
-      paymentRequest: quote.paymentRequest,
-      description: quote.description,
-      mintingFee: quote.mintingFee,
-      outputAmounts,
-    };
+    let dataToEncrypt: EncryptedDataLightning | EncryptedDataToken;
 
     if (quote.type === 'CASHU_TOKEN') {
-      dataToEncrypt.tokenReceiveData = {
-        sourceMintUrl: quote.tokenReceiveData.sourceMintUrl,
-        tokenProofs: quote.tokenReceiveData.tokenProofs,
-        meltQuoteId: quote.tokenReceiveData.meltQuoteId,
-      };
+      dataToEncrypt = {
+        amountReceived: quote.amount,
+        tokenAmount: quote.tokenAmount,
+        cashuReceiveFee: quote.cashuReceiveFee,
+        lightningFeeReserve: quote.lightningFeeReserve,
+        mintingFee: quote.mintingFee,
+        totalFees: quote.totalFees,
+        quoteId: quote.quoteId,
+        paymentRequest: quote.paymentRequest,
+        outputAmounts,
+        tokenReceiveData: {
+          sourceMintUrl: quote.tokenReceiveData.sourceMintUrl,
+          tokenProofs: quote.tokenReceiveData.tokenProofs,
+          meltQuoteId: quote.tokenReceiveData.meltQuoteId,
+        },
+      } satisfies EncryptedDataToken;
+    } else {
+      dataToEncrypt = {
+        amountReceived: quote.amount,
+        paymentRequest: quote.paymentRequest,
+        description: quote.description,
+        mintingFee: quote.mintingFee,
+        quoteId: quote.quoteId,
+        outputAmounts,
+      } satisfies EncryptedDataLightning;
     }
 
     const encryptedData = await this.encryption.encrypt(dataToEncrypt);
@@ -556,17 +574,18 @@ export class CashuReceiveQuoteRepository {
   }
 
   async toQuote(data: AgicashDbCashuReceiveQuote): Promise<CashuReceiveQuote> {
-    const [decryptedData] = await this.encryption.decryptBatch<[EncryptedData]>(
-      [data.encrypted_data],
-    );
+    const { decryptedData, typeData } =
+      data.type === 'CASHU_TOKEN'
+        ? await this.decryptTokenQuoteData(data)
+        : await this.decryptLightningQuoteData(data);
 
     const baseData = {
       id: data.id,
       userId: data.user_id,
       accountId: data.account_id,
       quoteId: decryptedData.quoteId,
-      amount: decryptedData.amount,
-      description: decryptedData.description,
+      amount: decryptedData.amountReceived,
+      description: (decryptedData as EncryptedDataLightning).description,
       createdAt: data.created_at,
       expiresAt: data.expires_at,
       paymentRequest: decryptedData.paymentRequest,
@@ -576,34 +595,6 @@ export class CashuReceiveQuoteRepository {
       transactionId: data.transaction_id,
       mintingFee: decryptedData.mintingFee,
     };
-
-    if (data.type === 'CASHU_TOKEN' && !decryptedData.tokenReceiveData) {
-      throw new Error(
-        'Invalid cashu receive quote data. Token receive data is required for CASHU_TOKEN type quotes.',
-      );
-    }
-
-    if (
-      data.type === 'CASHU_TOKEN' &&
-      data.cashu_token_melt_initiated == null
-    ) {
-      throw new Error(
-        'Invalid cashu receive quote data. cashu_token_melt_initiated cannot be null for CASHU_TOKEN type quotes.',
-      );
-    }
-
-    const typeData =
-      data.type === 'CASHU_TOKEN' && decryptedData.tokenReceiveData
-        ? ({
-            type: 'CASHU_TOKEN',
-            tokenReceiveData: {
-              sourceMintUrl: decryptedData.tokenReceiveData.sourceMintUrl,
-              tokenProofs: decryptedData.tokenReceiveData.tokenProofs,
-              meltQuoteId: decryptedData.tokenReceiveData.meltQuoteId,
-              meltInitiated: data.cashu_token_melt_initiated ?? false,
-            },
-          } as const)
-        : ({ type: 'LIGHTNING' } as const);
 
     if (data.state === 'PAID' || data.state === 'COMPLETED') {
       return {
@@ -634,6 +625,49 @@ export class CashuReceiveQuoteRepository {
     }
 
     throw new Error(`Unexpected quote state ${data.state}`);
+  }
+
+  private async decryptLightningQuoteData(data: AgicashDbCashuReceiveQuote) {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataLightning]
+    >([data.encrypted_data]);
+
+    return { decryptedData, typeData: { type: 'LIGHTNING' } as const };
+  }
+
+  private async decryptTokenQuoteData(data: AgicashDbCashuReceiveQuote) {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataToken]
+    >([data.encrypted_data]);
+
+    if (!decryptedData.tokenReceiveData) {
+      throw new Error(
+        'Invalid cashu receive quote data. Token receive data is required for CASHU_TOKEN type quotes.',
+      );
+    }
+
+    if (data.cashu_token_melt_initiated == null) {
+      throw new Error(
+        'Invalid cashu receive quote data. cashu_token_melt_initiated cannot be null for CASHU_TOKEN type quotes.',
+      );
+    }
+
+    return {
+      decryptedData,
+      typeData: {
+        type: 'CASHU_TOKEN',
+        tokenAmount: decryptedData.tokenAmount,
+        cashuReceiveFee: decryptedData.cashuReceiveFee,
+        lightningFeeReserve: decryptedData.lightningFeeReserve,
+        totalFees: decryptedData.totalFees,
+        tokenReceiveData: {
+          sourceMintUrl: decryptedData.tokenReceiveData.sourceMintUrl,
+          tokenProofs: decryptedData.tokenReceiveData.tokenProofs,
+          meltQuoteId: decryptedData.tokenReceiveData.meltQuoteId,
+          meltInitiated: data.cashu_token_melt_initiated,
+        },
+      } as const,
+    };
   }
 }
 

--- a/app/features/receive/cashu-receive-quote.ts
+++ b/app/features/receive/cashu-receive-quote.ts
@@ -104,6 +104,24 @@ type CashuReceiveQuoteByType =
        * Data related to cross-account cashu token receives.
        */
       tokenReceiveData: CashuReceiveQuoteTokenReceiveData;
+      /**
+       * The amount of the token being claimed.
+       */
+      tokenAmount: Money;
+      /**
+       * The fee that will be incurred when swapping proofs to the account.
+       */
+      cashuReceiveFee: Money;
+      /**
+       * The fee reserved for the lightning payment to melt the proofs to the account.
+       * This is defined when the token is melted from the source mint into this receiving account.
+       * This will be undefined when receiving proofs to the source account which just requires a swap.
+       */
+      lightningFeeReserve?: Money;
+      /**
+       * The total fees for the transaction.
+       */
+      totalFees: Money;
     };
 
 type CashuReceiveQuoteByState =

--- a/app/features/send/cashu-send-quote-repository.ts
+++ b/app/features/send/cashu-send-quote-repository.ts
@@ -27,17 +27,25 @@ type Options = {
   abortSignal?: AbortSignal;
 };
 
-type EncryptedData = {
-  paymentRequest: string;
+type EncryptedQuoteData = {
+  /**
+   * Amount requested to send in the original currency.
+   */
   amountRequested: Money;
+  /**
+   * Amount requested to send converted to milli-satoshis.
+   */
   amountRequestedInMsat: number;
-  amountToReceive: Money;
-  lightningFeeReserve: Money;
-  cashuFee: Money;
+  /**
+   * Id of the melt quote.
+   */
   quoteId: string;
-  amountSpent?: Money;
-  paymentPreimage?: string;
 };
+
+type EncryptedDataIncomplete = IncompleteCashuLightningSendTransactionDetails &
+  EncryptedQuoteData;
+type EncryptedDataCompleted = CompletedCashuLightningSendTransactionDetails &
+  EncryptedQuoteData;
 
 type CreateSendQuote = {
   /**
@@ -138,30 +146,22 @@ export class CashuSendQuoteRepository {
     }: CreateSendQuote,
     options?: Options,
   ): Promise<CashuSendQuote> {
-    const details: IncompleteCashuLightningSendTransactionDetails = {
+    const dataToEncrypt: EncryptedDataIncomplete = {
       amountToReceive,
       cashuSendFee: cashuFee,
       lightningFeeReserve,
       amountReserved,
       paymentRequest,
       destinationDetails,
-    };
-
-    const dataToEncrypt: EncryptedData = {
-      paymentRequest,
       amountRequested,
       amountRequestedInMsat,
-      amountToReceive,
-      lightningFeeReserve,
-      cashuFee,
       quoteId,
     };
 
-    const [[encryptedTransactionDetails, encryptedData], quoteIdHash] =
-      await Promise.all([
-        this.encryption.encryptBatch([details, dataToEncrypt]),
-        computeSHA256(quoteId),
-      ]);
+    const [encryptedData, quoteIdHash] = await Promise.all([
+      this.encryption.encrypt(dataToEncrypt),
+      computeSHA256(quoteId),
+    ]);
 
     const query = this.db.rpc('create_cashu_send_quote', {
       p_user_id: userId,
@@ -173,7 +173,7 @@ export class CashuSendQuoteRepository {
       p_number_of_change_outputs: numberOfChangeOutputs,
       p_proofs_to_send: proofsToSend.map((p) => p.id),
       p_encrypted_data: encryptedData,
-      p_encrypted_transaction_details: encryptedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
       p_quote_id_hash: quoteIdHash,
       p_payment_hash: paymentHash,
     });
@@ -248,41 +248,32 @@ export class CashuSendQuoteRepository {
       throw new Error(`Transaction not found for quote ${quote.id}.`);
     }
 
-    const updatedTransactionDetails: CompletedCashuLightningSendTransactionDetails =
-      {
-        ...transaction.details,
-        preimage: paymentPreimage,
-        amountSpent,
-        lightningFee: actualLightningFee,
-        totalFees,
-      };
-
     const proofDataToEncrypt = changeProofs.flatMap((x) => [
       x.amount,
       x.secret,
     ]);
 
-    const dataToEncrypt: EncryptedData = {
+    const dataToEncrypt: EncryptedDataCompleted = {
+      amountToReceive: quote.amountToReceive,
+      cashuSendFee: quote.cashuFee,
+      lightningFeeReserve: quote.lightningFeeReserve,
+      amountReserved: transaction.details.amountReserved,
       paymentRequest: quote.paymentRequest,
+      destinationDetails: transaction.details.destinationDetails,
       amountRequested: quote.amountRequested,
       amountRequestedInMsat: quote.amountRequestedInMsat,
-      amountToReceive: quote.amountToReceive,
-      lightningFeeReserve: quote.lightningFeeReserve,
-      cashuFee: quote.cashuFee,
       quoteId: quote.quoteId,
       amountSpent,
-      paymentPreimage,
+      preimage: paymentPreimage,
+      lightningFee: actualLightningFee,
+      totalFees,
     };
 
-    const [
-      encryptedData,
-      encryptedUpdatedTransactionDetails,
-      ...encryptedProofData
-    ] = await this.encryption.encryptBatch([
-      dataToEncrypt,
-      updatedTransactionDetails,
-      ...proofDataToEncrypt,
-    ]);
+    const [encryptedData, ...encryptedProofData] =
+      await this.encryption.encryptBatch([
+        dataToEncrypt,
+        ...proofDataToEncrypt,
+      ]);
 
     const encryptedProofs = changeProofs.map((x, index) => {
       const encryptedDataIndex = index * 2;
@@ -301,7 +292,7 @@ export class CashuSendQuoteRepository {
       p_quote_id: quote.id,
       p_change_proofs: encryptedProofs,
       p_encrypted_data: encryptedData,
-      p_encrypted_transaction_details: encryptedUpdatedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
     });
 
     if (options?.abortSignal) {
@@ -491,52 +482,12 @@ export class CashuSendQuoteRepository {
   async toSendQuote(
     data: AgicashDbCashuSendQuote & { cashu_proofs: AgicashDbCashuProof[] },
   ): Promise<CashuSendQuote> {
-    const [encryptedData] = await this.encryption.decryptBatch<[EncryptedData]>(
-      [data.encrypted_data],
-    );
-
-    const proofs = await this.decryptCashuProofs(data.cashu_proofs);
-
-    const commonData = {
-      id: data.id,
-      createdAt: data.created_at,
-      expiresAt: data.expires_at,
-      userId: data.user_id,
-      accountId: data.account_id,
-      paymentRequest: encryptedData.paymentRequest,
-      paymentHash: data.payment_hash,
-      amountRequested: encryptedData.amountRequested,
-      amountRequestedInMsat: encryptedData.amountRequestedInMsat,
-      amountToReceive: encryptedData.amountToReceive,
-      lightningFeeReserve: encryptedData.lightningFeeReserve,
-      cashuFee: encryptedData.cashuFee,
-      proofs,
-      quoteId: encryptedData.quoteId,
-      keysetId: data.keyset_id,
-      keysetCounter: data.keyset_counter,
-      numberOfChangeOutputs: data.number_of_change_outputs,
-      version: data.version,
-      transactionId: data.transaction_id,
-    };
-
     if (data.state === 'PAID') {
-      if (!encryptedData.amountSpent) {
-        throw new Error('amountSpent is required for PAID state');
-      }
-      return {
-        ...commonData,
-        state: 'PAID',
-        paymentPreimage: encryptedData.paymentPreimage ?? '',
-        amountSpent: encryptedData.amountSpent,
-      };
+      return this.decryptPaidQuote(data);
     }
 
     if (data.state === 'FAILED') {
-      return {
-        ...commonData,
-        state: 'FAILED',
-        failureReason: data.failure_reason ?? '',
-      };
+      return this.decryptFailedQuote(data);
     }
 
     if (
@@ -544,13 +495,112 @@ export class CashuSendQuoteRepository {
       data.state === 'PENDING' ||
       data.state === 'EXPIRED'
     ) {
-      return {
-        ...commonData,
-        state: data.state,
-      };
+      return this.decryptIncompleteQuote(data);
     }
 
     throw new Error(`Unexpected quote state ${data.state}`);
+  }
+
+  private async decryptIncompleteQuote(
+    data: AgicashDbCashuSendQuote & { cashu_proofs: AgicashDbCashuProof[] },
+  ): Promise<CashuSendQuote & { state: 'UNPAID' | 'PENDING' | 'EXPIRED' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataIncomplete]
+    >([data.encrypted_data]);
+
+    const proofs = await this.decryptCashuProofs(data.cashu_proofs);
+
+    return {
+      id: data.id,
+      state: data.state as 'UNPAID' | 'PENDING' | 'EXPIRED',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      userId: data.user_id,
+      accountId: data.account_id,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      amountRequested: decryptedData.amountRequested,
+      amountRequestedInMsat: decryptedData.amountRequestedInMsat,
+      amountToReceive: decryptedData.amountToReceive,
+      lightningFeeReserve: decryptedData.lightningFeeReserve,
+      cashuFee: decryptedData.cashuSendFee,
+      proofs,
+      quoteId: decryptedData.quoteId,
+      keysetId: data.keyset_id,
+      keysetCounter: data.keyset_counter,
+      numberOfChangeOutputs: data.number_of_change_outputs,
+      version: data.version,
+      transactionId: data.transaction_id,
+    };
+  }
+
+  private async decryptPaidQuote(
+    data: AgicashDbCashuSendQuote & { cashu_proofs: AgicashDbCashuProof[] },
+  ): Promise<CashuSendQuote & { state: 'PAID' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataCompleted]
+    >([data.encrypted_data]);
+
+    const proofs = await this.decryptCashuProofs(data.cashu_proofs);
+
+    return {
+      id: data.id,
+      state: 'PAID',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      userId: data.user_id,
+      accountId: data.account_id,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      amountRequested: decryptedData.amountRequested,
+      amountRequestedInMsat: decryptedData.amountRequestedInMsat,
+      amountToReceive: decryptedData.amountToReceive,
+      lightningFeeReserve: decryptedData.lightningFeeReserve,
+      cashuFee: decryptedData.cashuSendFee,
+      proofs,
+      quoteId: decryptedData.quoteId,
+      keysetId: data.keyset_id,
+      keysetCounter: data.keyset_counter,
+      numberOfChangeOutputs: data.number_of_change_outputs,
+      version: data.version,
+      transactionId: data.transaction_id,
+      paymentPreimage: decryptedData.preimage,
+      amountSpent: decryptedData.amountSpent,
+    };
+  }
+
+  private async decryptFailedQuote(
+    data: AgicashDbCashuSendQuote & { cashu_proofs: AgicashDbCashuProof[] },
+  ): Promise<CashuSendQuote & { state: 'FAILED' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataIncomplete]
+    >([data.encrypted_data]);
+
+    const proofs = await this.decryptCashuProofs(data.cashu_proofs);
+
+    return {
+      id: data.id,
+      state: 'FAILED',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      userId: data.user_id,
+      accountId: data.account_id,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      amountRequested: decryptedData.amountRequested,
+      amountRequestedInMsat: decryptedData.amountRequestedInMsat,
+      amountToReceive: decryptedData.amountToReceive,
+      lightningFeeReserve: decryptedData.lightningFeeReserve,
+      cashuFee: decryptedData.cashuSendFee,
+      proofs,
+      quoteId: decryptedData.quoteId,
+      keysetId: data.keyset_id,
+      keysetCounter: data.keyset_counter,
+      numberOfChangeOutputs: data.number_of_change_outputs,
+      version: data.version,
+      transactionId: data.transaction_id,
+      failureReason: data.failure_reason ?? '',
+    };
   }
 
   private async decryptCashuProofs(

--- a/app/features/send/spark-send-quote-repository.ts
+++ b/app/features/send/spark-send-quote-repository.ts
@@ -15,13 +15,13 @@ type Options = {
   abortSignal?: AbortSignal;
 };
 
-type EncryptedData = {
-  amount: Money;
-  estimatedFee: Money;
-  paymentRequest: string;
-  fee?: Money;
-  paymentPreimage?: string;
-};
+type EncryptedDataUnpaid = Pick<
+  IncompleteSparkLightningSendTransactionDetails,
+  'amountToReceive' | 'estimatedFee' | 'paymentRequest'
+>;
+type EncryptedDataPending =
+  Required<IncompleteSparkLightningSendTransactionDetails>;
+type EncryptedDataCompleted = CompletedSparkLightningSendTransactionDetails;
 
 type CreateQuoteParams = {
   /**
@@ -83,20 +83,13 @@ export class SparkSendQuoteRepository {
       expiresAt,
     } = params;
 
-    const detailsToEncrypt: IncompleteSparkLightningSendTransactionDetails = {
+    const dataToEncrypt: EncryptedDataUnpaid = {
       amountToReceive: amount,
       estimatedFee,
       paymentRequest,
     };
 
-    const dataToEncrypt: EncryptedData = {
-      amount,
-      estimatedFee,
-      paymentRequest,
-    };
-
-    const [encryptedTransactionDetails, encryptedData] =
-      await this.encryption.encryptBatch([detailsToEncrypt, dataToEncrypt]);
+    const encryptedData = await this.encryption.encrypt(dataToEncrypt);
 
     const query = this.db.rpc('create_spark_send_quote', {
       p_user_id: userId,
@@ -104,7 +97,7 @@ export class SparkSendQuoteRepository {
       p_currency: amount.currency,
       p_payment_hash: paymentHash,
       p_payment_request_is_amountless: paymentRequestIsAmountless,
-      p_encrypted_transaction_details: encryptedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
       p_encrypted_data: encryptedData,
       p_expires_at: expiresAt?.toISOString(),
     });
@@ -152,29 +145,23 @@ export class SparkSendQuoteRepository {
     },
     options?: Options,
   ): Promise<SparkSendQuote> {
-    const detailsToEncrypt: IncompleteSparkLightningSendTransactionDetails = {
+    const dataToEncrypt: EncryptedDataPending = {
       amountToReceive: quote.amount,
       amountSpent: quote.amount.add(fee),
       estimatedFee: quote.estimatedFee,
       paymentRequest: quote.paymentRequest,
+      sparkId: sparkSendRequestId,
+      sparkTransferId: sparkTransferId,
       fee,
     };
 
-    const dataToEncrypt: EncryptedData = {
-      amount: quote.amount,
-      estimatedFee: quote.estimatedFee,
-      paymentRequest: quote.paymentRequest,
-      fee: fee,
-    };
-
-    const [encryptedTransactionDetails, encryptedData] =
-      await this.encryption.encryptBatch([detailsToEncrypt, dataToEncrypt]);
+    const encryptedData = await this.encryption.encrypt(dataToEncrypt);
 
     const query = this.db.rpc('mark_spark_send_quote_as_pending', {
       p_quote_id: quote.id,
       p_spark_id: sparkSendRequestId,
       p_spark_transfer_id: sparkTransferId,
-      p_encrypted_transaction_details: encryptedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
       p_encrypted_data: encryptedData,
     });
 
@@ -213,32 +200,22 @@ export class SparkSendQuoteRepository {
     },
     options?: Options,
   ): Promise<SparkSendQuote> {
-    const detailsToEncrypt: Omit<
-      CompletedSparkLightningSendTransactionDetails,
-      'sparkId' | 'sparkTransferId'
-    > = {
+    const dataToEncrypt: EncryptedDataCompleted = {
       amountToReceive: quote.amount,
       amountSpent: quote.amount.add(quote.fee),
       estimatedFee: quote.estimatedFee,
       paymentRequest: quote.paymentRequest,
       fee: quote.fee,
+      sparkId: quote.sparkId,
+      sparkTransferId: quote.sparkTransferId,
       paymentPreimage,
     };
 
-    const dataToEncrypt: EncryptedData = {
-      amount: quote.amount,
-      estimatedFee: quote.estimatedFee,
-      paymentRequest: quote.paymentRequest,
-      fee: quote.fee,
-      paymentPreimage,
-    };
-
-    const [encryptedTransactionDetails, encryptedData] =
-      await this.encryption.encryptBatch([detailsToEncrypt, dataToEncrypt]);
+    const encryptedData = await this.encryption.encrypt(dataToEncrypt);
 
     const query = this.db.rpc('complete_spark_send_quote', {
       p_quote_id: quote.id,
-      p_encrypted_transaction_details: encryptedTransactionDetails,
+      p_encrypted_transaction_details: encryptedData,
       p_encrypted_data: encryptedData,
     });
 
@@ -333,16 +310,35 @@ export class SparkSendQuoteRepository {
   }
 
   async toQuote(data: AgicashDbSparkSendQuote): Promise<SparkSendQuote> {
-    const [decryptedData] = await this.encryption.decryptBatch<[EncryptedData]>(
-      [data.encrypted_data],
-    );
+    if (data.state === 'UNPAID') {
+      return this.decryptUnpaidQuote(data);
+    }
+    if (data.state === 'PENDING') {
+      return this.decryptPendingQuote(data);
+    }
+    if (data.state === 'COMPLETED') {
+      return this.decryptCompletedQuote(data);
+    }
+    if (data.state === 'FAILED') {
+      return this.decryptFailedQuote(data);
+    }
 
-    const baseQuote = {
+    throw new Error(`Unexpected quote state ${data.state}`);
+  }
+
+  private async decryptUnpaidQuote(
+    data: AgicashDbSparkSendQuote,
+  ): Promise<SparkSendQuote & { state: 'UNPAID' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataUnpaid]
+    >([data.encrypted_data]);
+
+    return {
       id: data.id,
-      sparkId: data.spark_id,
+      state: 'UNPAID',
       createdAt: data.created_at,
       expiresAt: data.expires_at,
-      amount: decryptedData.amount,
+      amount: decryptedData.amountToReceive,
       estimatedFee: decryptedData.estimatedFee,
       paymentRequest: decryptedData.paymentRequest,
       paymentHash: data.payment_hash,
@@ -352,84 +348,111 @@ export class SparkSendQuoteRepository {
       version: data.version,
       paymentRequestIsAmountless: data.payment_request_is_amountless,
     };
+  }
 
-    if (data.state === 'COMPLETED') {
-      if (!data.spark_id) {
-        throw new Error(
-          'Invalid spark send quote data. Spark id is required for completed state.',
-        );
-      }
-      if (!data.spark_transfer_id) {
-        throw new Error(
-          'Invalid spark send quote data. Spark transfer id is required for completed state.',
-        );
-      }
-      if (!decryptedData.fee) {
-        throw new Error(
-          'Invalid spark send quote data. Fee is required for completed state.',
-        );
-      }
-      if (!decryptedData.paymentPreimage) {
-        throw new Error(
-          'Invalid spark send quote data. Payment preimage is required for completed state.',
-        );
-      }
+  private async decryptPendingQuote(
+    data: AgicashDbSparkSendQuote,
+  ): Promise<SparkSendQuote & { state: 'PENDING' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataPending]
+    >([data.encrypted_data]);
 
-      return {
-        ...baseQuote,
-        state: 'COMPLETED',
-        sparkId: data.spark_id,
-        sparkTransferId: data.spark_transfer_id,
-        fee: decryptedData.fee,
-        paymentPreimage: decryptedData.paymentPreimage,
-      };
+    if (!data.spark_id) {
+      throw new Error(
+        'Invalid spark send quote data. Spark id is required for pending state.',
+      );
+    }
+    if (!data.spark_transfer_id) {
+      throw new Error(
+        'Invalid spark send quote data. Spark transfer id is required for pending state.',
+      );
     }
 
-    if (data.state === 'FAILED') {
-      return {
-        ...baseQuote,
-        state: 'FAILED',
-        failureReason: data.failure_reason ?? undefined,
-        sparkId: data.spark_id ?? undefined,
-        sparkTransferId: data.spark_transfer_id ?? undefined,
-        fee: decryptedData.fee,
-      };
+    return {
+      id: data.id,
+      state: 'PENDING',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      amount: decryptedData.amountToReceive,
+      estimatedFee: decryptedData.estimatedFee,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      transactionId: data.transaction_id,
+      userId: data.user_id,
+      accountId: data.account_id,
+      version: data.version,
+      paymentRequestIsAmountless: data.payment_request_is_amountless,
+      sparkId: data.spark_id,
+      sparkTransferId: data.spark_transfer_id,
+      fee: decryptedData.fee,
+    };
+  }
+
+  private async decryptCompletedQuote(
+    data: AgicashDbSparkSendQuote,
+  ): Promise<SparkSendQuote & { state: 'COMPLETED' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataCompleted]
+    >([data.encrypted_data]);
+
+    if (!data.spark_id) {
+      throw new Error(
+        'Invalid spark send quote data. Spark id is required for completed state.',
+      );
+    }
+    if (!data.spark_transfer_id) {
+      throw new Error(
+        'Invalid spark send quote data. Spark transfer id is required for completed state.',
+      );
     }
 
-    if (data.state === 'PENDING') {
-      if (!data.spark_id) {
-        throw new Error(
-          'Invalid spark send quote data. Spark id is required for pending state.',
-        );
-      }
-      if (!data.spark_transfer_id) {
-        throw new Error(
-          'Invalid spark send quote data. Spark transfer id is required for pending state.',
-        );
-      }
-      if (!decryptedData.fee) {
-        throw new Error(
-          'Invalid spark send quote data. Fee is required for pending state.',
-        );
-      }
+    return {
+      id: data.id,
+      state: 'COMPLETED',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      amount: decryptedData.amountToReceive,
+      estimatedFee: decryptedData.estimatedFee,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      transactionId: data.transaction_id,
+      userId: data.user_id,
+      accountId: data.account_id,
+      version: data.version,
+      paymentRequestIsAmountless: data.payment_request_is_amountless,
+      sparkId: data.spark_id,
+      sparkTransferId: data.spark_transfer_id,
+      fee: decryptedData.fee,
+      paymentPreimage: decryptedData.paymentPreimage,
+    };
+  }
 
-      return {
-        ...baseQuote,
-        state: 'PENDING',
-        sparkId: data.spark_id,
-        sparkTransferId: data.spark_transfer_id,
-        fee: decryptedData.fee,
-      };
-    }
+  private async decryptFailedQuote(
+    data: AgicashDbSparkSendQuote,
+  ): Promise<SparkSendQuote & { state: 'FAILED' }> {
+    const [decryptedData] = await this.encryption.decryptBatch<
+      [EncryptedDataPending | EncryptedDataUnpaid]
+    >([data.encrypted_data]);
 
-    if (data.state === 'UNPAID') {
-      return {
-        ...baseQuote,
-        state: 'UNPAID',
-      };
-    }
-
-    throw new Error(`Unexpected quote state ${data.state}`);
+    return {
+      id: data.id,
+      state: 'FAILED',
+      createdAt: data.created_at,
+      expiresAt: data.expires_at,
+      amount: decryptedData.amountToReceive,
+      estimatedFee: decryptedData.estimatedFee,
+      paymentRequest: decryptedData.paymentRequest,
+      paymentHash: data.payment_hash,
+      transactionId: data.transaction_id,
+      userId: data.user_id,
+      accountId: data.account_id,
+      version: data.version,
+      paymentRequestIsAmountless: data.payment_request_is_amountless,
+      failureReason: data.failure_reason ?? undefined,
+      sparkId: data.spark_id ?? undefined,
+      sparkTransferId: data.spark_transfer_id ?? undefined,
+      fee: (decryptedData as EncryptedDataPending).fee,
+    };
   }
 }
 


### PR DESCRIPTION
This makes it so that the encrypted data on quotes/swaps and the encrypted transaction details are the same encrypted blob.

The way I did this is by extending the `EncryptedData` types in the repositories with the encrypted transaction details for that type. I was also wondering if we would want to just make one shared type, like `EncryptedCashuReceiveQuoteData` and then import that to the transaction types which would allow us to remove all of the transaction details types