### PR TITLE
Add id-token: write permission to Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,6 +43,7 @@ jobs:
       pull-requests: write  # Create/comment on PRs
       issues: write         # Create/comment on issues
       actions: read         # Read CI results
+      id-token: write       # OIDC token for claude-code-action auth
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This is supposed to fix failed github actions when Claude is invoked. See this one for example -> https://github.com/MakePrisms/agicash/actions/runs/22620343019/job/65543512667

The claude-code-action requires OIDC token access to authenticate with Anthropic's API. Without this permission, the action fails with "Could not fetch an OIDC token".