### PR TITLE
fix: handle expired offer keysets when receiving cashu tokens

### DIFF
--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -56,11 +56,13 @@ export class ReceiveCashuTokenService {
       }
     }
 
+    const isExpired = expiresAt !== null && new Date(expiresAt) <= new Date();
+
     const baseAccount = {
       id: 'cashu-account-placeholder-id',
       type: 'cashu' as const,
       purpose: wallet.purpose,
-      state: 'active' as const,
+      state: isExpired ? ('expired' as const) : ('active' as const),
       name: mintUrl.replace('https://', '').replace('http://', ''),
       mintUrl,
       createdAt: new Date().toISOString(),
@@ -75,11 +77,12 @@ export class ReceiveCashuTokenService {
       wallet,
     };
 
-    if (!isOnline) {
+    if (!isOnline || isExpired) {
       return {
         ...baseAccount,
         canReceive: false,
-        isOnline: false,
+        cannotReceiveReason: isExpired ? 'This offer has expired' : undefined,
+        isOnline,
         isTestMint: false,
       };
     }


### PR DESCRIPTION
## Summary

Offer mints can report keysets as `active: true` even after their `final_expiry` has passed. Previously, receiving a token from such a mint would proceed as normal — the expired offer appeared claimable.

Now, if the active keyset's `final_expiry` is in the past, the account state is set to `expired`, claiming is disabled, and the user sees "This offer has expired."

Single file change in `receive-cashu-token-service.ts` — no changes to wallet initialization.