### PR TITLE
Add account purpose for #758

### DIFF
--- a/app/features/accounts/account-icons.tsx
+++ b/app/features/accounts/account-icons.tsx
@@ -1,16 +1,20 @@
-import { LandmarkIcon } from 'lucide-react';
+import { GiftIcon, LandmarkIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { SparkIcon as SparkIconSvg } from '~/components/spark-icon';
-import type { AccountType } from './account';
+import type { Account, AccountType } from './account';
 
 const CashuIcon = () => <LandmarkIcon className="h-4 w-4" />;
 const SparkIcon = () => <SparkIconSvg className="h-4 w-4" />;
+const GiftCardIcon = () => <GiftIcon className="h-4 w-4" />;
 
 const iconsByAccountType: Record<AccountType, ReactNode> = {
   cashu: <CashuIcon />,
   spark: <SparkIcon />,
 };
 
-export function AccountTypeIcon({ type }: { type: AccountType }) {
-  return iconsByAccountType[type];
+export function AccountIcon({ account }: { account: Account }) {
+  if (account.purpose === 'gift-card') {
+    return <GiftCardIcon />;
+  }
+  return iconsByAccountType[account.type];
 }

--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -127,6 +127,7 @@ export class AccountRepository {
       currency: accountInput.currency,
       details,
       user_id: accountInput.userId,
+      purpose: accountInput.purpose,
     };
 
     const query = this.db
@@ -160,6 +161,7 @@ export class AccountRepository {
       id: data.id,
       name: data.name,
       currency: data.currency as Currency,
+      purpose: data.purpose,
       createdAt: data.created_at,
       version: data.version,
     };

--- a/app/features/accounts/account-selector.tsx
+++ b/app/features/accounts/account-selector.tsx
@@ -12,7 +12,7 @@ import { ScrollArea } from '~/components/ui/scroll-area';
 import { cn } from '~/lib/utils';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import { type Account, getAccountBalance } from './account';
-import { AccountTypeIcon } from './account-icons';
+import { AccountIcon } from './account-icons';
 import { BalanceOfflineHoverCard } from './balance-offline-hover-card';
 
 export type AccountSelectorOption<T extends Account = Account> = T & {
@@ -46,7 +46,7 @@ function AccountItem({ account }: { account: AccountSelectorOption }) {
 
   return (
     <div className="flex w-full items-center gap-4 px-3 py-4">
-      <AccountTypeIcon type={account.type} />
+      <AccountIcon account={account} />
       <div className="flex w-full flex-col justify-between gap-2 text-start">
         <span className="font-medium">{account.name}</span>
         <div className="flex items-center justify-between text-xs">

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -8,6 +8,13 @@ import { type Currency, Money } from '~/lib/money';
 
 export type AccountType = 'cashu' | 'spark';
 
+/**
+ * The purpose of this account.
+ * - 'transactional': Regular accounts for sending/receiving payments
+ * - 'gift-card': Closed-loop accounts for mints that are issuing gift cards
+ */
+export type AccountPurpose = 'transactional' | 'gift-card';
+
 export type CashuProof = {
   id: string;
   accountId: string;
@@ -41,6 +48,7 @@ export type Account = {
   id: string;
   name: string;
   type: AccountType;
+  purpose: AccountPurpose;
   isOnline: boolean;
   currency: Currency;
   createdAt: string;
@@ -86,6 +94,25 @@ export type CashuAccount = Extract<Account, { type: 'cashu' }>;
 export type SparkAccount = Extract<Account, { type: 'spark' }>;
 export type ExtendedCashuAccount = ExtendedAccount<'cashu'>;
 export type ExtendedSparkAccount = ExtendedAccount<'spark'>;
+
+/**
+ * Returns true if the account can send payments through the Lightning network.
+ * Returns false for test mints and gift-card accounts.
+ */
+export const canSendToLightning = (account: Account): boolean => {
+  if (account.type === 'spark') {
+    return true;
+  }
+  return !account.isTestMint && account.purpose === 'transactional';
+};
+
+/**
+ * Returns true if the account can receive payments via the Lightning network.
+ * Returns false for test mints only.
+ */
+export const canReceiveFromLightning = (account: Account): boolean => {
+  return account.type === 'spark' || !account.isTestMint;
+};
 
 export const getAccountBalance = (account: Account) => {
   if (account.type === 'cashu') {

--- a/app/features/gift-cards/add-gift-card.tsx
+++ b/app/features/gift-cards/add-gift-card.tsx
@@ -20,7 +20,27 @@ import {
 } from '~/components/wallet-card';
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
 import { useToast } from '~/hooks/use-toast';
+import type { Currency } from '~/lib/money';
 import type { GiftCardInfo } from './use-discover-cards';
+
+type AddGiftCardParams = {
+  name: string;
+  currency: Currency;
+  url: string;
+};
+
+function useAddGiftCard() {
+  const addCashuAccount = useAddCashuAccount();
+
+  return ({ name, currency, url }: AddGiftCardParams) =>
+    addCashuAccount({
+      name,
+      currency,
+      mintUrl: url,
+      type: 'cashu',
+      purpose: 'gift-card',
+    });
+}
 
 type AddGiftCardProps = {
   giftCard: GiftCardInfo;
@@ -32,7 +52,7 @@ type AddGiftCardProps = {
  */
 export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   const [isAdding, setIsAdding] = useState(false);
-  const addAccount = useAddCashuAccount();
+  const addGiftCard = useAddGiftCard();
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
@@ -48,11 +68,10 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   const handleAddCard = async () => {
     setIsAdding(true);
     try {
-      await addAccount({
+      await addGiftCard({
         name: giftCard.name,
         currency: giftCard.currency,
-        mintUrl: giftCard.url,
-        type: 'cashu',
+        url: giftCard.url,
       });
       toast({
         title: 'Success',

--- a/app/features/gift-cards/gift-card-details.tsx
+++ b/app/features/gift-cards/gift-card-details.tsx
@@ -30,8 +30,7 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
   const isTransitioning = useViewTransitionState('/gift-cards');
 
   const { data: giftCardAccounts } = useAccounts({
-    type: 'cashu',
-    onlyIncludeClosedLoopAccounts: true,
+    purpose: 'gift-card',
   });
 
   const card = giftCardAccounts.find((c) => c.id === cardId);

--- a/app/features/gift-cards/gift-cards.tsx
+++ b/app/features/gift-cards/gift-cards.tsx
@@ -27,8 +27,7 @@ import {
  */
 export function GiftCards() {
   const { data: accounts } = useAccounts({
-    type: 'cashu',
-    onlyIncludeClosedLoopAccounts: true,
+    purpose: 'gift-card',
   });
 
   const navigate = useNavigate();

--- a/app/features/receive/receive-cashu-token-hooks.tsx
+++ b/app/features/receive/receive-cashu-token-hooks.tsx
@@ -229,8 +229,7 @@ export function useReceiveCashuTokenAccounts(
   return {
     selectableAccounts: possibleDestinationAccounts.map(toOption),
     receiveAccount: receiveAccount ? toOption(receiveAccount) : null,
-    isCrossMintSwapDisabled: sourceAccount.isTestMint,
-    sourceAccount: sourceAccount,
+    sourceAccount,
     setReceiveAccount,
     addAndSetReceiveAccount,
   };
@@ -305,6 +304,7 @@ function getSparkAccountPlaceholder(): ReceiveCashuTokenAccount & {
     id: 'spark-account-placeholder-id',
     name: 'Bitcoin',
     type: 'spark',
+    purpose: 'transactional',
     isOnline: true,
     currency: 'BTC',
     wallet: createSparkWalletStub(

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -26,6 +26,8 @@ import {
   useNavigateWithViewTransition,
 } from '~/lib/transitions';
 import { AccountSelector } from '../accounts/account-selector';
+import { GiftCardItem } from '../gift-cards/gift-card-item';
+import { getGiftCardImageByMintUrl } from '../gift-cards/use-discover-cards';
 import { tokenToMoney } from '../shared/cashu';
 import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
@@ -108,11 +110,12 @@ export default function ReceiveToken({
   const {
     selectableAccounts,
     receiveAccount,
-    isCrossMintSwapDisabled,
     sourceAccount,
     setReceiveAccount,
     addAndSetReceiveAccount,
   } = useReceiveCashuTokenAccounts(token, preferredReceiveAccountId);
+
+  const isGiftCardSource = sourceAccount.purpose === 'gift-card';
 
   const isReceiveAccountKnown = receiveAccount?.isUnknown === false;
 
@@ -192,12 +195,20 @@ export default function ReceiveToken({
         <div className="absolute top-0 right-0 bottom-0 left-0 mx-auto flex max-w-sm items-center justify-center">
           {claimableToken && receiveAccount ? (
             <div className="w-full max-w-sm px-4">
-              <AccountSelector
-                accounts={selectableAccounts}
-                selectedAccount={receiveAccount}
-                disabled={isCrossMintSwapDisabled}
-                onSelect={setReceiveAccount}
-              />
+              {isGiftCardSource ? (
+                <GiftCardItem
+                  account={sourceAccount}
+                  image={getGiftCardImageByMintUrl(sourceAccount.mintUrl)}
+                  hideOverlayContent
+                />
+              ) : (
+                <AccountSelector
+                  accounts={selectableAccounts}
+                  selectedAccount={receiveAccount}
+                  disabled={selectableAccounts.length <= 1}
+                  onSelect={setReceiveAccount}
+                />
+              )}
             </div>
           ) : (
             <TokenErrorDisplay

--- a/app/features/settings/accounts/add-mint-form.tsx
+++ b/app/features/settings/accounts/add-mint-form.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/features/shared/cashu';
 import { useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
-import { getCashuProtocolUnit } from '~/lib/cashu';
+import { getCashuProtocolUnit, getMintPurpose } from '~/lib/cashu';
 import type { Currency } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 
@@ -69,11 +69,16 @@ export function AddMintForm() {
 
   const onSubmit = async (data: FormValues) => {
     try {
+      const mintInfo = await queryClient.fetchQuery(
+        mintInfoQueryOptions(data.mintUrl),
+      );
+      const purpose = getMintPurpose(mintInfo);
       await addAccount({
         name: data.name,
         currency: data.currency,
         mintUrl: data.mintUrl,
         type: 'cashu',
+        purpose,
       });
       toast({
         title: 'Success',

--- a/app/features/settings/accounts/all-accounts.tsx
+++ b/app/features/settings/accounts/all-accounts.tsx
@@ -17,7 +17,7 @@ import { LinkWithViewTransition } from '~/lib/transitions';
 function CurrencyAccounts({ currency }: { currency: Currency }) {
   const { data: accounts } = useAccounts({
     currency,
-    excludeClosedLoopAccounts: true,
+    purpose: 'transactional',
   });
 
   return (

--- a/app/features/settings/settings.tsx
+++ b/app/features/settings/settings.tsx
@@ -20,7 +20,7 @@ import { canShare, shareContent } from '~/lib/share';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { cn } from '~/lib/utils';
 import { useDefaultAccount } from '../accounts/account-hooks';
-import { AccountTypeIcon } from '../accounts/account-icons';
+import { AccountIcon } from '../accounts/account-icons';
 import { ColorModeToggle } from '../theme/color-mode-toggle';
 import { useSignOut } from '../user/auth';
 import { useUser } from '../user/user-hooks';
@@ -114,7 +114,7 @@ export default function Settings() {
         </SettingsNavButton>
 
         <SettingsNavButton to="/settings/accounts">
-          <AccountTypeIcon type={defaultAccount.type} />
+          <AccountIcon account={defaultAccount} />
           <span>{defaultAccount.name}</span>
         </SettingsNavButton>
 

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -25,7 +25,7 @@ import type {
 import { useToast } from '~/hooks/use-toast';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { useAccount } from '../accounts/account-hooks';
-import { AccountTypeIcon } from '../accounts/account-icons';
+import { AccountIcon } from '../accounts/account-icons';
 import { getDefaultUnit } from '../shared/currencies';
 import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
@@ -337,7 +337,7 @@ export function TransactionDetails({
                 </span>
               </div>
               <div className="flex items-center gap-3">
-                <AccountTypeIcon type={account?.type} />
+                <AccountIcon account={account} />
                 <span>{account?.name}</span>
               </div>
 

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -82,6 +82,7 @@ export const defaultAccounts = [
     name: 'Bitcoin',
     network: 'MAINNET',
     isDefault: true,
+    purpose: 'transactional',
   },
   ...(isDevelopmentMode
     ? ([
@@ -92,6 +93,7 @@ export const defaultAccounts = [
           mintUrl: 'https://testnut.cashu.space',
           isTestMint: true,
           isDefault: false,
+          purpose: 'transactional',
         },
         {
           type: 'cashu',
@@ -100,6 +102,7 @@ export const defaultAccounts = [
           mintUrl: 'https://testnut.cashu.space',
           isTestMint: true,
           isDefault: true,
+          purpose: 'transactional',
         },
       ] as const)
     : []),

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -154,6 +154,7 @@ export class UserRepository {
       type: account.type,
       currency: account.currency,
       is_default: account.isDefault ?? false,
+      purpose: account.purpose,
       details: (() => {
         if (account.type === 'cashu') {
           return {

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -16,6 +16,7 @@ export type Database = {
           details: Json
           id: string
           name: string
+          purpose: string
           type: string
           user_id: string
           version: number
@@ -26,6 +27,7 @@ export type Database = {
           details: Json
           id?: string
           name: string
+          purpose?: string
           type: string
           user_id: string
           version?: number
@@ -36,6 +38,7 @@ export type Database = {
           details?: Json
           id?: string
           name?: string
+          purpose?: string
           type?: string
           user_id?: string
           version?: number
@@ -1565,6 +1568,7 @@ export type Database = {
         name: string | null
         details: Json | null
         is_default: boolean | null
+        purpose: string | null
       }
       add_cashu_proofs_and_update_account_result: {
         account: Json | null

--- a/supabase/migrations/20260112180000_add_account_purpose.sql
+++ b/supabase/migrations/20260112180000_add_account_purpose.sql
@@ -1,0 +1,174 @@
+-- Migration: Add Account Purpose Column
+-- 
+-- Purpose:
+--   1. Add 'purpose' column to accounts table to distinguish account types
+--   2. Update account_input composite type to include purpose
+--   3. Update upsert_user_with_accounts function to handle purpose
+--
+-- Affected Objects:
+--   - wallet.accounts (table - new column)
+--   - wallet.account_input (composite type - new field)
+--   - wallet.upsert_user_with_accounts (function)
+--
+-- Changes:
+--   1. Added purpose column with values: 'transactional' (default) or 'gift-card'
+--   2. Modified account_input type to include purpose field
+--   3. Modified upsert function to insert purpose when creating accounts
+--
+-- Special Considerations:
+--   - Existing accounts default to 'transactional' purpose
+--   - The purpose distinguishes regular accounts from closed-loop gift card accounts
+
+-- Add purpose column to accounts table with default value for existing rows
+alter table wallet.accounts 
+  add column purpose text not null default 'transactional';
+
+-- Add check constraint to validate purpose values
+alter table wallet.accounts 
+  add constraint accounts_purpose_check 
+  check (purpose in ('transactional', 'gift-card'));
+
+-- Recreate account_input type with purpose field
+-- Must drop and recreate since ALTER TYPE doesn't support adding fields to composite types
+drop type if exists wallet.account_input cascade;
+create type wallet.account_input as (
+  "type" text,
+  "currency" text,
+  "name" text,
+  "details" jsonb,
+  "is_default" boolean,
+  "purpose" text
+);
+
+-- Drop old function signature before recreating
+drop function if exists wallet.upsert_user_with_accounts(uuid, text, boolean, wallet.account_input[], text, text, text);
+
+-- Recreate upsert_user_with_accounts function with purpose support
+create or replace function wallet.upsert_user_with_accounts(
+  p_user_id uuid, 
+  p_email text, 
+  p_email_verified boolean, 
+  p_accounts wallet.account_input[], 
+  p_cashu_locking_xpub text, 
+  p_encryption_public_key text,
+  p_spark_identity_public_key text
+)
+returns wallet.upsert_user_with_accounts_result
+language plpgsql
+as $function$
+declare
+  result_user wallet.users;
+  result_accounts jsonb[];
+  usd_account_id uuid := null;
+  btc_account_id uuid := null;
+  placeholder_btc_account_id uuid := gen_random_uuid();
+begin
+  -- Insert user with placeholder default_btc_account_id. The FK constraint is deferred,
+  -- so it won't be checked until transaction commit. We'll update it with the real
+  -- account ID after creating accounts.
+  insert into wallet.users (id, email, email_verified, cashu_locking_xpub, encryption_public_key, spark_identity_public_key, default_currency, default_btc_account_id)
+  values (p_user_id, p_email, p_email_verified, p_cashu_locking_xpub, p_encryption_public_key, p_spark_identity_public_key, 'BTC', placeholder_btc_account_id)
+  on conflict (id) do update set
+    email = coalesce(excluded.email, wallet.users.email),
+    email_verified = excluded.email_verified;
+
+  select *
+  into result_user
+  from wallet.users u
+  where u.id = p_user_id
+  for update;
+
+  with accounts_with_proofs as (
+    select 
+      a.*,
+      coalesce(
+        jsonb_agg(to_jsonb(cp)) filter (where cp.id is not null),
+        '[]'::jsonb
+      ) as cashu_proofs
+    from
+      wallet.accounts a
+      left join wallet.cashu_proofs cp on cp.account_id = a.id and cp.state = 'UNSPENT'
+    where a.user_id = p_user_id
+    group by a.id
+  )
+  select array_agg(
+    jsonb_set(
+      to_jsonb(awp),
+      '{cashu_proofs}',
+      awp.cashu_proofs
+    )
+  )
+  into result_accounts
+  from accounts_with_proofs awp;
+
+  if result_accounts is not null then
+    return (result_user, result_accounts);
+  end if;
+
+  if array_length(p_accounts, 1) is null then
+    raise exception
+      using
+        hint = 'INVALID_ARGUMENT',
+        message = 'p_accounts cannot be an empty array';
+  end if;
+
+  if not exists (select 1 from unnest(p_accounts) as acct where acct.currency = 'BTC' and acct.type = 'spark') then
+    raise exception
+      using
+        hint = 'INVALID_ARGUMENT',
+        message = 'At least one BTC Spark account is required';
+  end if;
+
+  with
+    inserted_accounts as (
+      insert into wallet.accounts (user_id, type, currency, name, details, purpose)
+      select 
+        p_user_id,
+        acct.type,
+        acct.currency,
+        acct.name,
+        acct.details,
+        acct.purpose
+      from unnest(p_accounts) as acct
+      returning *
+    ),
+    accounts_with_default_flag as (
+      select 
+        ia.*,
+        coalesce(acct."is_default", false) as "is_default"
+      from
+        inserted_accounts ia
+        join unnest(p_accounts) as acct on 
+          ia.type = acct.type and 
+          ia.currency = acct.currency and 
+          ia.name = acct.name and 
+          ia.details = acct.details
+    )
+  select 
+    array_agg(
+      jsonb_set(
+        to_jsonb(awd),
+        '{cashu_proofs}',
+        '[]'::jsonb
+      )
+    ),
+    (array_agg(awd.id) filter (where awd.currency = 'USD' and awd."is_default"))[1],
+    (array_agg(awd.id) filter (where awd.currency = 'BTC' and awd."is_default"))[1]
+  into result_accounts, usd_account_id, btc_account_id
+  from accounts_with_default_flag awd;
+
+  update wallet.users u
+  set 
+    default_usd_account_id = coalesce(usd_account_id, u.default_usd_account_id),
+    default_btc_account_id = coalesce(btc_account_id, u.default_btc_account_id),
+    default_currency = case
+      when btc_account_id is not null then 'BTC'
+      when usd_account_id is not null then 'USD'
+      else u.default_currency
+    end
+  where id = p_user_id
+  returning * into result_user;
+
+  return (result_user, result_accounts);
+end;
+$function$;


### PR DESCRIPTION
This PR is to solve this comment: https://github.com/MakePrisms/agicash/pull/758#discussion_r2670248845

- Add a new `purpose` column to the account's table.
- Handles accounts based on their purpose
- Creates accounts with their purpose. Spark accounts are always `transactional` for now, and cashu account are `transactional | gift-card`. 
- The cashu account purpose is set based on whether the mint is closed loop or not.