### PR TITLE
Fix bug with missing enum cast in db function

### DIFF
--- a/supabase/migrations/20260112150000_initial_db.sql
+++ b/supabase/migrations/20260112150000_initial_db.sql
@@ -1664,7 +1664,7 @@ begin
   update wallet.transactions
   set state = 'COMPLETED',
       -- Only set acknowledgment status to pending if the receive swap is not reversing a send swap
-      acknowledgment_status = case when reversed_transaction_id is null then 'pending' else null end,
+      acknowledgment_status = case when reversed_transaction_id is null then 'pending'::wallet.acknowledgment_status else null end,
       completed_at = now()
   where id = v_receive_swap.transaction_id
   returning reversed_transaction_id into v_reversed_transaction_id;


### PR DESCRIPTION
I was getting error 400 when this db function was called.

I am updating the exiting migration file and then I will apply this change manually to the db. I don't want to add a new migration just for this