### PR TITLE
optimize spark leaves for faster payments

### DIFF
--- a/app/features/shared/spark.ts
+++ b/app/features/shared/spark.ts
@@ -62,7 +62,13 @@ export const sparkWalletQueryOptions = ({
         mnemonic ?? (await client.fetchQuery(sparkMnemonicQueryOptions()));
       const { wallet } = await SparkWallet.initialize({
         mnemonicOrSeed: mnemonicToUse,
-        options: { network },
+        options: {
+          network,
+          optimizationOptions: {
+            auto: true,
+            multiplicity: 5,
+          },
+        },
       });
       // Privacy mode hides the wallet from Spark explorers (e.g. sparkscan.io), but not from Spark Operators.
       // Toggling this setting retroactively hides/reveals all transactions, not just future ones.


### PR DESCRIPTION
This enables the most aggressive leaf optimization for Spark which should result in faster payments, but makes it harder to do a unilateral exit. See [Leaf Optimization](https://docs.spark.money/api-reference/wallet/initialize#leaf-optimization).