### PR TITLE
feat: add pull-to-refresh on transactions page

### DIFF
--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -1,4 +1,10 @@
-import { AlertCircle, BanknoteIcon, UserIcon, ZapIcon } from 'lucide-react';
+import {
+  AlertCircle,
+  BanknoteIcon,
+  LoaderCircle,
+  UserIcon,
+  ZapIcon,
+} from 'lucide-react';
 import {
   type Ref,
   useCallback,
@@ -12,6 +18,7 @@ import { SparkIcon } from '~/components/spark-icon';
 import { Card } from '~/components/ui/card';
 import { useTransactionAckStatusStore } from '~/features/transactions/transaction-ack-status-store';
 import { useIsVisible } from '~/hooks/use-is-visible';
+import { usePullToRefresh } from '~/hooks/use-pull-to-refresh';
 import { getStartOfWeek, isToday } from '~/lib/date';
 import {
   LinkWithViewTransition,
@@ -282,8 +289,19 @@ export function TransactionList({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    refetch,
     status,
   } = useTransactions(accountId);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const {
+    state: pullState,
+    pullDistance,
+    touchHandlers,
+  } = usePullToRefresh({
+    onRefresh: () => refetch(),
+    scrollRef,
+  });
 
   const allTransactions = useMemo(
     () => data?.pages.flatMap((page) => page.transactions) ?? [],
@@ -334,26 +352,48 @@ export function TransactionList({
 
   return (
     <div
+      ref={scrollRef}
       className={cn('scrollbar-none h-full min-h-0 overflow-y-auto', className)}
+      {...touchHandlers}
     >
-      <div className="w-full space-y-6">
-        <TransactionSection
-          title="Pending"
-          transactions={pendingTransactions}
-        />
-        <TransactionSection title="Today" transactions={todayTransactions} />
-        <TransactionSection
-          title="This Week"
-          transactions={thisWeekTransactions}
-        />
-        <TransactionSection title="Older" transactions={olderTransactions} />
+      <div
+        className="transition-transform duration-200 ease-out"
+        style={{
+          transform:
+            pullState !== 'idle' ? `translateY(${pullDistance}px)` : undefined,
+        }}
+      >
+        <div
+          className="flex items-center justify-center overflow-hidden transition-all duration-200 ease-out"
+          style={{ height: pullState !== 'idle' ? `${pullDistance}px` : '0px' }}
+        >
+          <LoaderCircle
+            className={cn(
+              'h-5 w-5 text-muted-foreground transition-opacity',
+              pullState === 'refreshing' && 'animate-spin',
+            )}
+            style={{ opacity: Math.min(pullDistance / 24, 1) }}
+          />
+        </div>
+        <div className="w-full space-y-6">
+          <TransactionSection
+            title="Pending"
+            transactions={pendingTransactions}
+          />
+          <TransactionSection title="Today" transactions={todayTransactions} />
+          <TransactionSection
+            title="This Week"
+            transactions={thisWeekTransactions}
+          />
+          <TransactionSection title="Older" transactions={olderTransactions} />
+        </div>
+        {hasNextPage && (
+          <LoadMore
+            onReached={() => !isFetchingNextPage && fetchNextPage()}
+            isLoading={isFetchingNextPage}
+          />
+        )}
       </div>
-      {hasNextPage && (
-        <LoadMore
-          onReached={() => !isFetchingNextPage && fetchNextPage()}
-          isLoading={isFetchingNextPage}
-        />
-      )}
     </div>
   );
 }

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -321,19 +321,6 @@ export function TransactionList({
     olderTransactions,
   } = usePartitionTransactions(allTransactions);
 
-  if (status === 'error') {
-    return (
-      <div className="flex h-full flex-col items-center justify-center p-8">
-        <Card className="max-w-sm p-6">
-          <div className="flex flex-col items-center gap-3 text-center text-primary-foreground">
-            <AlertCircle className="h-8 w-8" />
-            <span>{error?.message || 'Unable to load transactions'}</span>
-          </div>
-        </Card>
-      </div>
-    );
-  }
-
   if (status === 'pending') {
     return (
       <div className="flex flex-col items-center justify-center gap-2 p-4 text-center">
@@ -342,13 +329,51 @@ export function TransactionList({
     );
   }
 
-  if (!allTransactions.length) {
+  const content = (() => {
+    if (status === 'error') {
+      return (
+        <div className="flex h-full flex-col items-center justify-center p-8">
+          <Card className="max-w-sm p-6">
+            <div className="flex flex-col items-center gap-3 text-center text-primary-foreground">
+              <AlertCircle className="h-8 w-8" />
+              <span>{error?.message || 'Unable to load transactions'}</span>
+            </div>
+          </Card>
+        </div>
+      );
+    }
+
+    if (!allTransactions.length) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
+          <span className="text-muted-foreground">No transactions yet</span>
+        </div>
+      );
+    }
+
     return (
-      <div className="flex flex-col items-center justify-center gap-2 p-4 text-center">
-        <span className="text-muted-foreground">No transactions yet</span>
-      </div>
+      <>
+        <div className="w-full space-y-6">
+          <TransactionSection
+            title="Pending"
+            transactions={pendingTransactions}
+          />
+          <TransactionSection title="Today" transactions={todayTransactions} />
+          <TransactionSection
+            title="This Week"
+            transactions={thisWeekTransactions}
+          />
+          <TransactionSection title="Older" transactions={olderTransactions} />
+        </div>
+        {hasNextPage && (
+          <LoadMore
+            onReached={() => !isFetchingNextPage && fetchNextPage()}
+            isLoading={isFetchingNextPage}
+          />
+        )}
+      </>
     );
-  }
+  })();
 
   return (
     <div
@@ -375,24 +400,7 @@ export function TransactionList({
             style={{ opacity: Math.min(pullDistance / 24, 1) }}
           />
         </div>
-        <div className="w-full space-y-6">
-          <TransactionSection
-            title="Pending"
-            transactions={pendingTransactions}
-          />
-          <TransactionSection title="Today" transactions={todayTransactions} />
-          <TransactionSection
-            title="This Week"
-            transactions={thisWeekTransactions}
-          />
-          <TransactionSection title="Older" transactions={olderTransactions} />
-        </div>
-        {hasNextPage && (
-          <LoadMore
-            onReached={() => !isFetchingNextPage && fetchNextPage()}
-            isLoading={isFetchingNextPage}
-          />
-        )}
+        {content}
       </div>
     </div>
   );

--- a/app/hooks/use-pull-to-refresh.ts
+++ b/app/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,90 @@
+import { useCallback, useRef, useState } from 'react';
+
+const PULL_THRESHOLD = 60;
+const MAX_PULL_DISTANCE = 100;
+const RESISTANCE_FACTOR = 0.4;
+
+type PullToRefreshState = 'idle' | 'pulling' | 'refreshing';
+
+export function usePullToRefresh({
+  onRefresh,
+  scrollRef,
+}: {
+  onRefresh: () => Promise<unknown>;
+  scrollRef: React.RefObject<HTMLElement | null>;
+}) {
+  const [state, setState] = useState<PullToRefreshState>('idle');
+  const [pullDistance, setPullDistance] = useState(0);
+  const startY = useRef(0);
+  const currentY = useRef(0);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (state === 'refreshing') return;
+      const scrollTop = scrollRef.current?.scrollTop ?? 0;
+      if (scrollTop > 0) return;
+
+      startY.current = e.touches[0].clientY;
+      currentY.current = startY.current;
+    },
+    [state, scrollRef],
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (state === 'refreshing') return;
+      if (startY.current === 0) return;
+
+      const scrollTop = scrollRef.current?.scrollTop ?? 0;
+      if (scrollTop > 0) {
+        startY.current = 0;
+        setPullDistance(0);
+        setState('idle');
+        return;
+      }
+
+      currentY.current = e.touches[0].clientY;
+      const rawDistance = currentY.current - startY.current;
+
+      if (rawDistance <= 0) {
+        setPullDistance(0);
+        setState('idle');
+        return;
+      }
+
+      const distance = Math.min(
+        rawDistance * RESISTANCE_FACTOR,
+        MAX_PULL_DISTANCE,
+      );
+      setPullDistance(distance);
+      setState('pulling');
+    },
+    [state, scrollRef],
+  );
+
+  const onTouchEnd = useCallback(async () => {
+    if (state === 'refreshing') return;
+
+    if (pullDistance >= PULL_THRESHOLD * RESISTANCE_FACTOR) {
+      setState('refreshing');
+      setPullDistance(PULL_THRESHOLD * RESISTANCE_FACTOR);
+      try {
+        await onRefresh();
+      } finally {
+        setState('idle');
+        setPullDistance(0);
+      }
+    } else {
+      setState('idle');
+      setPullDistance(0);
+    }
+
+    startY.current = 0;
+  }, [state, pullDistance, onRefresh]);
+
+  return {
+    state,
+    pullDistance,
+    touchHandlers: { onTouchStart, onTouchMove, onTouchEnd },
+  };
+}


### PR DESCRIPTION
Closes #450

Adds pull-to-refresh to the transactions page for a mobile-like reload experience. Creates a reusable `usePullToRefresh` hook and integrates it into `TransactionList` with visual feedback (spinner indicator).

Generated with [Claude Code](https://claude.ai/code)