### PR TITLE
Add account state lifecycle (active → expired)

### DIFF
--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -51,6 +51,12 @@ export class AccountsCache {
     );
   }
 
+  remove(accountId: string) {
+    this.queryClient.setQueryData([AccountsCache.Key], (curr: Account[]) =>
+      curr.filter((x) => x.id !== accountId),
+    );
+  }
+
   // This is used for a Spark bug workaround in useTrackAndUpdateSparkAccountBalances hook.
   // Once the bug is resolved we can change this function to simply update the account balance if changed.
   // TODO: Update when Spark bug is fixed and workaround is removed.
@@ -155,7 +161,11 @@ export function useAccountChangeHandlers() {
       event: 'ACCOUNT_UPDATED',
       handleEvent: async (payload: AgicashDbAccountWithProofs) => {
         const updatedAccount = await accountRepository.toAccount(payload);
-        accountCache.update(updatedAccount);
+        if (updatedAccount.state === 'expired') {
+          accountCache.remove(updatedAccount.id);
+        } else {
+          accountCache.update(updatedAccount);
+        }
       },
     },
   ];

--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -32,7 +32,7 @@ type AccountOmit<
   AdditionalOmit extends keyof T = never,
 > = DistributedOmit<
   T,
-  'id' | 'createdAt' | 'version' | 'isOnline' | AdditionalOmit
+  'id' | 'createdAt' | 'version' | 'isOnline' | 'state' | AdditionalOmit
 >;
 
 type AccountInput<T extends Account> = {
@@ -93,6 +93,7 @@ export class AccountRepository {
       .from('accounts')
       .select('*, cashu_proofs(*)')
       .eq('user_id', userId)
+      .eq('state', 'active')
       .eq('cashu_proofs.state', 'UNSPENT');
 
     if (options?.abortSignal) {
@@ -175,6 +176,7 @@ export class AccountRepository {
       name: data.name,
       currency: data.currency,
       purpose: data.purpose,
+      state: data.state,
       createdAt: data.created_at,
       version: data.version,
       expiresAt: data.expires_at,

--- a/app/features/accounts/account-service.ts
+++ b/app/features/accounts/account-service.ts
@@ -64,6 +64,7 @@ export class AccountService {
       | 'version'
       | 'wallet'
       | 'isOnline'
+      | 'state'
     >;
   }) {
     const isTestMint = checkIsTestMint(account.mintUrl);

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -10,6 +10,8 @@ import type { CashuProof } from './cashu-account';
 
 export type AccountType = 'cashu' | 'spark';
 
+export type AccountState = 'active' | 'expired';
+
 /**
  * Account purpose. Maps to MintPurpose for cashu accounts.
  */
@@ -20,6 +22,7 @@ export type Account = {
   name: string;
   type: AccountType;
   purpose: AccountPurpose;
+  state: AccountState;
   isOnline: boolean;
   currency: Currency;
   createdAt: string;

--- a/app/features/receive/receive-cashu-token-hooks.ts
+++ b/app/features/receive/receive-cashu-token-hooks.ts
@@ -313,6 +313,7 @@ function getSparkAccountPlaceholder(): ReceiveCashuTokenAccount & {
     name: 'Bitcoin',
     type: 'spark',
     purpose: 'transactional',
+    state: 'active',
     isOnline: true,
     currency: 'BTC',
     wallet: createSparkWalletStub(

--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -60,6 +60,7 @@ export class ReceiveCashuTokenService {
       id: 'cashu-account-placeholder-id',
       type: 'cashu' as const,
       purpose: wallet.purpose,
+      state: 'active' as const,
       name: mintUrl.replace('https://', '').replace('http://', ''),
       mintUrl,
       createdAt: new Date().toISOString(),

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -49,6 +49,7 @@ type AccountInput = {
   | 'keysetCounters'
   | 'wallet'
   | 'isOnline'
+  | 'state'
   | 'ownedBalance'
   | 'availableBalance'
 >;
@@ -276,6 +277,7 @@ export class ReadUserDefaultAccountRepository {
       name: data.name,
       currency: data.currency,
       purpose: data.purpose,
+      state: data.state,
       createdAt: data.created_at,
       version: data.version,
       expiresAt: data.expires_at,

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -18,6 +18,7 @@ export type Database = {
           id: string
           name: string
           purpose: Database["wallet"]["Enums"]["account_purpose"]
+          state: Database["wallet"]["Enums"]["account_state"]
           type: Database["wallet"]["Enums"]["account_type"]
           user_id: string
           version: number
@@ -30,6 +31,7 @@ export type Database = {
           id?: string
           name: string
           purpose?: Database["wallet"]["Enums"]["account_purpose"]
+          state?: Database["wallet"]["Enums"]["account_state"]
           type: Database["wallet"]["Enums"]["account_type"]
           user_id: string
           version?: number
@@ -42,6 +44,7 @@ export type Database = {
           id?: string
           name?: string
           purpose?: Database["wallet"]["Enums"]["account_purpose"]
+          state?: Database["wallet"]["Enums"]["account_state"]
           type?: Database["wallet"]["Enums"]["account_type"]
           user_id?: string
           version?: number
@@ -1604,6 +1607,7 @@ export type Database = {
     }
     Enums: {
       account_purpose: "transactional" | "gift-card" | "offer"
+      account_state: "active" | "expired"
       account_type: "cashu" | "spark"
       acknowledgment_status: "pending" | "acknowledged"
       cashu_proof_state: "UNSPENT" | "RESERVED" | "SPENT"
@@ -1890,6 +1894,7 @@ export const Constants = {
   wallet: {
     Enums: {
       account_purpose: ["transactional", "gift-card", "offer"],
+      account_state: ["active", "expired"],
       account_type: ["cashu", "spark"],
       acknowledgment_status: ["pending", "acknowledged"],
       cashu_proof_state: ["UNSPENT", "RESERVED", "SPENT"],

--- a/supabase/migrations/20260325120000_add_account_state.sql
+++ b/supabase/migrations/20260325120000_add_account_state.sql
@@ -1,0 +1,67 @@
+-- Account state lifecycle: active -> expired
+-- Adds state column, updates indexes, creates pg_cron expiry job
+
+-- New enum
+create type "wallet"."account_state" as enum ('active', 'expired');
+
+-- Add state column (defaults to 'active', all existing rows become active)
+alter table "wallet"."accounts"
+  add column "state" "wallet"."account_state" not null default 'active';
+
+-- Replace uniqueness constraint: scope to active accounts only
+drop index "wallet"."cashu_accounts_user_currency_mint_url_unique";
+
+create unique index "cashu_accounts_active_user_currency_mint_url_unique"
+  on "wallet"."accounts" using btree (
+    "user_id",
+    "currency",
+    (("details" ->> 'mint_url'::text))
+  )
+  where ("type" = 'cashu' and "state" = 'active');
+
+-- Index for the cron job: find active accounts with passed expiry
+create index "idx_accounts_active_expires_at"
+  on "wallet"."accounts" using btree ("expires_at")
+  where ("state" = 'active' and "expires_at" is not null);
+
+-- General state index for repository queries filtering by state
+create index "idx_accounts_state" on "wallet"."accounts" ("state");
+
+-- Update enforce_accounts_limit to count only active accounts
+create or replace function "wallet"."enforce_accounts_limit"()
+returns "trigger"
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+declare
+  v_account_count integer;
+begin
+  select count(*) into v_account_count
+  from wallet.accounts
+  where user_id = new.user_id
+    and state = 'active';
+
+  if v_account_count >= 200 then
+    raise exception
+      using
+        hint = 'LIMIT_REACHED',
+        message = 'Maximum number of accounts limit reached.',
+        detail = format('Accounts count: %s, limit: 200.', v_account_count);
+  end if;
+
+  return new;
+end;
+$function$;
+
+-- pg_cron job: expire accounts every minute
+select cron.schedule('expire-offer-accounts', '* * * * *', $$
+  update wallet.accounts
+  set
+    state = 'expired',
+    version = version + 1
+  where
+    state = 'active'
+    and expires_at is not null
+    and expires_at <= now();
+$$);

--- a/supabase/migrations/20260325130000_default_account_no_expiry.sql
+++ b/supabase/migrations/20260325130000_default_account_no_expiry.sql
@@ -1,0 +1,71 @@
+-- Prevent default accounts from having expires_at set.
+-- Two triggers: one guards setting a default, the other guards adding expiry.
+
+-- Trigger A: block setting an expiring account as default
+create or replace function wallet.enforce_default_account_no_expiry()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.default_btc_account_id is distinct from old.default_btc_account_id
+     and new.default_btc_account_id is not null then
+    if exists (
+      select 1 from wallet.accounts
+      where id = new.default_btc_account_id
+        and expires_at is not null
+    ) then
+      raise exception 'Cannot set expiring account as default'
+        using hint = 'DEFAULT_ACCOUNT_EXPIRES';
+    end if;
+  end if;
+
+  if new.default_usd_account_id is distinct from old.default_usd_account_id
+     and new.default_usd_account_id is not null then
+    if exists (
+      select 1 from wallet.accounts
+      where id = new.default_usd_account_id
+        and expires_at is not null
+    ) then
+      raise exception 'Cannot set expiring account as default'
+        using hint = 'DEFAULT_ACCOUNT_EXPIRES';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger enforce_default_account_no_expiry_trigger
+  before insert or update on wallet.users
+  for each row
+  execute function wallet.enforce_default_account_no_expiry();
+
+-- Trigger B: block adding expires_at to an account that's someone's default
+create or replace function wallet.enforce_no_expiry_on_default_account()
+returns trigger
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+begin
+  if new.expires_at is not null and old.expires_at is null then
+    if exists (
+      select 1 from wallet.users
+      where default_btc_account_id = new.id
+         or default_usd_account_id = new.id
+    ) then
+      raise exception 'Cannot add expiry to a default account'
+        using hint = 'DEFAULT_ACCOUNT_EXPIRES';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger enforce_no_expiry_on_default_account_trigger
+  before update on wallet.accounts
+  for each row
+  execute function wallet.enforce_no_expiry_on_default_account();


### PR DESCRIPTION
Two commits, the first is clean and just adds the state and cron job to transition to expired. The second commit tries to add error handling, but is still a wip and I still need to test it. I'm wondering if we should just review the first commit and worry about this error handling later so we can get the account state migration on next.

@jbojcic1 we talked in discord about [keeping the keyset active after expiry](https://discord.com/channels/@me/1301542125279641703/1491350123752460378) which I think we should do. If we do that, then I think we can probably remove this error handling entirely

Full spec: https://github.com/MakePrisms/agicash/pull/960