### PR TITLE
add scoped view transitions to fix gift card navigation

### DIFF
--- a/app/features/gift-cards/discover-gift-cards.tsx
+++ b/app/features/gift-cards/discover-gift-cards.tsx
@@ -1,6 +1,9 @@
 import { WalletCard, WalletCardBackground } from '~/components/wallet-card';
 import useUserAgent from '~/hooks/use-user-agent';
-import { LinkWithViewTransition } from '~/lib/transitions';
+import {
+  LinkWithViewTransition,
+  useScopedTransitionName,
+} from '~/lib/transitions';
 import { cn } from '~/lib/utils';
 import type { GiftCardInfo } from './use-discover-cards';
 
@@ -13,9 +16,13 @@ type DiscoverSectionProps = {
  */
 export function DiscoverGiftCards({ giftCards }: DiscoverSectionProps) {
   const { isMobile } = useUserAgent();
+  const vtn = useScopedTransitionName('gift-cards');
 
   return (
-    <div className="view-transition-available w-full shrink-0">
+    <div
+      className="w-full shrink-0"
+      style={{ viewTransitionName: vtn('available-cards') }}
+    >
       <h2 className="mb-3 px-4 text-white">Discover</h2>
       <div className="sm:px-4">
         <div

--- a/app/features/gift-cards/gift-card-details.tsx
+++ b/app/features/gift-cards/gift-card-details.tsx
@@ -1,5 +1,4 @@
 import { X } from 'lucide-react';
-import { useNavigate } from 'react-router';
 
 import {
   Page,
@@ -14,7 +13,11 @@ import { GiftCardItem } from '~/features/gift-cards/gift-card-item';
 import { getGiftCardImageByMintUrl } from '~/features/gift-cards/use-discover-cards';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
 import { TransactionList } from '~/features/transactions/transaction-list';
-import { LinkWithViewTransition } from '~/lib/transitions';
+import {
+  LinkWithViewTransition,
+  useNavigateWithViewTransition,
+  useScopedTransitionName,
+} from '~/lib/transitions';
 import {
   CARD_HEIGHT,
   CARD_WIDTH,
@@ -26,7 +29,8 @@ type GiftCardDetailsProps = {
 };
 
 export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
-  const navigate = useNavigate();
+  const navigate = useNavigateWithViewTransition();
+  const vtn = useScopedTransitionName('gift-cards');
 
   const { data: giftCardAccounts } = useAccounts({
     type: 'cashu',
@@ -37,7 +41,7 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
   const selectedIndex = giftCardAccounts.findIndex((c) => c.id === cardId);
 
   const handleBack = () => {
-    navigate('/gift-cards', { viewTransition: true });
+    navigate('/gift-cards', { scope: 'gift-cards' });
   };
 
   if (!card) {
@@ -96,7 +100,7 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
                     style={{
                       top: isSelected ? undefined : 0,
                       zIndex,
-                      viewTransitionName: `card-${account.id}`,
+                      viewTransitionName: vtn(`card-${account.id}`),
                     }}
                   >
                     {isSelected ? (
@@ -125,7 +129,7 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
                   style={{
                     top: `calc(100vh + ${offsetBelowViewport}px)`,
                     zIndex,
-                    viewTransitionName: `card-${account.id}`,
+                    viewTransitionName: vtn(`card-${account.id}`),
                   }}
                 >
                   <GiftCardItem
@@ -139,7 +143,10 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
           </div>
         </div>
 
-        <div className="view-transition-transactions mx-auto flex flex-col items-center gap-4 px-4 pt-4 pb-8">
+        <div
+          className="mx-auto flex flex-col items-center gap-4 px-4 pt-4 pb-8"
+          style={{ viewTransitionName: vtn('transactions') }}
+        >
           {balance && <MoneyWithConvertedAmount money={balance} size="md" />}
 
           <div className="grid w-72 grid-cols-2 gap-10">

--- a/app/features/gift-cards/gift-card-item.tsx
+++ b/app/features/gift-cards/gift-card-item.tsx
@@ -10,6 +10,7 @@ import {
   type CashuAccount,
   getAccountBalance,
 } from '~/features/accounts/account';
+import { useScopedTransitionName } from '~/lib/transitions';
 import { getDefaultUnit } from '../shared/currencies';
 import { VERTICAL_CARD_OFFSET_IN_STACK } from './card-stack-constants';
 
@@ -32,6 +33,7 @@ export function GiftCardItem({
   const name =
     account.wallet.mintInfo?.name ??
     account.mintUrl.replace('https://', '').replace('http://', '');
+  const vtn = useScopedTransitionName('gift-cards');
 
   return (
     <WalletCard size={size} className={className}>
@@ -54,7 +56,7 @@ export function GiftCardItem({
             style={{
               height: VERTICAL_CARD_OFFSET_IN_STACK,
               opacity: hideOverlayContent ? 0 : 1,
-              viewTransitionName: `card-overlay-${account.id}`,
+              viewTransitionName: vtn(`card-overlay-${account.id}`),
             }}
           >
             <span className="text-lg text-white drop-shadow-md">{name}</span>

--- a/app/features/gift-cards/gift-cards.tsx
+++ b/app/features/gift-cards/gift-cards.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router';
 import {
   ClosePageButton,
   Page,
@@ -7,6 +6,10 @@ import {
   PageHeaderTitle,
 } from '~/components/page';
 import type { CashuAccount } from '~/features/accounts/account';
+import {
+  useNavigateWithViewTransition,
+  useScopedTransitionName,
+} from '~/lib/transitions';
 import { useAccounts } from '../accounts/account-hooks';
 import {
   CARD_HEIGHT,
@@ -31,14 +34,16 @@ export function GiftCards() {
     onlyIncludeClosedLoopAccounts: true,
   });
 
-  const navigate = useNavigate();
+  const navigate = useNavigateWithViewTransition();
+  const vtn = useScopedTransitionName('gift-cards');
+
   const hasCards = accounts.length > 0;
   const stackedHeight =
     CARD_HEIGHT + (accounts.length - 1) * VERTICAL_CARD_OFFSET_IN_STACK;
   const giftCardsToDiscover = useDiscoverGiftCards();
 
   const handleCardClick = (account: CashuAccount) => {
-    navigate(`/gift-cards/${account.id}`, { viewTransition: true });
+    navigate(`/gift-cards/${account.id}`, { scope: 'gift-cards' });
   };
 
   return (
@@ -72,7 +77,7 @@ export function GiftCards() {
                       style={{
                         transform: `translateY(${index * VERTICAL_CARD_OFFSET_IN_STACK}px)`,
                         zIndex: 1 + index,
-                        viewTransitionName: `card-${account.id}`,
+                        viewTransitionName: vtn(`card-${account.id}`),
                       }}
                     >
                       <GiftCardItem

--- a/app/features/gift-cards/transitions.css
+++ b/app/features/gift-cards/transitions.css
@@ -1,8 +1,4 @@
 /* Available cards section - fade out/in */
-.view-transition-available {
-  view-transition-name: available-cards;
-}
-
 ::view-transition-old(available-cards),
 ::view-transition-new(available-cards) {
   animation-duration: 0.3s;
@@ -18,8 +14,6 @@
 }
 
 /* Transactions section - slide up/down with fade */
-
-/* Slide + fade animations for transactions */
 @keyframes slide-fade-out {
   from {
     opacity: 1;
@@ -40,10 +34,6 @@
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-.view-transition-transactions {
-  view-transition-name: transactions;
 }
 
 ::view-transition-old(transactions),


### PR DESCRIPTION
I made it so our view transitions can now accept a `scope` which allows us to conditionally apply view transition styles. The reason that we need this is for navigation to/from routes that should not use those view transition styles. Previously, if you navigated from `/` to `/gift-cards` then the view transitions styles would be applied and the entire page didn't just slide in like it should. You can see the old behavior [in Discord](https://discord.com/channels/1189257044264501288/1303430668319195146/1460501765630988399)