### PR TITLE
Increase max num of levels that Sentry will traverse when stringifying objects

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -50,6 +50,7 @@ Sentry.init({
   environment: getEnvironment(),
   tunnel: '/api/logs',
   enableLogs: true,
+  normalizeDepth: 5,
 
   integrations: [
     Sentry.consoleLoggingIntegration(),

--- a/app/instrument.server.ts
+++ b/app/instrument.server.ts
@@ -113,6 +113,7 @@ Sentry.init({
     process.env.NODE_ENV === 'production' && !isServedLocally(hostname, ips),
   environment: getEnvironment(),
   enableLogs: true,
+  normalizeDepth: 5,
 
   integrations: [
     Sentry.consoleLoggingIntegration(),


### PR DESCRIPTION
In Sentry for `Failed to initialize spark wallet` we currently see this:
```
Failed to initialize spark wallet {"cause":{"name":"hA","message":"Failed to request leaves swap: ClientError: /spark.SparkService/query_all_transfers UNKNOWN: Transport error: Load failed (0.spark.lightspark.com) [idPubKey: 03cebd3800c38fa4a0ebaf74026dc6b3cd59f2dc46545bbf6cbb6b2bb5fae78c3a, clientEnv: js-spark-sdk/0.6.3 browser/mobile-safari-26.3/ios-18.7]","context":"[Object]","originalError":"[Object]","stack":"handlePublicMethodError@https://agi.cash/assets/spark-DznJ3TXy.js:2893:138503"}}
 ```
 or 
 ```
Failed to initialize spark wallet {"cause":{"name":"hA","message":"/spark.SparkService/query_nodes UNKNOWN: Transport error: Load failed (0.spark.lightspark.com) [idPubKey: 03cebd3800c38fa4a0ebaf74026dc6b3cd59f2dc46545bbf6cbb6b2bb5fae78c3a, clientEnv: js-spark-sdk/0.6.3 browser/mobile-safari-26.4/ios-18.7]","context":"[Object]","originalError":"[Object]","stack":"handlePublicMethodError@https://agi.cash/assets/spark-WAqDbPay.js:2893:138503"}}
 ```
 
 context and originalError are shown as "[Object]" because by default depth that Sentry traverses is 3. I'd like us to be able to see those so I am increasing the depth. This will mean we store more data so might cost more in the future but don't think it will be significant diff.