### PR TITLE
prefetch Cash App logo and PWA icon consistently from index route

### DIFF
--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -13,6 +13,7 @@ import {
   useDefaultAccount,
 } from '~/features/accounts/account-hooks';
 import { DefaultCurrencySwitcher } from '~/features/accounts/default-currency-switcher';
+import { CASH_APP_LOGO_URL } from '~/features/buy/cash-app';
 import { InstallPwaPrompt } from '~/features/pwa/install-pwa-prompt';
 import { useFeatureFlag } from '~/features/shared/feature-flags';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
@@ -22,7 +23,9 @@ import { LinkWithViewTransition } from '~/lib/transitions';
 
 export const links: LinksFunction = () => [
   // This icon is used in the PWA dialog and prefetched here to avoid a flash while loading
-  { rel: 'preload', href: agicashIcon192, as: 'image' },
+  { rel: 'prefetch', href: agicashIcon192, as: 'image' },
+  // This logo is used on the buy screen and prefetched here to avoid a flash while loading
+  { rel: 'prefetch', href: CASH_APP_LOGO_URL, as: 'image' },
 ];
 
 export default function Index() {

--- a/app/routes/_protected.buy.tsx
+++ b/app/routes/_protected.buy.tsx
@@ -1,12 +1,6 @@
-import type { LinksFunction } from 'react-router';
 import { Outlet, useSearchParams } from 'react-router';
 import { useAccountOrDefault } from '~/features/accounts/account-hooks';
 import { BuyProvider } from '~/features/buy';
-import { CASH_APP_LOGO_URL } from '~/features/buy/cash-app';
-
-export const links: LinksFunction = () => [
-  { rel: 'prefetch', href: CASH_APP_LOGO_URL, as: 'image' },
-];
 
 export default function BuyLayout() {
   const [searchParams] = useSearchParams();


### PR DESCRIPTION
Both images now use `rel="prefetch"` with descriptive comments on the index route. Removed redundant links export from the buy route since prefetching there was too late to prevent the flash.

Closes #939

Generated with [Claude Code](https://claude.ai/code)