### PR TITLE
Pin devenv to v1.11.2 in CI

### DIFF
--- a/.github/actions/setup-devenv/action.yml
+++ b/.github/actions/setup-devenv/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install devenv and direnv
       shell: bash
-      run: nix profile install nixpkgs#devenv nixpkgs#direnv
+      run: nix profile install github:cachix/devenv/v1.11.2 nixpkgs#direnv
 
     - name: Build devenv and export environment
       shell: bash


### PR DESCRIPTION
## Summary

- CI installs devenv via `nixpkgs#devenv`, which recently resolved to **devenv 2.0.1**
- devenv 2.0 [no longer includes the `git-hooks` input by default](https://devenv.sh/guides/migrating-to-2.0/), causing CI to fail with `Failed assertions: To use 'git-hooks', run the following command...`
- This went unnoticed locally because dev machines still had devenv 1.x
- Pins CI to `github:cachix/devenv/v1.11.2` until we do a proper devenv 2.0 migration
- Failed run: https://github.com/MakePrisms/agicash/actions/runs/22725931614/job/65900924981

## Test plan

- [ ] CI passes on this PR