### PR TITLE
Allow all origins for lnurl apis

### DIFF
--- a/app/routes/[.]well-known.lnurlp.$username.ts
+++ b/app/routes/[.]well-known.lnurlp.$username.ts
@@ -23,6 +23,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return new Response(JSON.stringify(response), {
     headers: {
       'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
     },
   });
 }

--- a/app/routes/api.lnurlp.callback.$userId.ts
+++ b/app/routes/api.lnurlp.callback.$userId.ts
@@ -18,6 +18,12 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   if (!amountMsat || Number.isNaN(Number(amountMsat))) {
     return new Response(
       JSON.stringify({ status: 'ERROR', reason: 'Invalid amount' }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+      },
     );
   }
 
@@ -44,6 +50,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   );
 
   return new Response(JSON.stringify(response), {
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
   });
 }

--- a/app/routes/api.lnurlp.verify.$encryptedQuoteData.ts
+++ b/app/routes/api.lnurlp.verify.$encryptedQuoteData.ts
@@ -24,6 +24,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   return new Response(JSON.stringify(response), {
     headers: {
       'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
     },
   });
 }


### PR DESCRIPTION
When I tried to pay my account on next.agi.cash from my localhost app, I was getting cors error for lnurl apis. I think the same would happen if any other browser app/wallet would try to pay to our ln address because it is currently only allowing same origin requests (one agicash next user can pay to ln address of another one)