### PR TITLE
fix: hide @ destination picker for gift-card accounts

### DIFF
--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -246,11 +246,13 @@ export function SendInput() {
                 <Scan />
               </LinkWithViewTransition>
 
-              <SelectDestinationDrawer
-                open={selectDestinationDrawerOpen}
-                onOpenChange={setSelectDestinationDrawerOpen}
-                onSelect={handleSelectDestination}
-              />
+              {sendAccount.purpose !== 'gift-card' && (
+                <SelectDestinationDrawer
+                  open={selectDestinationDrawerOpen}
+                  onOpenChange={setSelectDestinationDrawerOpen}
+                  onSelect={handleSelectDestination}
+                />
+              )}
             </div>
             <div /> {/* spacer */}
             <div className="flex items-center justify-end">


### PR DESCRIPTION
## Summary
- Hides the `@` (SelectDestinationDrawer) button on the send input screen when the selected account is a gift-card account
- Gift-card accounts can only send ecash tokens, so the contact/lightning address picker is not applicable

## Test plan
- [ ] Select a gift-card account on the send screen — verify the `@` button is not visible
- [ ] Select a transactional account — verify the `@` button is visible and works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)