### PR TITLE
Fix issue with Vercel analytics

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -137,11 +137,6 @@ export function shouldRevalidate() {
   return false;
 }
 
-const vercelAnalyticsMode =
-  process.env.NODE_ENV === 'production' && process.env.VERCEL
-    ? 'production'
-    : 'development';
-
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider>
@@ -171,7 +166,6 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
         <ScrollRestoration />
         <Scripts />
         <Analytics
-          mode={vercelAnalyticsMode}
           beforeSend={(event: BeforeSendEvent) => {
             return {
               ...event,


### PR DESCRIPTION
I noticed that events weren't showing up in the Vercel dashboard so I asked claude:
```md
There's your problem. Lines 140-142:

  const vercelAnalyticsMode =
    process.env.NODE_ENV === 'production' && process.env.VERCEL
      ? 'production'
      : 'development';

  This checks for process.env.VERCEL, which is a server-side environment variable set by Vercel during builds. But the <Analytics> component runs client-side in the browser, where
  process.env.VERCEL doesn't exist. So vercelAnalyticsMode always evaluates to 'development', and Vercel Analytics ignores development-mode events in the dashboard.

  Is agi.cash deployed on Vercel, or somewhere else? If it's on Vercel, the fix would be to use a Vite-accessible env var (prefixed with VITE_) or just hardcode based on NODE_ENV alone.
  If it's not on Vercel, then process.env.VERCEL will never be set and you'd need a different approach entirely.
  
  
  The three options:

  - 'production' — Sends real analytics data to Vercel's servers. Events show up in your dashboard.
  - 'development' — Logs events to the browser console instead of sending them. Nothing appears in the dashboard.
  - 'auto' — Calls detectEnvironment() which checks process.env.NODE_ENV. If it's "development" or "test", uses development mode; otherwise defaults to production.

  So the simplest fix is to just use mode="auto" (or omit the mode prop entirely since "auto" is the default). Since Vite inlines process.env.NODE_ENV as "production" in production
  builds, auto would correctly resolve to production mode on agi.cash and development mode locally.

  The current code's custom logic with process.env.VERCEL is unnecessarily reinventing what auto already does — and getting it wrong because VERCEL isn't available client-side.
  ```
  
so we are good with default `auto` mode.