### PR TITLE
fix: prefer default account over unknown source when receiving token from link

### DIFF
--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -169,20 +169,20 @@ export class ReceiveCashuTokenService {
       return preferredReceiveAccount;
     }
 
-    if (sourceAccount.canReceive) {
-      return sourceAccount;
-    }
-
     const defaultAccount = possibleDestinationAccounts.find(
       (account) =>
         account.isDefault && account.currency === sourceAccount.currency,
     );
 
-    if (!defaultAccount?.canReceive) {
-      return null;
+    if (defaultAccount?.canReceive) {
+      return defaultAccount;
     }
 
-    return defaultAccount;
+    if (sourceAccount.canReceive) {
+      return sourceAccount;
+    }
+
+    return null;
   }
 
   private augmentNonSourceAccountsWithTokenFlags(


### PR DESCRIPTION
When receiving a cashu token from a link where the mint is not in the
user's accounts, the account selector now defaults to the user's default
account instead of the unknown source account. The source remains selectable.

Co-Authored-By: Claude Opus 4.5

