### PR TITLE
Fix QR scanner play() interrupted error

### DIFF
--- a/app/components/qr-scanner/qr-scanner.tsx
+++ b/app/components/qr-scanner/qr-scanner.tsx
@@ -119,6 +119,10 @@ export const QRScanner = ({ onDecode }: QRScannerProps) => {
     });
 
     scannerInstance.start().catch((err: unknown) => {
+      // video.play() rejects with AbortError when the video element is removed
+      // from the DOM (e.g. during cleanup). This is transient, not a real error.
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+
       setCameraError(
         err instanceof Error ? err.message : 'Failed to start camera',
       );


### PR DESCRIPTION
## Summary
- When the QR scanner component unmounts while the camera is still initializing, `video.play()` rejects with an `AbortError` that was incorrectly treated as a fatal camera error, replacing the video feed with an error message. This ignores the benign `AbortError` since it just means cleanup happened during startup — not an actual camera problem.

This is the error I was seeing:
<img width="377" height="662" alt="image" src="https://github.com/user-attachments/assets/7a4bf6f0-ce5c-41dd-ab57-899cd97688d6" />


## Test plan
- [ ] Open QR scanner, verify camera feed works normally
- [ ] Navigate away from scanner quickly while camera is initializing, navigate back — should show camera feed, not error

🤖 Generated with [Claude Code](https://claude.com/claude-code)