### PR TITLE
fix: restore hiding @ destination picker for gift-card accounts

### DIFF
--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -246,11 +246,13 @@ export function SendInput() {
                 <Scan />
               </LinkWithViewTransition>
 
-              <SelectDestinationDrawer
-                open={selectDestinationDrawerOpen}
-                onOpenChange={setSelectDestinationDrawerOpen}
-                onSelect={handleSelectDestination}
-              />
+              {sendAccount.purpose !== 'gift-card' && (
+                <SelectDestinationDrawer
+                  open={selectDestinationDrawerOpen}
+                  onOpenChange={setSelectDestinationDrawerOpen}
+                  onSelect={handleSelectDestination}
+                />
+              )}
             </div>
             <div /> {/* spacer */}
             <div className="flex items-center justify-end">


### PR DESCRIPTION
## Summary
- PR #928 accidentally reverted the change from PR #927 that hides the `SelectDestinationDrawer` for gift-card accounts
- Restores the `sendAccount.purpose !== 'gift-card'` conditional guard

## Test plan
- [ ] Open a gift-card account's send flow — @ destination picker should not appear
- [ ] Open a regular account's send flow — @ destination picker should still work