### PR TITLE
Don't report any server 4xx errors to Sentry

### DIFF
--- a/app/instrument.server.ts
+++ b/app/instrument.server.ts
@@ -139,17 +139,16 @@ Sentry.init({
   },
 
   beforeSend(event) {
-    // Filter out 404s from error reporting
-    if (event.exception) {
-      const error = event.exception.values?.[0];
-      if (
-        error?.type === 'NotFoundException' ||
-        error?.value?.includes('404') ||
-        error?.value?.includes('No route matches URL')
-      ) {
-        return null;
-      }
+    // Filter out 4xx React Router errors (bots, crawlers, invalid requests)
+    const serialized = event.extra?.__serialized__ as
+      | { status?: number }
+      | undefined;
+    const status = serialized?.status;
+
+    if (status !== undefined && status >= 400 && status < 500) {
+      return null;
     }
+
     return event;
   },
 });


### PR DESCRIPTION
Solves https://make-prisms.sentry.io/issues/7266641938/?alert_rule_id=16176971&alert_type=issue&environment=production&notification_uuid=4cebb6bc-e908-4bcd-ac5d-ec2dde41a8d2&project=4509707316690944&referrer=discord

We don't want those reported because those are not errors.