### PR TITLE
Increase QR scanner processing resolution from 400px to 1024px

### DIFF
--- a/app/components/qr-scanner/qr-scanner.tsx
+++ b/app/components/qr-scanner/qr-scanner.tsx
@@ -90,6 +90,18 @@ export const QRScanner = ({ onDecode }: QRScannerProps) => {
       returnDetailedScanResult: true,
       highlightScanRegion: true,
       highlightCodeOutline: true,
+      calculateScanRegion: (video) => {
+        const smallestDimension = Math.min(video.videoWidth, video.videoHeight);
+        const scanRegionSize = Math.round((2 / 3) * smallestDimension);
+        return {
+          x: Math.round((video.videoWidth - scanRegionSize) / 2),
+          y: Math.round((video.videoHeight - scanRegionSize) / 2),
+          width: scanRegionSize,
+          height: scanRegionSize,
+          downScaledWidth: 1024,
+          downScaledHeight: 1024,
+        };
+      },
     });
 
     scannerInstance.start();


### PR DESCRIPTION
The qr-scanner library downscales video frames to 400x400px before decoding, which is insufficient for dense QR codes. This adds a calculateScanRegion config that keeps the same scan region but increases the decode resolution to 1024x1024px, giving ~2.5x more pixels per QR module.

Closes #676