### PR TITLE
chore: downgrade devenv to v2.0.6 in CI

### DIFF
--- a/.github/actions/setup-devenv/action.yml
+++ b/.github/actions/setup-devenv/action.yml
@@ -20,7 +20,7 @@ runs:
 
     - name: Install devenv and direnv
       shell: bash
-      run: nix profile install github:cachix/devenv/v2.0.7 nixpkgs#direnv
+      run: nix profile install github:cachix/devenv/v2.0.6 nixpkgs#direnv
 
     - name: Build devenv and export environment
       shell: bash

--- a/devenv.lock
+++ b/devenv.lock
@@ -78,11 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774855581,
-        "narHash": "sha256-YkreHeMgTCYvJ5fESV0YyqQK49bHGe2B51tH6claUh4=",
+        "lastModified": 1775034801,
+        "narHash": "sha256-tsecHNsWwr4wSaM2oW9GwafMwE24J+xD8bKDoto3exY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "15c6719d8c604779cf59e03c245ea61d3d7ab69b",
+        "rev": "8d029aa64915e54b7846873d9583af4c9fd21ea4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Downgrade devenv from v2.0.7 to v2.0.6 in the CI setup-devenv action
- Update devenv.lock with corresponding nixpkgs changes

## Test plan
- [ ] CI workflows using `setup-devenv` action pass successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)