### PR TITLE
make gift card name same as account name

### DIFF
--- a/app/features/gift-cards/gift-card-item.tsx
+++ b/app/features/gift-cards/gift-card-item.tsx
@@ -29,12 +29,7 @@ export function GiftCardItem({
   hideOverlayContent,
 }: GiftCardItemProps) {
   const balance = getAccountBalance(account);
-  const mintInfoName = account.isOnline
-    ? account.wallet.mintInfo.name
-    : undefined;
-  const name =
-    mintInfoName ??
-    account.mintUrl.replace('https://', '').replace('http://', '');
+  const name = account.name;
 
   return (
     <WalletCard size={size} className={className}>


### PR DESCRIPTION
we already configure the gift cards with a name. That name gets used to create the account when the user adds the mint.

The reason that I'm doing this is because we want "The Epicurean Trader" to be "Epicurean Trader", but the Square business name is "The Epicurean Trader" and the way I have the mints built we have to name the mint the same as the business name for the validation to work which means I can't change the mint info name.

We still need to do something about if the user adds the mint through the token receive flow, then it will be created with name "The Epicurean Trader"