### PR TITLE
chore: bump @buildonspark/spark-sdk to 0.7.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@agicash/bc-ur": "0.1.0",
         "@agicash/opensecret": "0.1.0",
         "@agicash/qr-scanner": "0.1.2",
-        "@buildonspark/spark-sdk": "0.7.1",
+        "@buildonspark/spark-sdk": "0.7.4",
         "@cashu/cashu-ts": "3.6.1",
         "@noble/ciphers": "1.3.0",
         "@noble/curves": "1.9.7",
@@ -91,7 +91,7 @@
   "patchedDependencies": {
     "@tanstack/query-core@5.90.20": "patches/@tanstack%2Fquery-core@5.90.20.patch",
     "@sentry/core@10.42.0": "patches/@sentry%2Fcore@10.42.0.patch",
-    "@buildonspark/spark-sdk@0.7.1": "patches/@buildonspark%2Fspark-sdk@0.7.1.patch",
+    "@buildonspark/spark-sdk@0.7.4": "patches/@buildonspark%2Fspark-sdk@0.7.4.patch",
   },
   "packages": {
     "@agicash/bc-ur": ["@agicash/bc-ur@0.1.0", "", { "dependencies": { "@apocentre/alias-sampling": "^0.5.3", "@noble/hashes": "^1.3.3", "big.js": "^6.2.2", "buffer": "^6.0.3", "cbor-sync": "^1.0.4", "cborg": "^4.0.9", "jsbi": "3.1.5" } }, "sha512-B2Hh7dSqdeVZuMCwdNR0MXUr4fUU5n+gTWd0b0m9HpV6/mAXRMnAfuJbeax/krvHf8A3qMxFLAkTBKcSxUSPuw=="],
@@ -178,7 +178,7 @@
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.11.0", "", {}, "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ=="],
 
-    "@buildonspark/spark-sdk": ["@buildonspark/spark-sdk@0.7.1", "", { "dependencies": { "@bufbuild/protobuf": "^2.2.5", "@lightsparkdev/core": "^1.4.9", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.7.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^2.0.0", "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.203.0", "@opentelemetry/instrumentation-undici": "^0.14.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/sdk-trace-web": "^2.0.1", "@scure/base": "^1.2.4", "@scure/bip32": "^1.6.2", "@scure/bip39": "^1.5.4", "@scure/btc-signer": "^1.5.0", "abort-controller-x": "^0.4.3", "abortcontroller-polyfill": "^1.7.8", "async-mutex": "^0.5.0", "bare-crypto": "^1.9.2", "bare-fetch": "^2.4.1", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "js-base64": "^3.7.7", "light-bolt11-decoder": "^3.2.0", "nice-grpc": "^2.1.10", "nice-grpc-client-middleware-retry": "^3.1.10", "nice-grpc-common": "^2.0.2", "nice-grpc-opentelemetry": "^0.1.18", "nice-grpc-web": "^3.3.7", "ts-proto": "2.8.3", "ua-parser-js": "^2.0.6", "uuidv7": "^1.0.2" }, "peerDependencies": { "react": ">=18.2.0", "react-native": ">=0.71.0", "react-native-get-random-values": ">=1.11.0" }, "optionalPeers": ["react", "react-native", "react-native-get-random-values"] }, "sha512-4EkIlkXpCfojUVYwuHFKj4y8hTUm3/1T4Gf0ruz7Q5DlKkmjtr5KY2oNxvebfjMrctVj5ZnMQZXZl6pSLLMngg=="],
+    "@buildonspark/spark-sdk": ["@buildonspark/spark-sdk@0.7.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.2.5", "@lightsparkdev/core": "^1.4.9", "@noble/curves": "^1.9.7", "@noble/hashes": "^1.7.0", "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^2.0.0", "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.203.0", "@opentelemetry/instrumentation-undici": "^0.14.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.1", "@opentelemetry/sdk-trace-web": "^2.0.1", "@scure/base": "^1.2.4", "@scure/bip32": "^1.6.2", "@scure/bip39": "^1.5.4", "@scure/btc-signer": "^1.5.0", "abort-controller-x": "^0.4.3", "abortcontroller-polyfill": "^1.7.8", "async-mutex": "^0.5.0", "bare-crypto": "^1.9.2", "bare-fetch": "^2.4.1", "buffer": "^6.0.3", "eventemitter3": "^5.0.1", "js-base64": "^3.7.7", "light-bolt11-decoder": "^3.2.0", "nice-grpc": "^2.1.10", "nice-grpc-client-middleware-retry": "^3.1.10", "nice-grpc-common": "^2.0.2", "nice-grpc-opentelemetry": "^0.1.18", "nice-grpc-web": "^3.3.7", "ts-proto": "2.8.3", "ua-parser-js": "^2.0.6", "uuidv7": "^1.0.2" }, "peerDependencies": { "react": ">=18.2.0", "react-native": ">=0.71.0", "react-native-get-random-values": ">=1.11.0" }, "optionalPeers": ["react", "react-native", "react-native-get-random-values"] }, "sha512-DzlN6EkXyKLZVvq3ujZD6/uFauBkSL7kZEgE6moI+xuFU0HZ3qrao1zbNCv67yPGoK9h8s2YfpEl++s1ybiVjg=="],
 
     "@cashu/cashu-ts": ["@cashu/cashu-ts@3.6.1", "", { "dependencies": { "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1" } }, "sha512-ynncvX5vv/m2Dzp28m1ApxNsmrsw1p6laOdOnvlHVOPK3x4Nz3K/ScV7UjnbuwubTVeIcKP1FXEdycedhhlJbQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@agicash/bc-ur": "0.1.0",
     "@agicash/opensecret": "0.1.0",
     "@agicash/qr-scanner": "0.1.2",
-    "@buildonspark/spark-sdk": "0.7.1",
+    "@buildonspark/spark-sdk": "0.7.4",
     "@cashu/cashu-ts": "3.6.1",
     "@noble/ciphers": "1.3.0",
     "@noble/curves": "1.9.7",
@@ -119,7 +119,7 @@
   "patchedDependencies": {
     "@tanstack/query-core@5.90.20": "patches/@tanstack%2Fquery-core@5.90.20.patch",
     "@sentry/core@10.42.0": "patches/@sentry%2Fcore@10.42.0.patch",
-    "@buildonspark/spark-sdk@0.7.1": "patches/@buildonspark%2Fspark-sdk@0.7.1.patch"
+    "@buildonspark/spark-sdk@0.7.4": "patches/@buildonspark%2Fspark-sdk@0.7.4.patch"
   },
   "patchedDependencies:comments": {
     "@sentry/core@10.42.0": "This patch was added because we noticed that logs in Sentry dashboard started to show timstamps different than what our logs would record when the app would be in the background for a while and then brought back to the foreground. We suspected (not 100% sure but it seems like our patch has fixed it) that it is related to their logic which uses the Performance API to get the timestamp for greater precision (browser sometimes stops the performance api clock when the computer is asleep), so we opted out of that and are just using the Date API instead. Remove the patch once that has been solved.",

--- a/patches/@buildonspark%2Fspark-sdk@0.7.4.patch
+++ b/patches/@buildonspark%2Fspark-sdk@0.7.4.patch
@@ -1,20 +1,8 @@
-diff --git a/node_modules/@buildonspark/spark-sdk/.bun-tag-80eaa9cdf8a27381 b/.bun-tag-80eaa9cdf8a27381
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/@buildonspark/spark-sdk/.bun-tag-b36a28d4f5fa4c5f b/.bun-tag-b36a28d4f5fa4c5f
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/@buildonspark/spark-sdk/.bun-tag-dcb374d08a2ba5b4 b/.bun-tag-dcb374d08a2ba5b4
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/node_modules/@buildonspark/spark-sdk/.bun-tag-f306804a397e1327 b/.bun-tag-f306804a397e1327
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
-diff --git a/dist/spark-wallet-DL7eUjY2.js b/dist/spark-wallet-DL7eUjY2.js
-index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e43b9d649 100644
---- a/dist/spark-wallet-DL7eUjY2.js
-+++ b/dist/spark-wallet-DL7eUjY2.js
-@@ -12095,11 +12095,10 @@ var LeafManager = class {
+diff --git a/dist/spark-wallet-By0Gon5S.js b/dist/spark-wallet-By0Gon5S.js
+index b8681ae051ca90da12d179f9590f60bb5f6f81ac..acc14034e23b087763eebbbbbf3c89037268a521 100644
+--- a/dist/spark-wallet-By0Gon5S.js
++++ b/dist/spark-wallet-By0Gon5S.js
+@@ -12557,11 +12557,10 @@ var LeafManager = class {
  		this.onAutoOptimize = onAutoOptimize;
  	}
  	emitBalanceUpdate() {
@@ -30,7 +18,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  	}
  	/** Must be called before stream events are processed. Sets the identity
  	*  public key used by handleTransferEvent to filter sender events. */
-@@ -12107,6 +12106,8 @@ var LeafManager = class {
+@@ -12569,6 +12568,8 @@ var LeafManager = class {
  		this.identityPublicKey = await this.config.signer.getIdentityPublicKey();
  	}
  	async sync() {
@@ -39,7 +27,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		this.identityPublicKey = await this.config.signer.getIdentityPublicKey();
  		const [rawLeaves, swaps, outgoingTransfers, incomingTransfers] = await Promise.all([
  			this.getLeaves(),
-@@ -12114,6 +12115,7 @@ var LeafManager = class {
+@@ -12576,6 +12577,7 @@ var LeafManager = class {
  			this.getAllPendingOutgoingTransfers(),
  			this.transferService.queryPendingTransfers()
  		]);
@@ -47,7 +35,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		const leaves = await this.checkRenewLeaves(rawLeaves);
  		await this.leavesMutex.runExclusive(() => {
  			const preserved = /* @__PURE__ */ new Map();
-@@ -12159,6 +12161,8 @@ var LeafManager = class {
+@@ -12621,6 +12623,8 @@ var LeafManager = class {
  			for (const [id, record] of preserved) this.leaves.set(id, record);
  			this.hasSynced = true;
  		});
@@ -56,7 +44,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		this.autoOptimizeIfNeeded();
  		this.emitBalanceUpdate();
  	}
-@@ -12296,12 +12300,18 @@ var LeafManager = class {
+@@ -12758,12 +12762,18 @@ var LeafManager = class {
  		}
  	}
  	async addLeaves(leaves) {
@@ -77,7 +65,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  				this.leaves.set(leaf.id, {
  					treeNode: leaf,
  					status: LeafStatus.AVAILABLE,
-@@ -12310,16 +12320,23 @@ var LeafManager = class {
+@@ -12772,16 +12782,23 @@ var LeafManager = class {
  				changed = true;
  			}
  		});
@@ -102,7 +90,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  				this.leaves.set(leaf.id, {
  					treeNode: leaf,
  					status: LeafStatus.INCOMING,
-@@ -12331,6 +12348,7 @@ var LeafManager = class {
+@@ -12793,6 +12810,7 @@ var LeafManager = class {
  				changed = true;
  			}
  		});
@@ -110,7 +98,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		if (changed) this.emitBalanceUpdate();
  	}
  	/** Remove stale AVAILABLE leaves not in the fresh coordinator set.
-@@ -12338,13 +12356,17 @@ var LeafManager = class {
+@@ -12800,13 +12818,17 @@ var LeafManager = class {
  	*  (source "transfer") are preserved since they may not yet appear
  	*  in the coordinator response. */
  	async evictStaleAvailable(freshIds) {
@@ -128,7 +116,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		if (changed) this.emitBalanceUpdate();
  	}
  	async removeLeaves(leafIds) {
-@@ -12358,7 +12380,10 @@ var LeafManager = class {
+@@ -12820,7 +12842,10 @@ var LeafManager = class {
  	*  Unconditionally sets status to AVAILABLE, bypassing the IN_FLIGHT_STATUSES
  	*  guard in addLeaves, since successfully claimed leaves are definitively ours. */
  	async registerClaimedLeaves(leaves, transferId) {
@@ -139,7 +127,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		await this.leavesMutex.runExclusive(() => {
  			for (const leaf of renewed) this.leaves.set(leaf.id, {
  				treeNode: leaf,
-@@ -12495,7 +12520,13 @@ var LeafManager = class {
+@@ -12957,7 +12982,13 @@ var LeafManager = class {
  		}
  	}
  	async handleTransferEvent(transfer) {
@@ -154,7 +142,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		const leafIds = transfer.leaves.flatMap((leaf) => leaf.leaf ? [leaf.leaf.id] : []);
  		let changed = false;
  		await this.leavesMutex.runExclusive(() => {
-@@ -12509,6 +12540,8 @@ var LeafManager = class {
+@@ -12971,6 +13002,8 @@ var LeafManager = class {
  				if (record.status !== LeafStatus.AVAILABLE) return true;
  				return !(record.source.kind === "transfer" && record.source.transferId === transfer.id);
  			});
@@ -162,8 +150,8 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
 +			if (_skipped > 0) _dl("handleTransferEvent: skipped reclaimed leaves", { skipped: _skipped });
  			switch (transfer.status) {
  				case TransferStatus.TRANSFER_STATUS_RETURNED:
- 					this.transition(activeLeafIds, LeafStatus.AVAILABLE, { source: { kind: "none" } });
-@@ -12767,10 +12800,15 @@ var LeafManager = class {
+ 				case TransferStatus.TRANSFER_STATUS_EXPIRED:
+@@ -13232,10 +13265,15 @@ var LeafManager = class {
  	* - Unknown leaf ids are skipped (next sync() will pick them up).
  	*/
  	transition(leafIds, toStatus, meta) {
@@ -181,7 +169,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  			if (toStatus === LeafStatus.SPENT) {
  				this.leaves.delete(leafId);
  				continue;
-@@ -14548,21 +14586,29 @@ var SparkWallet = class SparkWallet extends EventEmitter {
+@@ -14959,21 +14997,29 @@ var SparkWallet = class SparkWallet extends EventEmitter {
  		return this.sspClient;
  	}
  	async handleStreamEvent({ event }) {
@@ -213,7 +201,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  				const wasAdded = await this.leafManager.handleDepositEvent(deposit);
  				if (deposit.status === "AVAILABLE" && wasAdded) this.emit(SparkWalletEvent.DepositConfirmed, deposit.id, BigInt(this.leafManager.getAvailableBalance()));
  			}
-@@ -14574,6 +14620,7 @@ var SparkWallet = class SparkWallet extends EventEmitter {
+@@ -14985,6 +15031,7 @@ var SparkWallet = class SparkWallet extends EventEmitter {
  		const MAX_RETRIES = 10;
  		const INITIAL_DELAY = 1e3;
  		const MAX_DELAY = 6e4;
@@ -221,7 +209,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  		const delay = (ms, signal) => {
  			return new Promise((resolve) => {
  				const timer = setTimeout(() => {
-@@ -14591,39 +14638,54 @@ var SparkWallet = class SparkWallet extends EventEmitter {
+@@ -15002,39 +15049,54 @@ var SparkWallet = class SparkWallet extends EventEmitter {
  		let retryCount = 0;
  		const streamController = new AbortController();
  		this.streamController = streamController;
@@ -281,7 +269,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  	}
  	async getLeaves(isBalanceCheck = false) {
  		return this.leafManager.getLeaves(isBalanceCheck);
-@@ -14693,8 +14755,11 @@ var SparkWallet = class SparkWallet extends EventEmitter {
+@@ -15104,8 +15166,11 @@ var SparkWallet = class SparkWallet extends EventEmitter {
  		}, intervalMs);
  	}
  	async syncWallet() {
@@ -293,7 +281,7 @@ index 8ac67f96a4d2cbef9bcbae240241dc36f441f3db..6e0feba1026883d79b59f14cd1e9f09e
  	}
  	/**
  	* Gets the identity public key of the wallet.
-@@ -14910,19 +14975,24 @@ var SparkWallet = class SparkWallet extends EventEmitter {
+@@ -15321,19 +15386,24 @@ var SparkWallet = class SparkWallet extends EventEmitter {
  	*   - tokenBalances: Map of the bech32m encoded token identifier to token balances and token info
  	*/
  	async getBalance() {


### PR DESCRIPTION
## Summary
- Bumps `@buildonspark/spark-sdk` from 0.7.1 to 0.7.4
- Reapplies the `__SPARK_SDK_DEBUG__` logging patch on the new version's bundle

## Test plan
- [ ] Verify app builds and starts without errors
- [ ] Enable `globalThis.__SPARK_SDK_DEBUG__ = true` in browser console and confirm debug logs appear during balance polling, stream events, and transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)