### PR TITLE
feat: universal QR scanner - phase 1/2

### DIFF
--- a/app/components/qr-scanner/qr-scanner.tsx
+++ b/app/components/qr-scanner/qr-scanner.tsx
@@ -144,7 +144,7 @@ export const QRScanner = ({ onDecode }: QRScannerProps) => {
   }, [throttledDecode]);
 
   return (
-    <section className="fixed inset-0 h-screen w-screen sm:relative sm:aspect-square sm:h-[400px] sm:w-[400px]">
+    <section className="fixed inset-0 h-screen w-screen sm:relative sm:aspect-square sm:h-[400px] sm:w-[400px] sm:overflow-hidden">
       <div className="relative h-full w-full">
         {cameraError ? (
           <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black p-6 text-center">

--- a/app/features/receive/cashu-receive-quote-core.ts
+++ b/app/features/receive/cashu-receive-quote-core.ts
@@ -281,7 +281,9 @@ export async function getLightningQuote(
       })
     : undefined;
 
-  const { paymentHash } = decodeBolt11(mintQuoteResponse.request);
+  const {
+    decoded: { paymentHash },
+  } = decodeBolt11(mintQuoteResponse.request);
 
   return {
     mintQuote: mintQuoteResponse,

--- a/app/features/scan/classify-input.test.ts
+++ b/app/features/scan/classify-input.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test';
+import { type Token, getEncodedToken } from '@cashu/cashu-ts';
+import { classifyInput } from './classify-input';
+
+// -- Test fixtures --
+
+const CASHU_TOKEN: Token = {
+  mint: 'https://mint.example.com',
+  proofs: [
+    {
+      id: '009a1f293253e41e',
+      amount: 1,
+      secret: 'test-secret-1',
+      C: '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    },
+  ],
+  unit: 'sat',
+};
+
+const CASHU_A_TOKEN = getEncodedToken(CASHU_TOKEN, { version: 3 });
+const CASHU_B_TOKEN = getEncodedToken(CASHU_TOKEN, { version: 4 });
+
+// Real BOLT11 test vector from bolt11.test.ts (250,000 sats, "1 cup coffee")
+const BOLT11_INVOICE =
+  'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp';
+
+// -- Tests --
+
+describe('classifyInput', () => {
+  describe('cashu tokens', () => {
+    test('cashuA token string', () => {
+      const result = classifyInput(CASHU_A_TOKEN);
+      expect(result).toEqual({
+        direction: 'receive',
+        type: 'cashu-token',
+        encoded: CASHU_A_TOKEN,
+      });
+    });
+
+    test('cashuB token string', () => {
+      const result = classifyInput(CASHU_B_TOKEN);
+      expect(result).toEqual({
+        direction: 'receive',
+        type: 'cashu-token',
+        encoded: CASHU_B_TOKEN,
+      });
+    });
+
+    test('URL containing cashu token', () => {
+      const result = classifyInput(`https://example.com/#${CASHU_A_TOKEN}`);
+      expect(result).toEqual({
+        direction: 'receive',
+        type: 'cashu-token',
+        encoded: CASHU_A_TOKEN,
+      });
+    });
+
+    test('token with leading/trailing whitespace', () => {
+      const result = classifyInput(`  ${CASHU_A_TOKEN}  `);
+      expect(result?.type).toBe('cashu-token');
+    });
+
+    test('cashu: URI prefix', () => {
+      const result = classifyInput(`cashu:${CASHU_A_TOKEN}`);
+      expect(result).toEqual({
+        direction: 'receive',
+        type: 'cashu-token',
+        encoded: CASHU_A_TOKEN,
+      });
+    });
+  });
+
+  describe('bolt11 invoices', () => {
+    test('raw bolt11 invoice with full decoded data', () => {
+      const result = classifyInput(BOLT11_INVOICE);
+      expect(result).toEqual({
+        direction: 'send',
+        type: 'bolt11',
+        invoice: BOLT11_INVOICE,
+        decoded: {
+          amountMsat: 250000000,
+          amountSat: 250000,
+          createdAtUnixMs: 1496314658000,
+          expiryUnixMs: 1496314718000,
+          network: 'bitcoin',
+          description: '1 cup coffee',
+          paymentHash:
+            '0001020304050607080900010203040506070809000102030405060708090102',
+        },
+      });
+    });
+
+    test('lightning: prefixed invoice', () => {
+      const result = classifyInput(`lightning:${BOLT11_INVOICE}`);
+      expect(result?.type).toBe('bolt11');
+      if (result?.type === 'bolt11') {
+        expect(result.invoice).toBe(BOLT11_INVOICE);
+      }
+    });
+
+    test('LIGHTNING: uppercase prefix', () => {
+      const result = classifyInput(`LIGHTNING:${BOLT11_INVOICE}`);
+      expect(result?.type).toBe('bolt11');
+      if (result?.type === 'bolt11') {
+        expect(result.invoice).toBe(BOLT11_INVOICE);
+      }
+    });
+  });
+
+  describe('lightning addresses', () => {
+    test('valid lightning address', () => {
+      const result = classifyInput('user@domain.com');
+      expect(result).toEqual({
+        direction: 'send',
+        type: 'ln-address',
+        address: 'user@domain.com',
+      });
+    });
+
+    test('uppercase address is lowercased', () => {
+      const result = classifyInput('USER@Domain.Com');
+      expect(result).toEqual({
+        direction: 'send',
+        type: 'ln-address',
+        address: 'user@domain.com',
+      });
+    });
+
+    test('address with subdomain', () => {
+      const result = classifyInput('alice@pay.example.org');
+      expect(result).toEqual({
+        direction: 'send',
+        type: 'ln-address',
+        address: 'alice@pay.example.org',
+      });
+    });
+  });
+
+  describe('unknown inputs', () => {
+    test('empty string', () => {
+      expect(classifyInput('')).toBeNull();
+    });
+
+    test('whitespace only', () => {
+      expect(classifyInput('   ')).toBeNull();
+    });
+
+    test('random gibberish', () => {
+      expect(classifyInput('not a valid anything')).toBeNull();
+    });
+
+    test('email-like but invalid TLD', () => {
+      expect(classifyInput('user@x')).toBeNull();
+    });
+
+    test('bare URL without token', () => {
+      expect(classifyInput('https://example.com')).toBeNull();
+    });
+  });
+
+  describe('classification priority', () => {
+    test('cashu token takes priority over everything', () => {
+      // A string that contains both a cashu token and an @ — cashu wins
+      const result = classifyInput(`user@domain.com ${CASHU_A_TOKEN}`);
+      expect(result?.type).toBe('cashu-token');
+    });
+  });
+});

--- a/app/features/scan/classify-input.ts
+++ b/app/features/scan/classify-input.ts
@@ -1,0 +1,59 @@
+import { type DecodedBolt11, parseBolt11Invoice } from '~/lib/bolt11';
+import { extractCashuToken } from '~/lib/cashu/token';
+import { buildLightningAddressFormatValidator } from '~/lib/lnurl';
+
+const validateLnAddressFormat = buildLightningAddressFormatValidator({
+  message: 'invalid',
+  allowLocalhost: import.meta.env.MODE === 'development',
+});
+
+export type ClassifiedInput =
+  | { direction: 'receive'; type: 'cashu-token'; encoded: string }
+  | {
+      direction: 'send';
+      type: 'bolt11';
+      invoice: string;
+      decoded: DecodedBolt11;
+    }
+  | { direction: 'send'; type: 'ln-address'; address: string };
+
+export type SendInput = Extract<ClassifiedInput, { direction: 'send' }>;
+export type ReceiveInput = Extract<ClassifiedInput, { direction: 'receive' }>;
+
+export function classifyInput(raw: string): ClassifiedInput | null {
+  const trimmed = raw.trim();
+
+  // 1. Cashu token (works on URLs, raw tokens, etc.)
+  const cashuResult = extractCashuToken(trimmed);
+  if (cashuResult) {
+    return {
+      direction: 'receive',
+      type: 'cashu-token',
+      encoded: cashuResult.encoded,
+    };
+  }
+
+  // 2. BOLT11 invoice
+  const bolt11Result = parseBolt11Invoice(trimmed);
+  if (bolt11Result.valid) {
+    return {
+      direction: 'send',
+      type: 'bolt11',
+      invoice: bolt11Result.encoded,
+      decoded: bolt11Result.decoded,
+    };
+  }
+
+  // 3. Lightning address — lowercase before validation since the format
+  // validator's local-part regex only accepts lowercase characters.
+  const lowered = trimmed.toLowerCase();
+  if (validateLnAddressFormat(lowered) === true) {
+    return {
+      direction: 'send',
+      type: 'ln-address',
+      address: lowered,
+    };
+  }
+
+  return null;
+}

--- a/app/features/scan/index.ts
+++ b/app/features/scan/index.ts
@@ -1,0 +1,6 @@
+export {
+  classifyInput,
+  type ClassifiedInput,
+  type ReceiveInput,
+  type SendInput,
+} from './classify-input';

--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -296,7 +296,9 @@ export class CashuSendQuoteService {
       unit: cashuUnit,
     });
 
-    const { paymentHash } = decodeBolt11(sendQuote.paymentRequest);
+    const {
+      decoded: { paymentHash },
+    } = decodeBolt11(sendQuote.paymentRequest);
 
     return this.cashuSendRepository.create({
       userId: userId,

--- a/app/features/send/resolve-destination.ts
+++ b/app/features/send/resolve-destination.ts
@@ -1,0 +1,98 @@
+import { parseBolt11Invoice } from '~/lib/bolt11';
+import { parseCashuPaymentRequest } from '~/lib/cashu';
+import { isValidLightningAddress } from '~/lib/lnurl';
+import type { Money } from '~/lib/money';
+import { type Contact, isContact } from '../contacts/contact';
+import { validateBolt11, validateLightningAddressFormat } from './validation';
+
+export type SendDestination =
+  | {
+      sendType: 'BOLT11_INVOICE';
+      destination: string;
+      destinationDisplay: string;
+      destinationDetails?: null;
+      amount: Money | null;
+    }
+  | {
+      sendType: 'LN_ADDRESS';
+      destination: null;
+      destinationDisplay: string;
+      destinationDetails: { lnAddress: string };
+      amount?: null;
+    }
+  | {
+      sendType: 'AGICASH_CONTACT';
+      destination: null;
+      destinationDisplay: string;
+      destinationDetails: Contact;
+      amount?: null;
+    };
+
+type ResolveResult =
+  | { success: true; data: SendDestination }
+  | { success: false; error: string };
+
+export async function resolveSendDestination(
+  input: string | Contact,
+  { allowZeroAmountBolt11 = false }: { allowZeroAmountBolt11?: boolean } = {},
+): Promise<ResolveResult> {
+  if (isContact(input)) {
+    return {
+      success: true,
+      data: {
+        sendType: 'AGICASH_CONTACT',
+        destination: null,
+        destinationDisplay: input.username,
+        destinationDetails: input,
+      },
+    };
+  }
+
+  if (validateLightningAddressFormat(input) === true) {
+    const isValid = await isValidLightningAddress(input);
+    if (!isValid) {
+      return { success: false, error: 'Invalid lightning address' };
+    }
+    return {
+      success: true,
+      data: {
+        sendType: 'LN_ADDRESS',
+        destination: null,
+        destinationDisplay: input,
+        destinationDetails: { lnAddress: input },
+      },
+    };
+  }
+
+  const bolt11 = parseBolt11Invoice(input);
+  if (bolt11.valid) {
+    const validated = validateBolt11(bolt11.decoded, {
+      allowZeroAmount: allowZeroAmountBolt11,
+    });
+    if (!validated.valid) {
+      return { success: false, error: validated.error };
+    }
+    const { encoded } = bolt11;
+    return {
+      success: true,
+      data: {
+        sendType: 'BOLT11_INVOICE',
+        destination: encoded,
+        destinationDisplay: `${encoded.slice(0, 6)}...${encoded.slice(-4)}`,
+        amount: validated.amount,
+      },
+    };
+  }
+
+  if (parseCashuPaymentRequest(input).valid) {
+    return {
+      success: false,
+      error: 'Cashu payment requests are not supported',
+    };
+  }
+
+  return {
+    success: false,
+    error: 'Invalid destination. Must be a lightning address or bolt11 invoice',
+  };
+}

--- a/app/features/send/send-confirmation.tsx
+++ b/app/features/send/send-confirmation.tsx
@@ -234,7 +234,9 @@ export const PayBolt11Confirmation = ({
     destinationDetails,
   });
 
-  const { description } = decodeBolt11(destination);
+  const {
+    decoded: { description },
+  } = decodeBolt11(destination);
 
   return (
     <BaseConfirmation

--- a/app/features/send/send-provider.tsx
+++ b/app/features/send/send-provider.tsx
@@ -9,6 +9,7 @@ import type { Account } from '~/features/accounts/account';
 import { useGetAccount } from '../accounts/account-hooks';
 import { useCreateCashuLightningSendQuote } from './cashu-send-quote-hooks';
 import { useCreateCashuSendSwapQuote } from './cashu-send-swap-hooks';
+import type { SendDestination } from './resolve-destination';
 import { type SendState, type SendStore, createSendStore } from './send-store';
 import { useCreateSparkLightningSendQuote } from './spark-send-quote-hooks';
 import { useGetInvoiceFromLud16 } from './use-get-invoice-from-lud16';
@@ -18,9 +19,15 @@ const SendContext = createContext<SendStore | null>(null);
 type Props = PropsWithChildren<{
   /** Usually the user's default account. This sets the initial account to send from. */
   initialAccount: Account;
+  /** Initial destination to send to, if any. */
+  initialDestination: SendDestination | null;
 }>;
 
-export const SendProvider = ({ initialAccount, children }: Props) => {
+export const SendProvider = ({
+  initialAccount,
+  initialDestination,
+  children,
+}: Props) => {
   const { mutateAsync: getInvoiceFromLud16 } = useGetInvoiceFromLud16();
   const { mutateAsync: getCashuLightningQuote } =
     useCreateCashuLightningSendQuote();
@@ -32,6 +39,7 @@ export const SendProvider = ({ initialAccount, children }: Props) => {
   const [store] = useState(() =>
     createSendStore({
       initialAccount,
+      initialDestination,
       getAccount,
       getInvoiceFromLud16,
       getCashuLightningQuote,

--- a/app/features/send/send-store.ts
+++ b/app/features/send/send-store.ts
@@ -4,17 +4,15 @@ import type {
   CashuAccount,
   SparkAccount,
 } from '~/features/accounts/account';
-import { type DecodedBolt11, parseBolt11Invoice } from '~/lib/bolt11';
-import { parseCashuPaymentRequest } from '~/lib/cashu';
-import {
-  buildLightningAddressFormatValidator,
-  isValidLightningAddress,
-} from '~/lib/lnurl';
-import { type Currency, Money } from '~/lib/money';
-import { type Contact, isContact } from '../contacts/contact';
+import type { Currency, Money } from '~/lib/money';
+import type { Contact } from '../contacts/contact';
 import { DomainError } from '../shared/error';
 import type { CashuLightningQuote } from './cashu-send-quote-service';
 import type { CashuSwapQuote } from './cashu-send-swap-service';
+import {
+  type SendDestination,
+  resolveSendDestination,
+} from './resolve-destination';
 import type { SparkLightningQuote } from './spark-send-quote-service';
 
 /**
@@ -26,66 +24,6 @@ const getDefaultSendType = (
   accountType: Account['type'],
 ): 'CASHU_TOKEN' | 'BOLT11_INVOICE' => {
   return accountType === 'cashu' ? 'CASHU_TOKEN' : 'BOLT11_INVOICE';
-};
-
-const validateLightningAddressFormat = buildLightningAddressFormatValidator({
-  message: 'Invalid lightning address',
-  allowLocalhost: import.meta.env.MODE === 'development',
-});
-
-type ValidateResult =
-  | {
-      valid: false;
-      error: string;
-    }
-  | {
-      valid: true;
-      amount: Money<Currency> | null;
-      currency: Currency;
-      unit: 'sat' | 'cent';
-    };
-
-const validateBolt11 = (
-  { network, amountSat, expiryUnixMs }: DecodedBolt11,
-  { allowZeroAmount = false } = {},
-): ValidateResult => {
-  if (network !== 'bitcoin') {
-    return {
-      valid: false,
-      error: `Unsupported network: ${network}. Only Bitcoin mainnet is supported`,
-    };
-  }
-
-  if (expiryUnixMs) {
-    const expiresAt = new Date(expiryUnixMs);
-    const now = new Date();
-    if (expiresAt < now) {
-      return {
-        valid: false,
-        error: 'Invoice expired',
-      };
-    }
-  }
-
-  if (!amountSat && !allowZeroAmount) {
-    return {
-      valid: false,
-      error: 'Amount is required for Lightning invoices',
-    };
-  }
-
-  return {
-    valid: true,
-    amount: amountSat
-      ? new Money({
-          amount: amountSat,
-          currency: 'BTC' as Currency,
-          unit: 'sat',
-        })
-      : null,
-    unit: 'sat',
-    currency: 'BTC',
-  };
 };
 
 const pickAmountByCurrency = <T extends Currency>(
@@ -200,6 +138,8 @@ export type SendState = State & Actions;
 
 type CreateSendStoreProps = {
   initialAccount: Account;
+  /** Initial destination to send to, if any. */
+  initialDestination: SendDestination | null;
   getAccount: (accountId: string) => Account;
   getInvoiceFromLud16: (params: {
     lud16: string;
@@ -236,6 +176,7 @@ const isSendTypeSupportedForAccount = (
 
 export const createSendStore = ({
   initialAccount,
+  initialDestination,
   getAccount,
   getInvoiceFromLud16,
   getCashuLightningQuote,
@@ -255,14 +196,18 @@ export const createSendStore = ({
     };
 
     return {
-      status: 'idle',
-      amount: null,
+      status: 'idle' as const,
       accountId: initialAccount.id,
-      sendType: getDefaultSendType(initialAccount.type),
-      destination: null,
-      destinationDisplay: null,
+      sendType:
+        initialDestination?.sendType ?? getDefaultSendType(initialAccount.type),
+      destination: initialDestination?.destination ?? null,
+      destinationDisplay: initialDestination?.destinationDisplay ?? null,
+      destinationDetails: initialDestination?.destinationDetails ?? null,
+      amount:
+        initialDestination?.sendType === 'BOLT11_INVOICE'
+          ? initialDestination.amount
+          : null,
       quote: null,
-      cashuToken: null,
 
       selectSourceAccount: (account) => {
         const {
@@ -305,77 +250,37 @@ export const createSendStore = ({
         } as Partial<SendState>);
       },
 
-      selectDestination: async (destination) => {
-        if (isContact(destination)) {
-          set({
-            sendType: 'AGICASH_CONTACT',
-            destinationDisplay: destination.username,
-            destinationDetails: destination,
-          });
-
-          return {
-            success: true,
-            data: { type: 'AGICASH_CONTACT' },
-          };
+      selectDestination: async (input) => {
+        const account = get().getSourceAccount();
+        const result = await resolveSendDestination(input, {
+          allowZeroAmountBolt11: account.type === 'spark',
+        });
+        if (!result.success) {
+          return result;
         }
 
-        const isLnAddressFormat = validateLightningAddressFormat(destination);
-        if (isLnAddressFormat === true) {
-          const isValidLnAddress = await isValidLightningAddress(destination);
-          if (!isValidLnAddress) {
-            return {
-              success: false,
-              error: 'Invalid lightning address',
-            };
-          }
-
-          set({
-            sendType: 'LN_ADDRESS',
-            destinationDisplay: destination,
-            destinationDetails: { lnAddress: destination },
-          });
-
-          return {
-            success: true,
-            data: { type: 'LN_ADDRESS' },
-          };
-        }
-
-        const bolt11ParseResult = parseBolt11Invoice(destination);
-        if (bolt11ParseResult.valid) {
-          const invoice = bolt11ParseResult.decoded;
-          const account = get().getSourceAccount();
-          const allowZeroAmount = account.type === 'spark';
-          const result = validateBolt11(invoice, { allowZeroAmount });
-          if (!result.valid) {
-            return { success: false, error: result.error };
-          }
-
-          const cleanedDestination = destination.replace(/^lightning:/i, '');
-          set({
-            sendType: 'BOLT11_INVOICE',
-            destination: cleanedDestination,
-            destinationDisplay: `${cleanedDestination.slice(0, 6)}...${cleanedDestination.slice(-4)}`,
-          });
-
-          return {
-            success: true,
-            data: { type: 'BOLT11_INVOICE', amount: result.amount },
-          };
-        }
-
-        const cashuRequestParseResult = parseCashuPaymentRequest(destination);
-        if (cashuRequestParseResult.valid) {
-          return {
-            success: false,
-            error: 'Cashu payment requests are not supported',
-          };
-        }
+        const {
+          sendType,
+          destination,
+          destinationDisplay,
+          destinationDetails,
+        } = result.data;
+        set({
+          sendType,
+          destination,
+          destinationDisplay,
+          destinationDetails,
+        } as Partial<SendState>);
 
         return {
-          success: false,
-          error:
-            'Invalid destination. Must be lightning address, bolt11 invoice or cashu payment request',
+          success: true,
+          data: {
+            type: result.data.sendType,
+            amount:
+              result.data.sendType === 'BOLT11_INVOICE'
+                ? result.data.amount
+                : null,
+          },
         };
       },
 
@@ -484,7 +389,7 @@ export const createSendStore = ({
         set({ status: 'idle' });
         return { success: true, next: 'confirmQuote' };
       },
-    };
+    } as SendState;
   });
 };
 

--- a/app/features/send/validation.ts
+++ b/app/features/send/validation.ts
@@ -1,0 +1,72 @@
+import type { DecodedBolt11 } from '~/lib/bolt11';
+import { buildLightningAddressFormatValidator } from '~/lib/lnurl';
+import { type Currency, Money } from '~/lib/money';
+
+export type ValidateResult =
+  | {
+      valid: false;
+      error: string;
+    }
+  | {
+      valid: true;
+      amount: Money<Currency> | null;
+      currency: Currency;
+      unit: 'sat' | 'cent';
+    };
+
+/**
+ * Deep validation for a decoded BOLT11 invoice: checks network, expiry, and
+ * (optionally) amount. Returns a typed success/failure result.
+ */
+export const validateBolt11 = (
+  { network, amountSat, expiryUnixMs }: DecodedBolt11,
+  { allowZeroAmount = false } = {},
+): ValidateResult => {
+  if (network !== 'bitcoin') {
+    return {
+      valid: false,
+      error: `Unsupported network: ${network}. Only Bitcoin mainnet is supported`,
+    };
+  }
+
+  if (expiryUnixMs) {
+    const expiresAt = new Date(expiryUnixMs);
+    const now = new Date();
+    if (expiresAt < now) {
+      return {
+        valid: false,
+        error: 'Invoice expired',
+      };
+    }
+  }
+
+  if (!amountSat && !allowZeroAmount) {
+    return {
+      valid: false,
+      error: 'Amount is required for Lightning invoices',
+    };
+  }
+
+  return {
+    valid: true,
+    amount: amountSat
+      ? new Money({
+          amount: amountSat,
+          currency: 'BTC' as Currency,
+          unit: 'sat',
+        })
+      : null,
+    unit: 'sat',
+    currency: 'BTC',
+  };
+};
+
+/**
+ * Format-level validator for Lightning addresses. Returns `true` if the input
+ * parses as a well-formed address, or an error message string otherwise.
+ */
+export const validateLightningAddressFormat =
+  buildLightningAddressFormatValidator({
+    message: 'Invalid lightning address',
+    allowLocalhost: import.meta.env.MODE === 'development',
+  });

--- a/app/features/transfer/transfer-input.tsx
+++ b/app/features/transfer/transfer-input.tsx
@@ -121,6 +121,8 @@ export default function TransferInput() {
 
     const hash = `#${encodedToken}`;
 
+    // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it
+    // See https://github.com/remix-run/remix/discussions/10721
     window.history.replaceState(null, '', hash);
     navigate(
       {

--- a/app/features/transfer/transfer-scanner.tsx
+++ b/app/features/transfer/transfer-scanner.tsx
@@ -42,6 +42,8 @@ export default function TransferScanner() {
 
             const hash = `#${encodedToken}`;
 
+            // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it
+            // See https://github.com/remix-run/remix/discussions/10721
             window.history.replaceState(null, '', hash);
             navigate(
               {

--- a/app/lib/bolt11/bolt11.test.ts
+++ b/app/lib/bolt11/bolt11.test.ts
@@ -1,52 +1,89 @@
 import { describe, expect, it } from 'bun:test';
-import { decodeBolt11 } from './index';
+import { decodeBolt11, parseBolt11Invoice } from './index';
 
 const invoice =
   'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp';
 const testnetInvoice =
   'lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8';
 
+const expectedDecoded = {
+  amountMsat: 250000000,
+  amountSat: 250000,
+  createdAtUnixMs: 1496314658000,
+  expiryUnixMs: 1496314718000,
+  network: 'bitcoin',
+  description: '1 cup coffee',
+  paymentHash:
+    '0001020304050607080900010203040506070809000102030405060708090102',
+};
+
 // NOTE: You can confirm these values using https://lightningdecoder.com
 describe('decodeBolt11', () => {
   it('should decode the invoice', () => {
-    const result = decodeBolt11(invoice);
-    expect(result).toEqual({
-      amountMsat: 250000000,
-      amountSat: 250000,
-      createdAtUnixMs: 1496314658000,
-      expiryUnixMs: 1496314718000,
-      network: 'bitcoin',
-      description: '1 cup coffee',
-      paymentHash:
-        '0001020304050607080900010203040506070809000102030405060708090102',
+    expect(decodeBolt11(invoice)).toEqual({
+      encoded: invoice,
+      decoded: expectedDecoded,
+    });
+  });
+
+  it('should strip lightning: prefix', () => {
+    expect(decodeBolt11(`lightning:${invoice}`)).toEqual({
+      encoded: invoice,
+      decoded: expectedDecoded,
+    });
+  });
+
+  it('should strip LIGHTNING: prefix case-insensitively', () => {
+    expect(decodeBolt11(`LIGHTNING:${invoice}`)).toEqual({
+      encoded: invoice,
+      decoded: expectedDecoded,
+    });
+  });
+
+  it('should lowercase an uppercase invoice', () => {
+    expect(decodeBolt11(invoice.toUpperCase())).toEqual({
+      encoded: invoice,
+      decoded: expectedDecoded,
     });
   });
 
   it('should decode a testnet invoice', () => {
-    const result = decodeBolt11(testnetInvoice);
+    expect(decodeBolt11(testnetInvoice)).toEqual({
+      encoded: testnetInvoice,
+      decoded: {
+        amountMsat: 2000000000,
+        amountSat: 2000000,
+        createdAtUnixMs: 1496314658000,
+        expiryUnixMs: 1496318258000,
+        network: 'testnet',
+        description: undefined,
+        paymentHash:
+          '0001020304050607080900010203040506070809000102030405060708090102',
+      },
+    });
+  });
+});
+
+describe('parseBolt11Invoice', () => {
+  it('should parse a raw invoice', () => {
+    const result = parseBolt11Invoice(invoice);
     expect(result).toEqual({
-      amountMsat: 2000000000,
-      amountSat: 2000000,
-      createdAtUnixMs: 1496314658000,
-      expiryUnixMs: 1496318258000,
-      network: 'testnet',
-      description: undefined,
-      paymentHash:
-        '0001020304050607080900010203040506070809000102030405060708090102',
+      valid: true,
+      encoded: invoice,
+      decoded: expectedDecoded,
     });
   });
 
-  it('should decode an invoice with a `lightning` prefix', () => {
-    const result = decodeBolt11(`lightning:${invoice}`);
+  it('should strip lightning: prefix and lowercase', () => {
+    const result = parseBolt11Invoice(`LIGHTNING:${invoice.toUpperCase()}`);
     expect(result).toEqual({
-      amountMsat: 250000000,
-      amountSat: 250000,
-      createdAtUnixMs: 1496314658000,
-      expiryUnixMs: 1496314718000,
-      network: 'bitcoin',
-      description: '1 cup coffee',
-      paymentHash:
-        '0001020304050607080900010203040506070809000102030405060708090102',
+      valid: true,
+      encoded: invoice,
+      decoded: expectedDecoded,
     });
+  });
+
+  it('should return valid: false for invalid input', () => {
+    expect(parseBolt11Invoice('not an invoice')).toEqual({ valid: false });
   });
 });

--- a/app/lib/bolt11/index.ts
+++ b/app/lib/bolt11/index.ts
@@ -15,11 +15,17 @@ export type DecodedBolt11 = {
 };
 
 /**
- * Decodes a BOLT11 invoice
- * @param invoice invoice to decode
+ * Decodes a BOLT11 invoice. Strips an optional `lightning:` prefix
+ * (case-insensitive per BIP21) and lowercases the result — bech32 requires
+ * uniform case, and lowercase is the canonical form. The cleaned bech32
+ * string is returned alongside the decoded fields.
+ * @param invoice invoice to decode (accepts optional lightning: prefix, case-insensitive)
  */
-export const decodeBolt11 = (invoice: string): DecodedBolt11 => {
-  const { sections } = bolt11Decoder.decode(invoice.replace(/^lightning:/, ''));
+export const decodeBolt11 = (
+  invoice: string,
+): { encoded: string; decoded: DecodedBolt11 } => {
+  const encoded = invoice.replace(/^lightning:/i, '').toLowerCase();
+  const { sections } = bolt11Decoder.decode(encoded);
 
   const amountSection = findSection(sections, 'amount');
   const amountMsat = amountSection?.value
@@ -51,26 +57,32 @@ export const decodeBolt11 = (invoice: string): DecodedBolt11 => {
   }
 
   return {
-    amountMsat,
-    amountSat,
-    createdAtUnixMs,
-    expiryUnixMs,
-    network,
-    description,
-    paymentHash,
+    encoded,
+    decoded: {
+      amountMsat,
+      amountSat,
+      createdAtUnixMs,
+      expiryUnixMs,
+      network,
+      description,
+      paymentHash,
+    },
   };
 };
 
 /**
- * Checks if a string is a valid BOLT11 invoice
- * @param invoice invoice to check
+ * Checks if a string is a valid BOLT11 invoice. Returns the cleaned bech32
+ * form and the decoded fields on success.
+ * @param invoice invoice to check (accepts optional lightning: prefix, case-insensitive)
  */
 export const parseBolt11Invoice = (
   invoice: string,
-): { valid: true; decoded: DecodedBolt11 } | { valid: false } => {
+):
+  | { valid: true; encoded: string; decoded: DecodedBolt11 }
+  | { valid: false } => {
   try {
-    const decoded = decodeBolt11(invoice);
-    return { valid: true, decoded };
+    const { encoded, decoded } = decodeBolt11(invoice);
+    return { valid: true, encoded, decoded };
   } catch {
     return { valid: false };
   }

--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -1,4 +1,4 @@
-import { Clock, GiftIcon, UserCircle2 } from 'lucide-react';
+import { Clock, GiftIcon, Scan, UserCircle2 } from 'lucide-react';
 import type { LinksFunction } from 'react-router';
 import agicashIcon192 from '~/assets/icon-192x192.png';
 import {
@@ -40,7 +40,7 @@ export default function Index() {
   return (
     <Page>
       <PageHeader className="z-10 px-4">
-        <PageHeaderItem position="left">
+        <PageHeaderItem position="left" className="flex gap-6">
           {giftCardsEnabled && (
             <LinkWithViewTransition
               to="/gift-cards"
@@ -50,6 +50,13 @@ export default function Index() {
               <GiftIcon className="text-muted-foreground" />
             </LinkWithViewTransition>
           )}
+          <LinkWithViewTransition
+            to="/scan"
+            transition="slideUp"
+            applyTo="newView"
+          >
+            <Scan className="text-muted-foreground" />
+          </LinkWithViewTransition>
         </PageHeaderItem>
 
         <PageHeaderItem position="right" className="flex gap-6">

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -1,0 +1,92 @@
+import { Clipboard } from 'lucide-react';
+import {
+  Page,
+  PageBackButton,
+  PageContent,
+  PageFooter,
+  PageHeader,
+  PageHeaderTitle,
+} from '~/components/page';
+import { QRScanner } from '~/components/qr-scanner';
+import { Button } from '~/components/ui/button';
+import { classifyInput } from '~/features/scan';
+import { validateBolt11 } from '~/features/send/validation';
+import { useToast } from '~/hooks/use-toast';
+import { readClipboard } from '~/lib/read-clipboard';
+import { useNavigateWithViewTransition } from '~/lib/transitions';
+
+export default function ScanPage() {
+  const navigate = useNavigateWithViewTransition();
+  const { toast } = useToast();
+
+  const handleInput = (raw: string) => {
+    const result = classifyInput(raw);
+
+    if (!result) {
+      toast({
+        title: 'Invalid QR code',
+        description:
+          'Please scan a cashu token, lightning invoice, or lightning address',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (result.direction === 'receive') {
+      const hash = `#${result.encoded}`;
+      // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it
+      // See https://github.com/remix-run/remix/discussions/10721
+      window.history.replaceState(null, '', hash);
+      navigate(
+        { pathname: '/receive/cashu/token', hash },
+        { transition: 'slideLeft', applyTo: 'newView' },
+      );
+      return;
+    }
+
+    if (result.type === 'bolt11') {
+      const validation = validateBolt11(result.decoded, {
+        allowZeroAmount: true,
+      });
+      if (!validation.valid) {
+        toast({
+          title: 'Invalid invoice',
+          description: validation.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+
+    const hash = `#${result.type === 'bolt11' ? result.invoice : result.address}`;
+    // The hash needs to be set manually before navigating or clientLoader of the destination route won't see it
+    // See https://github.com/remix-run/remix/discussions/10721
+    window.history.replaceState(null, '', hash);
+    navigate(
+      { pathname: '/send', hash },
+      { transition: 'slideLeft', applyTo: 'newView' },
+    );
+  };
+
+  const handlePaste = async () => {
+    const text = await readClipboard();
+    if (text) handleInput(text);
+  };
+
+  return (
+    <Page>
+      <PageHeader className="z-10">
+        <PageBackButton to="/" transition="slideDown" applyTo="oldView" />
+        <PageHeaderTitle>Scan</PageHeaderTitle>
+      </PageHeader>
+      <PageContent className="relative flex items-center justify-center">
+        <QRScanner onDecode={handleInput} />
+      </PageContent>
+      <PageFooter className="pb-14">
+        <Button type="button" onClick={handlePaste}>
+          <Clipboard className="h-5 w-5" /> Paste
+        </Button>
+      </PageFooter>
+    </Page>
+  );
+}

--- a/app/routes/_protected.send.tsx
+++ b/app/routes/_protected.send.tsx
@@ -1,14 +1,58 @@
 import { Outlet, useSearchParams } from 'react-router';
 import { useAccountOrDefault } from '~/features/accounts/account-hooks';
 import { SendProvider } from '~/features/send';
+import {
+  type SendDestination,
+  resolveSendDestination,
+} from '~/features/send/resolve-destination';
+import { toast } from '~/hooks/use-toast';
+import type { Route } from './+types/_protected.send';
 
-export default function SendLayout() {
+export async function clientLoader(): Promise<{
+  initialDestination: SendDestination | null;
+}> {
+  const hash = window.location.hash.slice(1);
+  if (!hash) {
+    return { initialDestination: null };
+  }
+
+  // Strip the hash from the URL after reading it so refreshes / back-navigation
+  // don't re-apply the destination.
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+
+  const result = await resolveSendDestination(hash, {
+    allowZeroAmountBolt11: true,
+  });
+
+  if (!result.success) {
+    toast({
+      title: 'Invalid destination',
+      description: result.error,
+      variant: 'destructive',
+      duration: 8000,
+    });
+    return { initialDestination: null };
+  }
+
+  return { initialDestination: result.data };
+}
+
+clientLoader.hydrate = true as const;
+
+export default function SendLayout({ loaderData }: Route.ComponentProps) {
   const [searchParams] = useSearchParams();
   const accountId = searchParams.get('accountId');
   const initialAccount = useAccountOrDefault(accountId);
 
   return (
-    <SendProvider initialAccount={initialAccount}>
+    <SendProvider
+      initialAccount={initialAccount}
+      initialDestination={loaderData.initialDestination}
+    >
       <Outlet />
     </SendProvider>
   );


### PR DESCRIPTION
This is the first of two phases for this QR scanner. In this PR I made it so that there's a scanner on the home page that classifies the input and then routes to the send or receive page with the destination pre-filled. 

To do this I also needed to add a loader to the send routes so that the input could be passed through the hash. One cool thing about this is that we now have the same "deep link" flow that we use from Cash App (ie. agi.cash/send#lnbc21m... will open the send-input with the invoice already input.

I'll open a follow up with smart account selection