### PR TITLE
fix feature flags not updating on login

### DIFF
--- a/app/features/signup/verify-email.ts
+++ b/app/features/signup/verify-email.ts
@@ -1,10 +1,9 @@
 import { verifyEmail as osVerifyEmail } from '@opensecret/react';
 import { useState } from 'react';
 import { createContext, redirect } from 'react-router';
-import { getQueryClient } from '~/features/shared/query-client';
 import { useToast } from '~/hooks/use-toast';
 import type { Route } from '../../routes/+types/_protected.verify-email.($code)';
-import { authStateQueryKey } from '../user/auth';
+import { invalidateAuthQueries } from '../user/auth';
 import { type FullUser, shouldVerifyEmail } from '../user/user';
 import { useRequestNewEmailVerificationCode } from '../user/user-hooks';
 import { getUserFromCacheOrThrow } from '../user/user-hooks';
@@ -38,11 +37,7 @@ export const verifyEmail = async (
 ): Promise<{ verified: true } | { verified: false; error: Error }> => {
   try {
     await osVerifyEmail(code);
-    const queryClient = getQueryClient();
-    await queryClient.invalidateQueries({
-      queryKey: [authStateQueryKey],
-      refetchType: 'all',
-    });
+    await invalidateAuthQueries();
     return { verified: true };
   } catch (e) {
     const error = new Error('Failed to verify email', { cause: e });

--- a/app/routes/_auth.oauth.$provider.tsx
+++ b/app/routes/_auth.oauth.$provider.tsx
@@ -3,8 +3,7 @@ import { decodeURLSafe } from '@stablelib/base64';
 import { redirect } from 'react-router';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { getErrorMessage } from '~/features/shared/error';
-import { getQueryClient } from '~/features/shared/query-client';
-import { authStateQueryKey } from '~/features/user/auth';
+import { invalidateAuthQueries } from '~/features/user/auth';
 import { oauthLoginSessionStorage } from '~/features/user/oauth-login-session-storage';
 import { toast } from '~/hooks/use-toast';
 import type { Route } from './+types/_auth.oauth.$provider';
@@ -63,11 +62,7 @@ export async function clientLoader({
     throw redirect('/login');
   }
 
-  const queryClient = getQueryClient();
-  await queryClient.invalidateQueries({
-    queryKey: [authStateQueryKey],
-    refetchType: 'all',
-  });
+  await invalidateAuthQueries();
 
   const stateValue = JSON.parse(new TextDecoder().decode(decodeURLSafe(state)));
   const oauthLoginSession = oauthLoginSessionStorage.get(


### PR DESCRIPTION
Fixes: "When a user first logs into a new device after we turn on gift cards for them, they may need to refresh, even though they already had it on their other device."

The OAuth callback and URL-based email verification paths only invalidated auth-state after login, not feature-flags. Thus, feature-flags remained cached with their pre-login (anon) values, where user-targeted flags like GIFT_CARDS evaluate to false, until a manual page refresh.