### PR TITLE
Add sentry integration for error cause

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -55,6 +55,7 @@ Sentry.init({
     Sentry.consoleLoggingIntegration(),
     Sentry.reactRouterTracingIntegration(),
     Sentry.browserProfilingIntegration(),
+    Sentry.extraErrorDataIntegration({ depth: 5 }),
   ],
 
   // Performance monitoring

--- a/app/instrument.server.ts
+++ b/app/instrument.server.ts
@@ -117,6 +117,7 @@ Sentry.init({
   integrations: [
     Sentry.consoleLoggingIntegration(),
     nodeProfilingIntegration(),
+    Sentry.extraErrorDataIntegration({ depth: 5 }),
   ],
 
   // Performance monitoring


### PR DESCRIPTION
Add sentry integration which enables error cause to be attached to the Sentry error events.

Currently error cause is lost and that makes debugging harder.