### PR TITLE
Fix "Mint info not loaded" crash on gift cards page

### DIFF
--- a/app/features/gift-cards/gift-card-item.tsx
+++ b/app/features/gift-cards/gift-card-item.tsx
@@ -31,8 +31,11 @@ export function GiftCardItem({
 }: GiftCardItemProps) {
   const isTransitioning = useViewTransitionState('/gift-cards/:accountId');
   const balance = getAccountBalance(account);
+  const mintInfoName = account.isOnline
+    ? account.wallet.mintInfo.name
+    : undefined;
   const name =
-    account.wallet.mintInfo?.name ??
+    mintInfoName ??
     account.mintUrl.replace('https://', '').replace('http://', '');
 
   return (


### PR DESCRIPTION
Guard mintInfo access behind isOnline check to avoid the throwing getter when the mint was unreachable during account initialization.

Fixes AGICASH-6T