### PR TITLE
Fix send/receive flows redirecting to history instead of balance

### DIFF
--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -168,7 +168,7 @@ export default function ReceiveToken({
           showOkButton: 'true',
         }),
         {
-          transition: 'slideLeft',
+          transition: 'fade',
           applyTo: 'newView',
         },
       );

--- a/app/features/receive/receive-cashu.tsx
+++ b/app/features/receive/receive-cashu.tsx
@@ -122,7 +122,7 @@ export default function ReceiveCashu({ amount, account }: Props) {
         buildLinkWithSearchParams(`/transactions/${quote.transactionId}`, {
           showOkButton: 'true',
         }),
-        { transition: 'slideLeft', applyTo: 'newView' },
+        { transition: 'fade', applyTo: 'newView' },
       );
     },
   });

--- a/app/features/receive/receive-spark.tsx
+++ b/app/features/receive/receive-spark.tsx
@@ -83,7 +83,7 @@ export default function ReceiveSpark({ amount, account }: Props) {
         buildLinkWithSearchParams(`/transactions/${quote.transactionId}`, {
           showOkButton: 'true',
         }),
-        { transition: 'slideLeft', applyTo: 'newView' },
+        { transition: 'fade', applyTo: 'newView' },
       );
     },
   });

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -124,7 +124,7 @@ const usePayBolt11 = ({
             showOkButton: 'true',
           }),
           {
-            transition: 'slideLeft',
+            transition: 'fade',
             applyTo: 'newView',
           },
         );

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -99,7 +99,7 @@ export function TransactionDetails({
 }) {
   const [searchParams] = useSearchParams();
   const showOkButton = searchParams.get('showOkButton') === 'true';
-  const { redirectTo } = useRedirectTo('/transactions');
+  const { redirectTo } = useRedirectTo('/');
   const account = useAccount(transaction.accountId);
   const { toast } = useToast();
   const { mutate: acknowledgeTransaction } = useAcknowledgeTransaction();

--- a/app/routes/_protected.transactions.$transactionId_.tsx
+++ b/app/routes/_protected.transactions.$transactionId_.tsx
@@ -13,7 +13,7 @@ export default function TransactionDetailsPage({
   params: { transactionId },
 }: Route.ComponentProps) {
   const { data: transaction } = useTransaction(transactionId);
-  const { redirectTo } = useRedirectTo('/transactions');
+  const { redirectTo } = useRedirectTo('/');
 
   return (
     <Page>


### PR DESCRIPTION
After completing a send or receive, clicking OK on the transaction details page incorrectly navigated to /transactions (history) because no redirectTo param was passed. Now all send/receive flows explicitly pass redirectTo=/ so users return to the balance page.