### PR TITLE
additionally prune invoices and cashu mint quote IDs

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -536,11 +536,6 @@ const useOnMintQuoteStateChange = ({
 
   const processMintQuote = useCallback(
     async (mintQuote: MintQuoteResponse) => {
-      console.debug(`Mint quote state changed: ${mintQuote.state}`, {
-        paymentRequest: mintQuote.request,
-        unit: mintQuote.unit,
-      });
-
       const relatedReceiveQuote = pendingQuotesCache.getByMintQuoteId(
         mintQuote.quote,
       );
@@ -549,6 +544,11 @@ const useOnMintQuoteStateChange = ({
         console.warn('No related receive quote found for the mint quote');
         return;
       }
+
+      console.debug(`Mint quote state changed: ${mintQuote.state}`, {
+        receiveQuoteId: relatedReceiveQuote.id,
+        unit: mintQuote.unit,
+      });
 
       const expiresAt = new Date(relatedReceiveQuote.expiresAt);
       const now = new Date();

--- a/app/lib/cashu/melt-quote-subscription-manager.ts
+++ b/app/lib/cashu/melt-quote-subscription-manager.ts
@@ -41,8 +41,7 @@ export class MeltQuoteSubscriptionManager {
         });
         console.debug(
           'Melt quote updates subscription already exists for mint. Updated callback.',
-          mintUrl,
-          quoteIds,
+          { mintUrl, quoteCount: quoteIds.length },
         );
         return () => {
           unsubscribe();
@@ -56,11 +55,10 @@ export class MeltQuoteSubscriptionManager {
 
     const wallet = getCashuWallet(mintUrl);
 
-    console.debug(
-      'Subscribing to melt quote updates for mint',
+    console.debug('Subscribing to melt quote updates for mint', {
       mintUrl,
-      quoteIds,
-    );
+      quoteCount: quoteIds.length,
+    });
 
     const subscriptionCallback = (meltQuote: MeltQuoteResponse) => {
       const currentSubscription = this.subscriptions.get(mintUrl);

--- a/app/lib/cashu/melt-quote-subscription.ts
+++ b/app/lib/cashu/melt-quote-subscription.ts
@@ -43,10 +43,7 @@ export function useOnMeltQuoteStateChange({
 
   const handleMeltQuoteUpdate = useCallback(
     async (meltQuote: PartialMeltQuoteResponse, handleExpiry = false) => {
-      console.debug(`Melt quote state changed: ${meltQuote.state}`, {
-        request: meltQuote.request,
-        unit: meltQuote.unit,
-      });
+      console.debug(`Melt quote state changed: ${meltQuote.state}`);
 
       const quoteData = getQuoteDataRef.current(meltQuote.quote);
       if (!quoteData) {

--- a/app/lib/cashu/mint-quote-subscription-manager.ts
+++ b/app/lib/cashu/mint-quote-subscription-manager.ts
@@ -41,7 +41,7 @@ export class MintQuoteSubscriptionManager {
         });
         console.debug(
           'Mint quote updates subscription already exists for mint. Updated callback.',
-          { mintUrl, quoteIds },
+          { mintUrl, quoteCount: quoteIds.length },
         );
         return () => {
           unsubscribe();
@@ -59,7 +59,7 @@ export class MintQuoteSubscriptionManager {
 
     console.debug('Subscribing to mint quote updates for mint', {
       mintUrl,
-      quoteIds,
+      quoteCount: quoteIds.length,
     });
 
     const subscriptionCallback = (mintQuote: MintQuoteResponse) => {


### PR DESCRIPTION
Just a few more things Claude found. We shouldn't log invoices because those reveal amounts, and we shouldn't log the mint/melt quote IDs because those can be used to lookup amounts and invoices.