### PR TITLE
Add db seed file for dev feature flags

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,5 +1,5 @@
--- Seed file for local development
--- Runs automatically after migrations during `supabase db reset`
+-- Seed file for local development and Supabase preview branches
+-- Runs automatically after migrations during `supabase db reset` and when preview branches are created
 
 -- Enable dev-relevant feature flags
 update "wallet"."feature_flags" set "enabled" = true where "key" in (


### PR DESCRIPTION
Adds `supabase/seed.sql` to enable dev-relevant feature flags (`GUEST_SIGNUP`, `GIFT_CARDS`, `DEBUG_LOGGING_SPARK`) automatically after `supabase db reset`.

Closes #932

Generated with [Claude Code](https://claude.ai/code)