### PR TITLE
Ignore DuckDuckGo iOS hover CSS parser error in Sentry

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -57,6 +57,9 @@ Sentry.init({
     // The transition is simply skipped; navigation still works. This is a React Router
     // internal call we can't wrap. See https://make-prisms.sentry.io/issues/6786605134/?project=4509707316690944.
     /^View transition was skipped because document visibility state is hidden\.$/,
+    // DuckDuckGo on iOS (WebKit) throws when encountering @media (hover: hover)
+    // from Tailwind v4. No stack trace, not our code. See AGICASH-7B.
+    /^feature named `.*` was not found$/,
   ],
   enabled:
     process.env.NODE_ENV === 'production' &&


### PR DESCRIPTION
Ignores AGICASH-7B.

Claude's analysis:

```
  Summary

  Error: feature named 'hover' was not found
  Where: /signup page, single occurrence on an iPhone (DuckDuckGo Mobile 26.3, iOS 18.6)
  Mechanism: onunhandledrejection — no stack trace available

  Analysis

  The exact error string feature named 'hover' was not found doesn't exist in our codebase or any of our dependencies (I searched source code, build output, and WASM binaries). The backtick formatting suggests it comes from a Rust-based tool
  (likely lightningcss or similar) but none of our build-time dependencies ship this to the browser.

  Most likely cause: This is a DuckDuckGo Mobile browser internal error. DuckDuckGo on iOS injects its own content blocking/privacy scripts that process CSS. When it encounters @media (hover: hover) (which Tailwind v4 uses for all hover:
  variants), the browser's internal CSS parser throws this error. It surfaces as an unhandled rejection on our page, but it's not our code.

  Evidence:
  - No stack trace (browser-internal errors often have none)
  - Only 1 occurrence, 0 users impacted
  - Only on DuckDuckGo Mobile (not a standard WebKit browser)
  - The error message format doesn't match any of our dependencies
```

I tried to reproduce it with duck duck go browser on android and iphone and happens only on iphone without anything visible for the user