### PR TITLE
refactor: replace custom hex utils with @noble/hashes

### DIFF
--- a/app/features/shared/encryption.ts
+++ b/app/features/shared/encryption.ts
@@ -1,4 +1,5 @@
 import { getPrivateKeyBytes, getPublicKey } from '@agicash/opensecret';
+import { hexToBytes } from '@noble/hashes/utils';
 import { decode, encode } from '@stablelib/base64';
 import { queryOptions, useSuspenseQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -9,7 +10,6 @@ import {
   eciesEncryptBatch,
 } from '~/lib/ecies';
 import { Money } from '~/lib/money';
-import { hexToUint8Array } from '~/lib/utils';
 
 // 10111099 is 'enc' (for encryption) in ascii
 const encryptionKeyDerivationPath = `m/10111099'/0'`;
@@ -20,7 +20,7 @@ export const encryptionPrivateKeyQueryOptions = () =>
     queryFn: () =>
       getPrivateKeyBytes({
         private_key_derivation_path: encryptionKeyDerivationPath,
-      }).then((response) => hexToUint8Array(response.private_key)),
+      }).then((response) => hexToBytes(response.private_key)),
     staleTime: Number.POSITIVE_INFINITY,
   });
 
@@ -117,7 +117,7 @@ export function encryptToPublicKey<T = unknown>(
 
   const encoder = new TextEncoder();
   const dataBytes = encoder.encode(serialized);
-  const publicKeyBytes = hexToUint8Array(publicKeyHex);
+  const publicKeyBytes = hexToBytes(publicKeyHex);
 
   const encryptedBytes = eciesEncrypt(dataBytes, publicKeyBytes);
   return encode(encryptedBytes);
@@ -140,7 +140,7 @@ export function encryptBatchToPublicKey<T extends readonly unknown[]>(
     const serialized = JSON.stringify(preprocessedData);
     return encoder.encode(serialized);
   });
-  const publicKeyBytes = hexToUint8Array(publicKeyHex);
+  const publicKeyBytes = hexToBytes(publicKeyHex);
 
   const encryptedBytes = eciesEncryptBatch(dataBytes, publicKeyBytes);
   return encryptedBytes.map((x) => encode(x));

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -9,18 +9,6 @@ export function sum(numbers: number[]) {
   return numbers.reduce((acc, curr) => acc + curr, 0);
 }
 
-export function hexToUint8Array(hex: string) {
-  return new Uint8Array(
-    hex.match(/.{1,2}/g)?.map((byte) => Number.parseInt(byte, 16)) ?? [],
-  );
-}
-
-export function uint8ArrayToHex(uint8Array: Uint8Array) {
-  return Array.from(uint8Array)
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
-}
-
 export function isSubset<T>(subset: Set<T>, superset: Set<T>): boolean {
   const isSubsetOf = (
     subset as unknown as {


### PR DESCRIPTION
Remove custom `uint8ArrayToHex` and `hexToUint8Array` from `lib/utils` and use `bytesToHex` / `hexToBytes` from `@noble/hashes/utils` instead.

Closes #626

Generated with [Claude Code](https://claude.ai/code)