### PR TITLE
Make QrScanner logs toggle-able and off by default

### DIFF
--- a/app/components/qr-scanner/qr-scanner.tsx
+++ b/app/components/qr-scanner/qr-scanner.tsx
@@ -9,6 +9,16 @@ import { useToast } from '~/hooks/use-toast';
 import { useAnimatedQRDecoder } from '~/lib/cashu/animated-qr-code';
 import { useThrottle } from '~/lib/use-throttle';
 
+declare global {
+  interface Window {
+    QrScanner?: typeof QrScanner;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.QrScanner = QrScanner;
+}
+
 const DECODE_COOLDOWN_MS = 3000;
 
 const AnimatedScanProgress = ({ progress }: { progress: number }) => {

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "agicash",
       "dependencies": {
-        "@agicash/qr-scanner": "0.1.0",
+        "@agicash/qr-scanner": "0.1.1",
         "@buildonspark/spark-sdk": "0.6.3",
         "@cashu/cashu-ts": "2.6.0",
         "@cashu/crypto": "0.3.4",
@@ -95,7 +95,7 @@
     "@sentry/core@10.38.0": "patches/@sentry%2Fcore@10.38.0.patch",
   },
   "packages": {
-    "@agicash/qr-scanner": ["@agicash/qr-scanner@0.1.0", "", { "dependencies": { "zxing-wasm": "2.2.4" } }, "sha512-+jK5MyKYtAAkW7W19AjdRIEzGd2alHpjlk/OVw0PVwezJTMkNVm07MxMaqCOqzzbVxfek8LfU1n8ubHAzxIgTA=="],
+    "@agicash/qr-scanner": ["@agicash/qr-scanner@0.1.1", "", { "dependencies": { "zxing-wasm": "2.2.4" } }, "sha512-aEwgrw87eFixlYNFl2GFK0Fyvx82EBgQDxQ+K0ikqGLWd9+Yf6MnEWnsCQpkobnvlSu88DiVHcKddTo5k9sE6Q=="],
 
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.8.2", "", {}, "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "We are running the build in node because atm we are using node as the build target."
   },
   "dependencies": {
-    "@agicash/qr-scanner": "0.1.0",
+    "@agicash/qr-scanner": "0.1.1",
     "@buildonspark/spark-sdk": "0.6.3",
     "@cashu/cashu-ts": "2.6.0",
     "@cashu/crypto": "0.3.4",


### PR DESCRIPTION
Upgrade to 0.1.1 which makes debug profiling logs toggleable (off by default). Expose QrScanner on window so setDebug() can be called from the browser console: QrScanner.setDebug(true)