### PR TITLE
alt: store transferId in transaction_details JSONB

### DIFF
--- a/app/features/transactions/transaction-details/cashu-lightning-receive-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-lightning-receive-transaction-details.ts
@@ -35,6 +35,10 @@ export const CashuLightningReceiveTransactionDetailsSchema = z.object({
    * In this case it is equal to `mintingFee` or zero if the mint has no minting fee.
    */
   totalFee: z.instanceof(Money),
+  /**
+   * UUID linking paired send/receive transactions for internal transfers.
+   */
+  transferId: z.string().optional(),
 });
 
 export type CashuLightningReceiveTransactionDetails = z.infer<
@@ -48,6 +52,7 @@ export const CashuLightningReceiveTransactionDetailsParser = z
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
+      transferId: z.string().optional(),
     }),
     decryptedTransactionDetails: CashuLightningReceiveDbDataSchema,
   })
@@ -63,6 +68,7 @@ export const CashuLightningReceiveTransactionDetailsParser = z
         mintingFee: decryptedTransactionDetails.mintingFee,
         amount: decryptedTransactionDetails.amountReceived,
         totalFee: decryptedTransactionDetails.totalFee,
+        transferId: transactionDetails.transferId,
       };
     },
   ) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/cashu-lightning-send-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-lightning-send-transaction-details.ts
@@ -58,6 +58,10 @@ export const IncompleteCashuLightningSendTransactionDetailsSchema = z.object({
    * This is the sum of `amountReceived` and `totalFee`.
    */
   amount: z.instanceof(Money),
+  /**
+   * UUID linking paired send/receive transactions for internal transfers.
+   */
+  transferId: z.string().optional(),
 });
 
 export type IncompleteCashuLightningSendTransactionDetails = z.infer<
@@ -107,6 +111,7 @@ export const CashuLightningSendTransactionDetailsParser = z
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
+      transferId: z.string().optional(),
     }),
     decryptedTransactionDetails: CashuLightningSendDbDataSchema,
   })
@@ -132,6 +137,7 @@ export const CashuLightningSendTransactionDetailsParser = z
               decryptedTransactionDetails.cashuSendFee,
             ),
           amount: decryptedTransactionDetails.amountReserved,
+          transferId: transactionDetails.transferId,
         };
 
       if (state === 'COMPLETED') {

--- a/app/features/transactions/transaction-details/spark-lightning-receive-transaction-details.ts
+++ b/app/features/transactions/transaction-details/spark-lightning-receive-transaction-details.ts
@@ -30,6 +30,10 @@ export const IncompleteSparkLightningReceiveTransactionDetailsSchema = z.object(
      * This is the amount of the bolt 11 payment request.
      */
     amount: z.instanceof(Money),
+    /**
+     * UUID linking paired send/receive transactions for internal transfers.
+     */
+    transferId: z.string().optional(),
   },
 );
 
@@ -74,6 +78,7 @@ export const SparkLightningReceiveTransactionDetailsParser = z
       paymentHash: z.string(),
       sparkId: z.string(),
       sparkTransferId: z.string().optional(),
+      transferId: z.string().optional(),
     }),
     decryptedTransactionDetails: SparkLightningReceiveDbDataSchema,
   })
@@ -92,6 +97,7 @@ export const SparkLightningReceiveTransactionDetailsParser = z
           sparkId: transactionDetails.sparkId,
           description: decryptedTransactionDetails.description,
           amount: decryptedTransactionDetails.amountReceived,
+          transferId: transactionDetails.transferId,
         };
 
       if (state === 'COMPLETED') {

--- a/app/features/transactions/transaction-details/spark-lightning-send-transaction-details.ts
+++ b/app/features/transactions/transaction-details/spark-lightning-send-transaction-details.ts
@@ -50,6 +50,10 @@ export const IncompleteSparkLightningSendTransactionDetailsSchema = z.object({
    * Available after the payment is initiated.
    */
   sparkTransferId: z.string().optional(),
+  /**
+   * UUID linking paired send/receive transactions for internal transfers.
+   */
+  transferId: z.string().optional(),
 });
 
 export type IncompleteSparkLightningSendTransactionDetails = z.infer<
@@ -63,6 +67,8 @@ export const CompletedSparkLightningSendTransactionDetailsSchema =
   IncompleteSparkLightningSendTransactionDetailsSchema.required().extend({
     /** The preimage of the lightning payment. */
     paymentPreimage: z.string(),
+    /** transferId remains optional — only present for TRANSFER transactions. */
+    transferId: z.string().optional(),
   });
 
 export type CompletedSparkLightningSendTransactionDetails = z.infer<
@@ -87,6 +93,7 @@ export const SparkLightningSendTransactionDetailsParser = z
       paymentHash: z.string(),
       sparkId: z.string().optional(),
       sparkTransferId: z.string().optional(),
+      transferId: z.string().optional(),
     }),
     decryptedTransactionDetails: SparkLightningSendDbDataSchema,
   })
