### PR TITLE
fix: use mint quote ID for pending melt quote

### DIFF
--- a/app/features/send/cashu-send-quote-hooks.ts
+++ b/app/features/send/cashu-send-quote-hooks.ts
@@ -343,7 +343,7 @@ function usePendingMeltQuotes() {
         throw new Error(`Cashu account not found for send quote: ${q.id}`);
       }
       return {
-        id: q.id,
+        id: q.quoteId,
         mintUrl: account.mintUrl,
         expiryInMs: new Date(q.expiresAt).getTime(),
         inputAmount: sumProofs(q.proofs),


### PR DESCRIPTION
We were using the Agicash quote ID, not the mint's quote ID to track pending melts. I checked the other two places that `useOnMeltQuoteStateChange` are used and those properly use the quoteId.