### PR TITLE
fix: always redirect to gift card after completing a flow

### DIFF
--- a/app/features/buy/buy-checkout.tsx
+++ b/app/features/buy/buy-checkout.tsx
@@ -10,11 +10,12 @@ import {
 import { QRCode } from '~/components/qr-code';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
+import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import useUserAgent from '~/hooks/use-user-agent';
 import type { Money } from '~/lib/money';
 import { useNavigateWithViewTransition } from '~/lib/transitions';
-import type { Account, CashuAccount, SparkAccount } from '../accounts/account';
+import type { CashuAccount, SparkAccount } from '../accounts/account';
 import { useCashuReceiveQuote } from '../receive/cashu-receive-quote-hooks';
 import { useSparkReceiveQuote } from '../receive/spark-receive-quote-hooks';
 import { getDefaultUnit } from '../shared/currencies';
@@ -32,24 +33,16 @@ const getErrorMessageFromQuoteStatus = (status: string) => {
   return undefined;
 };
 
-const getRedirectTo = (account: Account) => {
-  if (account.purpose === 'gift-card') {
-    return `/gift-cards/${account.id}`;
-  }
-  return undefined;
-};
-
-const useNavigateToTransaction = (redirectTo?: string) => {
+const useNavigateToTransaction = (redirectTo: string) => {
   const navigate = useNavigateWithViewTransition();
   const buildLinkWithSearchParams = useBuildLinkWithSearchParams();
 
   return (transactionId: string) => {
-    const params: Record<string, string> = { showOkButton: 'true' };
-    if (redirectTo) {
-      params.redirectTo = redirectTo;
-    }
     navigate(
-      buildLinkWithSearchParams(`/transactions/${transactionId}`, params),
+      buildLinkWithSearchParams(`/transactions/${transactionId}`, {
+        showOkButton: 'true',
+        redirectTo,
+      }),
       { transition: 'fade', applyTo: 'newView' },
     );
   };
@@ -225,9 +218,10 @@ export function BuyCheckoutCashu({
   amount: Money;
   account: CashuAccount;
 }) {
-  const navigateToTransaction = useNavigateToTransaction(
-    getRedirectTo(account),
+  const { redirectTo } = useRedirectTo(
+    account.purpose === 'gift-card' ? `/gift-cards/${account.id}` : '/',
   );
+  const navigateToTransaction = useNavigateToTransaction(redirectTo);
 
   const { status: quotePaymentStatus } = useCashuReceiveQuote({
     quoteId: quote.id,
@@ -256,9 +250,10 @@ export function BuyCheckoutSpark({
   amount: Money;
   account: SparkAccount;
 }) {
-  const navigateToTransaction = useNavigateToTransaction(
-    getRedirectTo(account),
+  const { redirectTo } = useRedirectTo(
+    account.purpose === 'gift-card' ? `/gift-cards/${account.id}` : '/',
   );
+  const navigateToTransaction = useNavigateToTransaction(redirectTo);
 
   const { status: quotePaymentStatus } = useSparkReceiveQuote({
     quoteId: quote.id,

--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -24,7 +24,12 @@ import { ReceiveCashuTokenService } from './receive-cashu-token-service';
 import type { SparkReceiveQuote } from './spark-receive-quote';
 import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
 
-type ClaimTokenResult = { success: true } | { success: false; message: string };
+type ClaimTokenResult =
+  | {
+      success: true;
+      destinationAccount: Pick<Account, 'id' | 'purpose'>;
+    }
+  | { success: false; message: string };
 
 export class ClaimCashuTokenService {
   private readonly accountsCache: AccountsCache;
@@ -194,7 +199,13 @@ export class ClaimCashuTokenService {
       }
     }
 
-    return { success: true };
+    return {
+      success: true,
+      destinationAccount: {
+        id: receiveAccount.id,
+        purpose: receiveAccount.purpose,
+      },
+    };
   }
 
   private async trySetDefaultAccount(

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/components/page';
 import { Button } from '~/components/ui/button';
 import { useFeatureFlag } from '~/features/shared/feature-flags';
+import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { useToast } from '~/hooks/use-toast';
 import type { Currency } from '~/lib/money';
@@ -117,6 +118,11 @@ export default function ReceiveToken({
     setReceiveAccount,
     addAndSetReceiveAccount,
   } = useReceiveCashuTokenAccounts(token, preferredReceiveAccountId);
+  const { redirectTo } = useRedirectTo(
+    receiveAccount?.purpose === 'gift-card'
+      ? `/gift-cards/${receiveAccount.id}`
+      : '/',
+  );
 
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
 
@@ -166,6 +172,7 @@ export default function ReceiveToken({
       navigate(
         buildLinkWithSearchParams(`/transactions/${transactionId}`, {
           showOkButton: 'true',
+          redirectTo,
         }),
         {
           transition: 'fade',

--- a/app/features/receive/receive-cashu.tsx
+++ b/app/features/receive/receive-cashu.tsx
@@ -13,6 +13,7 @@ import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
 import type { CashuAccount } from '~/features/accounts/account';
 import { useEffectNoStrictMode } from '~/hooks/use-effect-no-strict-mode';
+import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { useToast } from '~/hooks/use-toast';
 import type { Money } from '~/lib/money';
@@ -113,6 +114,9 @@ export default function ReceiveCashu({ amount, account }: Props) {
   const { toast } = useToast();
   const navigate = useNavigateWithViewTransition();
   const buildLinkWithSearchParams = useBuildLinkWithSearchParams();
+  const { redirectTo } = useRedirectTo(
+    account.purpose === 'gift-card' ? `/gift-cards/${account.id}` : '/',
+  );
 
   const { quote, errorMessage, isLoading } = useCreateQuote({
     account,
@@ -121,6 +125,7 @@ export default function ReceiveCashu({ amount, account }: Props) {
       navigate(
         buildLinkWithSearchParams(`/transactions/${quote.transactionId}`, {
           showOkButton: 'true',
+          redirectTo,
         }),
         { transition: 'fade', applyTo: 'newView' },
       );

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from '~/components/ui/card';
 import type { CashuAccount, SparkAccount } from '~/features/accounts/account';
 import type { CashuLightningQuote } from '~/features/send/cashu-send-quote-service';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
+import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { useToast } from '~/hooks/use-toast';
 import { decodeBolt11 } from '~/lib/bolt11';
@@ -115,6 +116,9 @@ const usePayBolt11 = ({
   const { toast } = useToast();
   const navigate = useNavigateWithViewTransition();
   const buildLinkWithSearchParams = useBuildLinkWithSearchParams();
+  const { redirectTo } = useRedirectTo(
+    account.purpose === 'gift-card' ? `/gift-cards/${account.id}` : '/',
+  );
 
   const { mutate: initiateCashuSend, status: initiateCashuSendQuoteStatus } =
     useInitiateCashuSendQuote({
@@ -122,6 +126,7 @@ const usePayBolt11 = ({
         navigate(
           buildLinkWithSearchParams(`/transactions/${data.transactionId}`, {
             showOkButton: 'true',
+            redirectTo,
           }),
           {
             transition: 'fade',
@@ -149,7 +154,7 @@ const usePayBolt11 = ({
         navigate(
           buildLinkWithSearchParams(
             `/transactions/${sendQuote.transactionId}`,
-            { showOkButton: 'true' },
+            { showOkButton: 'true', redirectTo },
           ),
           {
             transition: 'slideLeft',
@@ -286,14 +291,20 @@ export const CreateCashuTokenConfirmation = ({
   const navigate = useNavigateWithViewTransition();
   const { toast } = useToast();
   const buildLinkWithSearchParams = useBuildLinkWithSearchParams();
+  const { redirectTo } = useRedirectTo(
+    account.purpose === 'gift-card' ? `/gift-cards/${account.id}` : '/',
+  );
 
   const { mutate: createCashuSendSwap, status: createSwapStatus } =
     useCreateCashuSendSwap({
       onSuccess: (swap) => {
-        navigate(buildLinkWithSearchParams(`/send/share/${swap.id}`), {
-          transition: 'slideUp',
-          applyTo: 'newView',
-        });
+        navigate(
+          buildLinkWithSearchParams(`/send/share/${swap.id}`, { redirectTo }),
+          {
+            transition: 'slideUp',
+            applyTo: 'newView',
+          },
+        );
       },
       onError: (error) => {
         if (error instanceof DomainError) {

--- a/app/routes/_protected.receive.cashu_.token.tsx
+++ b/app/routes/_protected.receive.cashu_.token.tsx
@@ -135,7 +135,18 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
         duration: 8000,
       });
     }
-    const redirectTo = location.searchParams.get('redirectTo') ?? '/';
+
+    const explicitRedirectTo = location.searchParams.get('redirectTo');
+    let redirectTo = explicitRedirectTo ?? '/';
+
+    if (
+      !explicitRedirectTo &&
+      result.success &&
+      result.destinationAccount.purpose === 'gift-card'
+    ) {
+      redirectTo = `/gift-cards/${result.destinationAccount.id}`;
+    }
+
     throw redirect(redirectTo);
   }
 


### PR DESCRIPTION
## Summary

- Any completed flow (send, receive, buy, token claim) on a gift card account now redirects back to that gift card's page, regardless of where the flow was initiated
- Previously only the buy flow did this
- Uses the existing `useRedirectTo` hook with an account-aware default (`/gift-cards/{id}` for gift cards, `/` otherwise) — no new abstractions
- Explicit `redirectTo` in the URL always takes priority

## Test plan

- [ ] Complete a receive/send/buy/token-claim flow on a gift card account from any entry point → should return to gift card page
- [ ] Same flows on non-gift-card accounts → should return to `/`