@@ -111,6 +118,7 @@ export const SparkLightningSendTransactionDetailsParser = z
             ),
           sparkId: transactionDetails.sparkId,
           sparkTransferId: transactionDetails.sparkTransferId,
+          transferId: transactionDetails.transferId,
           fee:
             decryptedTransactionDetails.lightningFee ??
             decryptedTransactionDetails.estimatedLightningFee,

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -177,9 +177,9 @@ const CompletedSparkLightningSendTransactionSchema =
   });
 
 /**
- * Schema for all transaction types.
+ * Union of all transaction type/direction/state variants.
  */
-export const TransactionSchema = z.union([
+const TransactionByTypeSchema = z.union([
   CashuTokenSendTransactionSchema,
   CashuTokenReceiveTransactionSchema,
   IncompleteCashuLightningSendTransactionSchema,
@@ -189,6 +189,24 @@ export const TransactionSchema = z.union([
   CompletedSparkLightningReceiveTransactionSchema,
   IncompleteSparkLightningSendTransactionSchema,
   CompletedSparkLightningSendTransactionSchema,
+]);
+
+/**
+ * Schema for all transaction types.
+ * Enforces that details.transferId is required when purpose is TRANSFER.
+ */
+export const TransactionSchema = z.union([
+  TransactionByTypeSchema.and(
+    z.object({
+      purpose: z.literal('TRANSFER'),
+      details: z.object({ transferId: z.string() }),
+    }),
+  ),
+  TransactionByTypeSchema.and(
+    z.object({
+      purpose: z.enum(['PAYMENT', 'BUY_CASHAPP']),
+    }),
+  ),
 ]);
 
 export type Transaction = z.infer<typeof TransactionSchema>;

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -738,7 +738,6 @@ export type Database = {
           state: Database["wallet"]["Enums"]["transaction_state"]
           state_sort_order: number | null
           transaction_details: Json | null
-          transfer_id: string | null
           type: Database["wallet"]["Enums"]["transaction_type"]
           user_id: string
           version: number
@@ -762,7 +761,6 @@ export type Database = {
           state: Database["wallet"]["Enums"]["transaction_state"]
           state_sort_order?: number | null
           transaction_details?: Json | null
-          transfer_id?: string | null
           type: Database["wallet"]["Enums"]["transaction_type"]
           user_id: string
           version?: number
@@ -786,7 +784,6 @@ export type Database = {
           state?: Database["wallet"]["Enums"]["transaction_state"]
           state_sort_order?: number | null
           transaction_details?: Json | null
-          transfer_id?: string | null
           type?: Database["wallet"]["Enums"]["transaction_type"]
           user_id?: string
           version?: number
@@ -1453,7 +1450,6 @@ export type Database = {
           state: Database["wallet"]["Enums"]["transaction_state"]
           state_sort_order: number | null
           transaction_details: Json | null
-          transfer_id: string | null
           type: Database["wallet"]["Enums"]["transaction_type"]
           user_id: string
           version: number

--- a/supabase/migrations/20260306120000_add_transaction_purpose_and_transfer_id.sql
+++ b/supabase/migrations/20260306120000_add_transaction_purpose_and_transfer_id.sql
@@ -2,34 +2,32 @@
 --
 -- Purpose:
 -- 1. Track the purpose of a transaction — e.g. PAYMENT, BUY_CASHAPP, TRANSFER
--- 2. Link paired send/receive transactions via transfer_id for transfers
+-- 2. Link paired send/receive transactions via transferId stored in
+--    transaction_details JSONB (same pattern as sparkTransferId, paymentHash)
 -- 3. Accept purpose and transfer_id when creating quotes so the purpose is recorded
 --    at creation time
 --
 -- Notes:
 -- - purpose defaults to 'PAYMENT' for organic send/receive transactions
--- - transfer_id is nullable: null = non-transfer transaction
--- - The unique partial index on (transfer_id, direction) ensures at most one
---   send and one receive per transfer, and excludes nulls to avoid indexing
---   the common case
+-- - transferId in transaction_details is optional: absent = non-transfer transaction
+-- - The unique partial index on (transaction_details->>'transferId', direction)
+--   ensures at most one send and one receive per transfer, and excludes nulls
+--   to avoid indexing the common case
 
--- 1. Schema changes: enum, columns, index
+-- 1. Schema changes: enum, column, index, constraint
 
 create type "wallet"."transaction_purpose" as enum ('PAYMENT', 'BUY_CASHAPP', 'TRANSFER');
 
 alter table "wallet"."transactions"
   add column "purpose" "wallet"."transaction_purpose" not null default 'PAYMENT';
 
-alter table "wallet"."transactions"
-  add column "transfer_id" uuid;
-
 create unique index "idx_transactions_transfer_id_direction"
-  on "wallet"."transactions" ("transfer_id", "direction")
-  where "transfer_id" is not null;
+  on "wallet"."transactions" (("transaction_details" ->> 'transferId'), "direction")
+  where ("transaction_details" ->> 'transferId') is not null;
 
 alter table "wallet"."transactions"
   add constraint "chk_transfer_id_required_for_transfer"
-  check (purpose != 'TRANSFER' or transfer_id is not null);
+  check (purpose != 'TRANSFER' or ("transaction_details" ->> 'transferId') is not null);
 
 -- 2. Cashu receive quote: drop old signature, recreate with p_purpose and p_transfer_id
 
@@ -62,6 +60,7 @@ declare
   v_cashu_token_melt_initiated boolean;
   v_transaction_id uuid;
   v_quote wallet.cashu_receive_quotes;
+  v_transaction_details jsonb;
 begin
   v_transaction_type := case p_receive_type
     when 'LIGHTNING' then 'CASHU_LIGHTNING'
@@ -91,6 +90,11 @@ begin
     else null
   end;
 
+  v_transaction_details := jsonb_build_object('paymentHash', p_payment_hash);
+  if p_transfer_id is not null then
+    v_transaction_details := v_transaction_details || jsonb_build_object('transferId', p_transfer_id::text);
+  end if;
+
   -- Store encrypted data in transactions table as encrypted_transaction_details
   insert into wallet.transactions (
     user_id,
@@ -101,8 +105,7 @@ begin
     currency,
     encrypted_transaction_details,
     transaction_details,
-    purpose,
-    transfer_id
+    purpose
   ) values (
     p_user_id,
     p_account_id,
@@ -111,9 +114,8 @@ begin
     v_transaction_state,
     p_currency,
     p_encrypted_data,
-    jsonb_build_object('paymentHash', p_payment_hash),
-    p_purpose,
-    p_transfer_id
+    v_transaction_details,
+    p_purpose
   ) returning id into v_transaction_id;
 
   insert into wallet.cashu_receive_quotes (
@@ -177,6 +179,7 @@ declare
   v_cashu_token_melt_initiated boolean;
   v_transaction_id uuid;
   v_quote wallet.spark_receive_quotes;
+  v_transaction_details jsonb;
 begin
   v_transaction_type := case p_receive_type
     when 'LIGHTNING' then 'SPARK_LIGHTNING'
@@ -206,6 +209,11 @@ begin
     else null
   end;
 
+  v_transaction_details := jsonb_build_object('sparkId', p_spark_id, 'paymentHash', p_payment_hash);
+  if p_transfer_id is not null then
+    v_transaction_details := v_transaction_details || jsonb_build_object('transferId', p_transfer_id::text);
+  end if;
+
   insert into wallet.transactions (
     user_id,
     account_id,
@@ -215,8 +223,7 @@ begin
     currency,
     encrypted_transaction_details,
     transaction_details,
-    purpose,
-    transfer_id
+    purpose
   ) values (
     p_user_id,
     p_account_id,
@@ -225,9 +232,8 @@ begin
     v_transaction_state,
     p_currency,
     p_encrypted_data,
-    jsonb_build_object('sparkId', p_spark_id, 'paymentHash', p_payment_hash),
-    p_purpose,
-    p_transfer_id
+    v_transaction_details,
+    p_purpose
   ) returning id into v_transaction_id;
 
   insert into wallet.spark_receive_quotes (
@@ -294,6 +300,7 @@ declare
   v_counter integer;
   v_transaction_id uuid;
   v_reserved_proofs wallet.cashu_proofs[];
+  v_transaction_details jsonb;
 begin
   if p_number_of_change_outputs < 0 then
     raise exception
@@ -329,6 +336,11 @@ begin
     v_counter := coalesce((v_account.details->'keyset_counters'->>p_keyset_id)::integer, 0);
   end if;
 
+  v_transaction_details := jsonb_build_object('paymentHash', p_payment_hash);
+  if p_transfer_id is not null then
+    v_transaction_details := v_transaction_details || jsonb_build_object('transferId', p_transfer_id::text);
+  end if;
+
   insert into wallet.transactions (
     user_id,
     account_id,
@@ -338,8 +350,7 @@ begin
     currency,
     encrypted_transaction_details,
     transaction_details,
-    purpose,
-    transfer_id
+    purpose
   ) values (
     p_user_id,
     p_account_id,
@@ -348,9 +359,8 @@ begin
     'PENDING',
     p_currency,
     p_encrypted_data,
-    jsonb_build_object('paymentHash', p_payment_hash),
-    p_purpose,
-    p_transfer_id
+    v_transaction_details,
+    p_purpose
   ) returning id into v_transaction_id;
 
   insert into wallet.cashu_send_quotes (
@@ -436,7 +446,13 @@ as $function$
 declare
   v_transaction_id uuid;
   v_quote wallet.spark_send_quotes;
+  v_transaction_details jsonb;
 begin
+  v_transaction_details := jsonb_build_object('paymentHash', p_payment_hash);
+  if p_transfer_id is not null then
+    v_transaction_details := v_transaction_details || jsonb_build_object('transferId', p_transfer_id::text);
+  end if;
+
   insert into wallet.transactions (
     user_id,
     account_id,
@@ -447,8 +463,7 @@ begin
     encrypted_transaction_details,
     transaction_details,
     pending_at,
-    purpose,
-    transfer_id
+    purpose
   ) values (
     p_user_id,
     p_account_id,
@@ -457,10 +472,9 @@ begin
     'DRAFT',
     p_currency,
     p_encrypted_data,
-    jsonb_build_object('paymentHash', p_payment_hash),
+    v_transaction_details,
     now(),
-    p_purpose,
-    p_transfer_id
+    p_purpose
   ) returning id into v_transaction_id;
 
   insert into wallet.spark_send_quotes (


### PR DESCRIPTION
## Summary

Alternative to #928 — stores `transferId` in the `transaction_details` JSONB column instead of adding a dedicated `transfer_id` column on `wallet.transactions`.

- Follows the same pattern as `sparkTransferId` and `paymentHash` (already stored in `transaction_details`)
- Unique partial index on `(transaction_details->>'transferId', direction)` enforces one send + one receive per transfer
- CHECK constraint ensures `transferId` is present when `purpose = 'TRANSFER'`
- All 4 quote creation functions conditionally merge `transferId` into the JSONB when provided
- TypeScript transaction detail schemas updated with optional `transferId` field

### Trade-off vs #928

- **This PR** modifies the original migration directly → **requires a db reset** on next `supabase migration up`
- **#928** adds a separate migration to move the column after the fact → **no db reset needed**

## Test plan

- [ ] `supabase db reset` + `supabase migration up` applies cleanly
- [ ] Creating a quote with `p_transfer_id` stores it in `transaction_details->>'transferId'`
- [ ] Creating a quote without `p_transfer_id` has no `transferId` key in JSONB
- [ ] Unique index prevents duplicate `(transferId, direction)` pairs
- [ ] CHECK constraint rejects `purpose = 'TRANSFER'` without `transferId` in JSONB
- [ ] TypeScript types parse correctly with and without `transferId`