### PR TITLE
feat: add v2 keyset ID support for token receive flows

### DIFF
--- a/app/features/receive/receive-input.tsx
+++ b/app/features/receive/receive-input.tsx
@@ -1,4 +1,3 @@
-import { getEncodedToken } from '@cashu/cashu-ts';
 import { Clipboard, Scan } from 'lucide-react';
 import { MoneyInputDisplay } from '~/components/money-display';
 import { Numpad } from '~/components/numpad';
@@ -91,8 +90,8 @@ export default function ReceiveInput() {
       return;
     }
 
-    const token = extractCashuToken(clipboardContent);
-    if (!token) {
+    const encodedToken = extractCashuToken(clipboardContent)?.encoded;
+    if (!encodedToken) {
       toast({
         title: 'Invalid input',
         description: 'Please paste a valid cashu token',
@@ -101,7 +100,6 @@ export default function ReceiveInput() {
       return;
     }
 
-    const encodedToken = getEncodedToken(token);
     const hash = `#${encodedToken}`;
 
     // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it

--- a/app/features/receive/receive-scanner.tsx
+++ b/app/features/receive/receive-scanner.tsx
@@ -1,4 +1,3 @@
-import { getEncodedToken } from '@cashu/cashu-ts';
 import {
   PageBackButton,
   PageContent,
@@ -31,8 +30,8 @@ export default function ReceiveScanner() {
       <PageContent className="relative flex items-center justify-center">
         <QRScanner
           onDecode={(scannedContent) => {
-            const token = extractCashuToken(scannedContent);
-            if (!token) {
+            const encodedToken = extractCashuToken(scannedContent)?.encoded;
+            if (!encodedToken) {
               toast({
                 title: 'Invalid input',
                 description: 'Please scan a valid cashu token',
@@ -41,7 +40,6 @@ export default function ReceiveScanner() {
               return;
             }
 
-            const encodedToken = getEncodedToken(token);
             const hash = `#${encodedToken}`;
 
             // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -9,6 +9,7 @@ import {
   Mint,
   NetworkError,
   type Token,
+  getDecodedToken,
   getEncodedToken,
 } from '@cashu/cashu-ts';
 import { HDKey } from '@scure/bip32';
@@ -19,10 +20,12 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { getQueryClient } from '~/features/shared/query-client';
 import {
   type ExtendedCashuWallet,
   ExtendedMintInfo,
   checkIsTestMint,
+  extractCashuToken,
   getCashuProtocolUnit,
   getCashuUnit,
   getCashuWallet,
@@ -153,9 +156,17 @@ export function useCashuCryptography(): CashuCryptography {
 }
 
 export function getTokenHash(token: Token | string): Promise<string> {
-  const encodedToken =
-    typeof token === 'string' ? token : getEncodedToken(token);
-  return computeSHA256(encodedToken);
+  if (typeof token === 'string') {
+    return computeSHA256(token);
+  }
+  // Deep-clone proofs before encoding to prevent getEncodedToken from
+  // mutating proof.id (it truncates v2 keyset IDs to their short form).
+  // TODO: remove this workaround after upgrading to cashu-ts v4+ (fix merged in cashu-ts#536, unreleased as of v3.6.1)
+  const cloned: Token = {
+    ...token,
+    proofs: token.proofs.map((p) => ({ ...p })),
+  };
+  return computeSHA256(getEncodedToken(cloned));
 }
 
 const mintBlocklist = MintBlocklistSchema.parse(
@@ -205,6 +216,27 @@ export const allMintKeysetsQueryOptions = (mintUrl: string) =>
     queryFn: async () => new Mint(mintUrl).getKeySets(),
     staleTime: 1000 * 60 * 60, // 1 hour
   });
+
+/**
+ * Extract and decode a cashu token from arbitrary content.
+ * Fetches keyset IDs from the token's mint for v2 keyset resolution.
+ */
+export async function decodeCashuToken(content: string): Promise<Token | null> {
+  const result = extractCashuToken(content);
+  if (!result) return null;
+
+  try {
+    const queryClient = getQueryClient();
+    const data = await queryClient.fetchQuery(
+      allMintKeysetsQueryOptions(result.metadata.mint),
+    );
+    const keysetIds = data.keysets.map((k) => k.id);
+    return getDecodedToken(result.encoded, keysetIds);
+  } catch (error) {
+    console.error('Failed to decode cashu token', error);
+    return null;
+  }
+}
 
 /**
  * Get the mints public keys.

--- a/app/features/transfer/transfer-input.tsx
+++ b/app/features/transfer/transfer-input.tsx
@@ -1,4 +1,3 @@
-import { getEncodedToken } from '@cashu/cashu-ts';
 import { Clipboard, Scan } from 'lucide-react';
 import { useState } from 'react';
 import { MoneyInputDisplay } from '~/components/money-display';
@@ -110,8 +109,8 @@ export default function TransferInput() {
       return;
     }
 
-    const token = extractCashuToken(clipboardContent);
-    if (!token) {
+    const encodedToken = extractCashuToken(clipboardContent)?.encoded;
+    if (!encodedToken) {
       toast({
         title: 'Invalid input',
         description: 'Please paste a valid cashu token',
@@ -120,7 +119,6 @@ export default function TransferInput() {
       return;
     }
 
-    const encodedToken = getEncodedToken(token);
     const hash = `#${encodedToken}`;
 
     window.history.replaceState(null, '', hash);

--- a/app/features/transfer/transfer-scanner.tsx
+++ b/app/features/transfer/transfer-scanner.tsx
@@ -1,4 +1,3 @@
-import { getEncodedToken } from '@cashu/cashu-ts';
 import {
   PageBackButton,
   PageContent,
@@ -31,8 +30,8 @@ export default function TransferScanner() {
       <PageContent className="relative flex items-center justify-center">
         <QRScanner
           onDecode={(scannedContent) => {
-            const token = extractCashuToken(scannedContent);
-            if (!token) {
+            const encodedToken = extractCashuToken(scannedContent)?.encoded;
+            if (!encodedToken) {
               toast({
                 title: 'Invalid input',
                 description: 'Please scan a valid cashu token',
@@ -41,7 +40,6 @@ export default function TransferScanner() {
               return;
             }
 
-            const encodedToken = getEncodedToken(token);
             const hash = `#${encodedToken}`;
 
             window.history.replaceState(null, '', hash);

--- a/app/lib/cashu/token.test.ts
+++ b/app/lib/cashu/token.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import { type Token, getDecodedToken, getEncodedToken } from '@cashu/cashu-ts';
+import { extractCashuToken } from './token';
+
+// A real v1 cashuA token (v1 keyset ID starts with "00")
+const V1_TOKEN: Token = {
+  mint: 'https://mint.example.com',
+  proofs: [
+    {
+      id: '009a1f293253e41e',
+      amount: 1,
+      secret: 'test-secret-1',
+      C: '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    },
+  ],
+  unit: 'sat',
+};
+
+const V1_ENCODED_A = getEncodedToken(V1_TOKEN, { version: 3 });
+const V1_ENCODED_B = getEncodedToken(V1_TOKEN, { version: 4 });
+
+describe('extractCashuToken', () => {
+  test('extracts a valid cashuA token with metadata from content', () => {
+    const result = extractCashuToken(`check this out: ${V1_ENCODED_A}`);
+    expect(result?.encoded).toBe(V1_ENCODED_A);
+    expect(result?.metadata.mint).toBe('https://mint.example.com');
+  });
+
+  test('extracts a valid cashuB token from content', () => {
+    expect(extractCashuToken(`here: ${V1_ENCODED_B}`)?.encoded).toBe(
+      V1_ENCODED_B,
+    );
+  });
+
+  test('returns null for content with no token', () => {
+    expect(extractCashuToken('hello world')).toBeNull();
+  });
+
+  test('returns null for malformed token that matches regex but fails metadata parse', () => {
+    expect(extractCashuToken('cashuBinvaliddata')).toBeNull();
+  });
+
+  test('extracts token from URL with hash', () => {
+    expect(extractCashuToken(`#${V1_ENCODED_B}`)?.encoded).toBe(V1_ENCODED_B);
+  });
+});
+
+// V2 keyset ID tests — verify getDecodedToken resolves v2 keyset IDs correctly.
+// We construct tokens with a fake v2 keyset ID (prefix "01", 66 hex chars).
+const V2_KEYSET_ID = `01${'a'.repeat(64)}`; // 66 chars, v2 format
+
+const V2_TOKEN: Token = {
+  mint: 'https://v2mint.example.com',
+  proofs: [
+    {
+      id: V2_KEYSET_ID,
+      amount: 1,
+      secret: 'test-secret-v2',
+      C: '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    },
+  ],
+  unit: 'sat',
+};
+
+// cashuA preserves full keyset IDs in the JSON
+const V2_ENCODED_A = getEncodedToken(V2_TOKEN, { version: 3 });
+// cashuB truncates v2 keyset IDs to 16 chars (short ID)
+const V2_ENCODED_B = getEncodedToken(V2_TOKEN, { version: 4 });
+
+describe('getDecodedToken with v2 keyset IDs', () => {
+  test('decodes a v2 cashuB token with keyset IDs', () => {
+    const token = getDecodedToken(V2_ENCODED_B, [V2_KEYSET_ID]);
+    expect(token.proofs[0].id).toBe(V2_KEYSET_ID);
+  });
+
+  test('decodes a v2 cashuA token with keyset IDs', () => {
+    const token = getDecodedToken(V2_ENCODED_A, [V2_KEYSET_ID]);
+    expect(token.mint).toBe('https://v2mint.example.com');
+    expect(token.proofs[0].id).toBe(V2_KEYSET_ID);
+  });
+
+  test('throws for v2 token with non-matching keyset IDs', () => {
+    expect(() => getDecodedToken(V2_ENCODED_A, ['00deadbeefcafe00'])).toThrow();
+  });
+
+  test('v2 round-trip: decode → encode (truncates) → decode with keyset IDs', () => {
+    const original = getDecodedToken(V2_ENCODED_A, [V2_KEYSET_ID]);
+
+    // Re-encode: getEncodedToken truncates v2 IDs to 16 chars (cashuB format)
+    const reEncoded = getEncodedToken(original);
+
+    // Decode the re-encoded token — needs keyset IDs to resolve short IDs
+    const roundTripped = getDecodedToken(reEncoded, [V2_KEYSET_ID]);
+    expect(roundTripped.mint).toBe(original.mint);
+    expect(roundTripped.proofs[0].id).toBe(V2_KEYSET_ID);
+    expect(roundTripped.proofs[0].amount).toBe(original.proofs[0].amount);
+  });
+});

--- a/app/lib/cashu/token.ts
+++ b/app/lib/cashu/token.ts
@@ -2,8 +2,9 @@ import {
   CheckStateEnum,
   type Proof,
   type Token,
+  type TokenMetadata,
   Wallet,
-  getDecodedToken,
+  getTokenMetadata,
 } from '@cashu/cashu-ts';
 import { proofToY } from './proof';
 
@@ -31,43 +32,24 @@ export const getUnspentProofsFromToken = async (
   });
 };
 
-const getDecodedTokenSafe = (
-  encodedToken: string,
-):
-  | {
-      success: true;
-      token: Token;
-    }
-  | {
-      success: false;
-      error: string;
-    } => {
-  try {
-    return { success: true, token: getDecodedToken(encodedToken) };
-  } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : 'Failed to decode token';
-    return { success: false, error: errorMessage };
-  }
-};
+const CASHU_TOKEN_REGEX = /cashu[AB][A-Za-z0-9_-]+={0,2}/;
 
 /**
- * Extract a cashu token from a string if there is one and then validate it
- * @param content - The content to extract the encoded cashu token from (a string like a URL or a direct token)
- * @returns The extracted token if found and valid, otherwise null
+ * Find and validate a cashu token in arbitrary content without fully decoding it.
+ * Uses regex to find the token, then getTokenMetadata() to validate structure.
+ * @param content - The content to search for a cashu token (URL, clipboard text, etc.)
+ * @returns The encoded token string and metadata, or null if not found/invalid.
  */
-export const extractCashuToken = (content: string): Token | null => {
-  // Look for V3 (cashuA) or V4 (cashuB) tokens anywhere in the content
-  // Tokens are base64_urlsafe encoded, so they can contain: A-Z, a-z, 0-9, -, _, and optional = padding
-  // See https://github.com/cashubtc/nuts/blob/main/00.md#serialization-of-tokens for more details
-  const tokenMatch = content.match(/cashu[AB][A-Za-z0-9_-]+={0,2}/);
-  if (tokenMatch) {
-    const extractedToken = tokenMatch[0];
-    const result = getDecodedTokenSafe(extractedToken);
-    if (result.success) {
-      return result.token;
-    }
-  }
+export function extractCashuToken(
+  content: string,
+): { encoded: string; metadata: TokenMetadata } | null {
+  const tokenMatch = content.match(CASHU_TOKEN_REGEX);
+  if (!tokenMatch) return null;
 
-  return null;
-};
+  try {
+    const metadata = getTokenMetadata(tokenMatch[0]);
+    return { encoded: tokenMatch[0], metadata };
+  } catch {
+    return null;
+  }
+}

--- a/app/routes/_protected.receive.cashu_.token.tsx
+++ b/app/routes/_protected.receive.cashu_.token.tsx
@@ -16,6 +16,7 @@ import { ReceiveCashuTokenService } from '~/features/receive/receive-cashu-token
 import { SparkReceiveQuoteRepository } from '~/features/receive/spark-receive-quote-repository';
 import { SparkReceiveQuoteService } from '~/features/receive/spark-receive-quote-service';
 import {
+  decodeCashuToken,
   getCashuCryptography,
   seedQueryOptions,
 } from '~/features/shared/cashu';
@@ -30,7 +31,6 @@ import { getUserFromCacheOrThrow } from '~/features/user/user-hooks';
 import { WriteUserRepository } from '~/features/user/user-repository';
 import { UserService } from '~/features/user/user-service';
 import { toast } from '~/hooks/use-toast';
-import { extractCashuToken } from '~/lib/cashu';
 import type { Route } from './+types/_protected.receive.cashu_.token';
 import { ReceiveCashuTokenSkeleton } from './receive-cashu-token-skeleton';
 
@@ -107,7 +107,7 @@ const getClaimTo = (
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   // Request url doesn't include hash so we need to read it from the window location instead
-  const token = extractCashuToken(window.location.hash);
+  const token = await decodeCashuToken(window.location.hash);
 
   if (!token) {
     throw redirect('/receive');

--- a/app/routes/_public.receive-cashu-token.tsx
+++ b/app/routes/_public.receive-cashu-token.tsx
@@ -2,9 +2,9 @@ import { redirect } from 'react-router';
 import { Page } from '~/components/page';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { PublicReceiveCashuToken } from '~/features/receive/receive-cashu-token';
+import { decodeCashuToken } from '~/features/shared/cashu';
 import { getQueryClient } from '~/features/shared/query-client';
 import { authQueryOptions } from '~/features/user/auth';
-import { extractCashuToken } from '~/lib/cashu';
 import type { Route } from './+types/_public.receive-cashu-token';
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
@@ -20,7 +20,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
     throw redirect(`/receive/cashu/token${location.search}${hash}`);
   }
 
-  const token = extractCashuToken(hash);
+  const token = await decodeCashuToken(hash);
 
   if (!token) {
     throw redirect('/home');


### PR DESCRIPTION
## Summary

- Token receive flows handle v2 keyset IDs via `getTokenMetadata` + `getDecodedToken`