### PR TITLE
Improve useOnSparkSendStateChange

### DIFF
--- a/app/features/send/spark-send-quote-hooks.ts
+++ b/app/features/send/spark-send-quote-hooks.ts
@@ -168,13 +168,12 @@ export function useOnSparkSendStateChange({
         return;
       }
 
-      const lastTriggeredState = lastTriggeredStateRef.current.get(quoteId);
-
-      if (quote.state === 'UNPAID') {
-        if (lastTriggeredState !== 'UNPAID') {
-          lastTriggeredStateRef.current.set(quoteId, 'UNPAID');
-          onUnpaidRef.current(quote);
-        }
+      if (
+        quote.state === 'UNPAID' &&
+        lastTriggeredStateRef.current.get(quoteId) !== 'UNPAID'
+      ) {
+        lastTriggeredStateRef.current.set(quoteId, 'UNPAID');
+        onUnpaidRef.current(quote);
         return;
       }
 
@@ -194,7 +193,7 @@ export function useOnSparkSendStateChange({
 
       if (
         sendRequest.status === LightningSendRequestStatus.TRANSFER_COMPLETED &&
-        lastTriggeredState !== 'COMPLETED'
+        lastTriggeredStateRef.current.get(quoteId) !== 'COMPLETED'
       ) {
         if (!sendRequest.paymentPreimage) {
           throw new Error(
@@ -212,7 +211,7 @@ export function useOnSparkSendStateChange({
 
       if (
         sendRequest.status === LightningSendRequestStatus.USER_SWAP_RETURNED &&
-        lastTriggeredState !== 'FAILED'
+        lastTriggeredStateRef.current.get(quoteId) !== 'FAILED'
       ) {
         lastTriggeredStateRef.current.set(quoteId, 'FAILED');
 


### PR DESCRIPTION
Current version of `checkQuoteStatus` function reads `lastTriggeredState` from the ref at the beginning and then uses that var until the end of the function. However, since the function is making some async calls, when `lastTriggeredState` is used after the await it might hold the stale value if the ref value was changed in the meantime. Now we are always reading it with `lastTriggeredStateRef.current.get(quoteId)` which will make sure that it will always use the latest value.

This will reduce number of callback calls but don't think this has anything to do with send error that Bob had.