### PR TITLE
Allow DRAFT transactions on transaction details page

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -595,8 +595,10 @@ export function useProcessCashuReceiveQuoteTasks() {
         // Updating the quote cache triggers navigation to the transaction details page.
         // Completing the quote also completes the transaction and if navigation to transaction
         // page happens before transaction udpated realtime notification is processed, the
-        // transaction would be stale in the cache with the DRAFT state, which is not allowed on
-        // transaction details page. Thus it needs to be invalidated to force refetch.
+        // transaction would be stale in the cache with the DRAFT state. We are invalidating the
+        // transaction cache here so that it starts refetching the transaction as soon as possible
+        // without relying on realtime notification which might be delayed when reconnecting due to
+        // the app being in background.
         transactionsCache.invalidateTransaction(data.quote.transactionId);
         cashuReceiveQuoteCache.updateIfExists(data.quote);
         pendingQuotesCache.update(data.quote);

--- a/app/features/receive/spark-receive-quote-hooks.ts
+++ b/app/features/receive/spark-receive-quote-hooks.ts
@@ -505,8 +505,10 @@ export function useProcessSparkReceiveQuoteTasks() {
         // Updating the quote cache triggers navigation to the transaction details page.
         // Completing the quote also completes the transaction and if navigation to transaction
         // page happens before transaction udpated realtime notification is processed, the
-        // transaction would be stale in the cache with the DRAFT state, which is not allowed on
-        // transaction details page. Thus it needs to be invalidated to force refetch.
+        // transaction would be stale in the cache with the DRAFT state. We are invalidating the
+        // transaction cache here so that it starts refetching the transaction as soon as possible
+        // without relying on realtime notification which might be delayed when reconnecting due to
+        // the app being in background.
         transactionsCache.invalidateTransaction(updatedQuote.transactionId);
         sparkReceiveQuoteCache.updateIfExists(updatedQuote);
         pendingQuotesCache.remove(updatedQuote);

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -18,7 +18,7 @@ import { isThisWeek, isToday, isYesterday } from '~/lib/date';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { useAccount } from '../accounts/account-hooks';
 import { AccountIcon } from '../accounts/account-icons';
-import { NotFoundError, getErrorMessage } from '../shared/error';
+import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import {
   isTransactionReversable,
@@ -58,23 +58,15 @@ function formatRelativeTimestampWithTime(timestamp: string): string {
   })} at ${timeString}`;
 }
 
-const transactionIconMap = {
+const transactionIconMap: Record<Transaction['state'], React.ReactNode> = {
+  DRAFT: <ClockIcon size={18} className="text-yellow-500" />,
+  PENDING: <ClockIcon size={18} className="text-yellow-500" />,
   COMPLETED: <CheckIcon size={18} className="text-green-500" />,
   REVERSED: <BanIcon size={18} className="text-red-500" />,
   FAILED: <XIcon size={18} className="text-red-500" />,
-  PENDING: <ClockIcon size={18} className="text-yellow-500" />,
 };
 
 function getTransactionIcon(transaction: Transaction) {
-  if (transaction.state === 'DRAFT') {
-    if (
-      transaction.type === 'SPARK_LIGHTNING' &&
-      transaction.direction === 'SEND'
-    ) {
-      return transactionIconMap.PENDING;
-    }
-    throw new NotFoundError(`Transaction not found for id: ${transaction.id}`);
-  }
   return transactionIconMap[transaction.state];
 }
 
@@ -82,11 +74,7 @@ function getTransactionLabel(transaction: Transaction) {
   if (transaction.state === 'REVERSED') {
     return 'Reclaimed';
   }
-  if (
-    transaction.state === 'DRAFT' &&
-    transaction.type === 'SPARK_LIGHTNING' &&
-    transaction.direction === 'SEND'
-  ) {
+  if (transaction.state === 'DRAFT') {
     return 'Pending';
   }
   if (transaction.purpose === 'BUY_CASHAPP') {


### PR DESCRIPTION
Summary:
- DRAFT transactions can briefly appear on the transaction details page due to cache timing — the transaction is cached in DRAFT state via the TRANSACTION_CREATED Realtime event, and quote completion can navigate to the transaction page before
the TRANSACTION_UPDATED Realtime event arrives with the COMPLETED state
- Instead of throwing NotFoundError (which crashes to the root error boundary), show "Pending" — it updates to the correct state moments later via Realtime
- Types transactionIconMap as Record<Transaction['state'], ...> so missing states are caught at compile time

Test plan:
- Complete a Spark Lightning receive — transaction page should show correctly (may briefly flash "Pending" before showing "Completed")
- Complete a Cashu receive — same behavior
- Spark Lightning send should still show "Pending" while in DRAFT state as before