### PR TITLE
Exclude worktrees from typechecking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     ".claude/**/*.ts",
     ".react-router/types/**/*"
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", ".claude/worktrees"],
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["@react-router/node", "vite/client", "bun"],


### PR DESCRIPTION
Without this if you had some worktrees in `.claude/worktrees`, `bun run typecheck` would fail with errors like:
```
.claude/worktrees/loving-davinci/app/features/signup/verify-email.ts:6:28 - error TS2307: Cannot find module '../../routes/+types/_protected.verify-email.($code)' or its
  corresponding type declarations.

  6 import type { Route } from '../../routes/+types/_protected.verify-email.($code)';
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Worktrees have their own configs and type checking so should be ignored here.