### PR TITLE
Fix gift card overlay flash on send/receive navigation

### DIFF
--- a/app/features/gift-cards/gift-card-item.tsx
+++ b/app/features/gift-cards/gift-card-item.tsx
@@ -1,4 +1,3 @@
-import { useViewTransitionState } from 'react-router';
 import { MoneyDisplay } from '~/components/money-display';
 import {
   WalletCard,
@@ -29,7 +28,6 @@ export function GiftCardItem({
   className,
   hideOverlayContent,
 }: GiftCardItemProps) {
-  const isTransitioning = useViewTransitionState('/gift-cards/:accountId');
   const balance = getAccountBalance(account);
   const mintInfoName = account.isOnline
     ? account.wallet.mintInfo.name
@@ -59,9 +57,6 @@ export function GiftCardItem({
             style={{
               height: VERTICAL_CARD_OFFSET_IN_STACK,
               opacity: hideOverlayContent ? 0 : 1,
-              viewTransitionName: isTransitioning
-                ? `card-overlay-${account.id}`
-                : undefined,
             }}
           >
             <span className="text-lg text-white drop-shadow-md">{name}</span>


### PR DESCRIPTION
## Summary
- Removed the `card-overlay-${id}` view transition name from `GiftCardItem` that caused a visible flash when navigating to send/receive from a gift card detail page
- Root cause: `useViewTransitionState('/gift-cards/:accountId')` matches **both** current and next locations — so navigating from `/gift-cards/$cardId` to `/receive` still returned `true`, extracting the overlay into its own view transition group with no matching element on the destination page (browser default crossfade = flash)
- The overlay transition name was redundant: the parent already morphs the entire card via `card-${id}`, and the overlay content cross-fades naturally as part of that card snapshot

## Test plan
- [ ] Open a gift card from the stack — card stack animation should look the same as before
- [ ] Close a gift card back to the list — same animation
- [ ] Tap "Add" or "Send" from a gift card detail — new page slides up smoothly with no flash/transparency on the card behind it
- [ ] Navigate back from send/receive to the gift card — slides back down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)