### PR TITLE
fix: prevent getEncodedToken from mutating proof keyset IDs

### DIFF
--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -1,4 +1,4 @@
-import { type Token, getEncodedToken } from '@cashu/cashu-ts';
+import type { Token } from '@cashu/cashu-ts';
 import { useMutation } from '@tanstack/react-query';
 import { AlertCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -21,6 +21,7 @@ import { Button } from '~/components/ui/button';
 import { useFeatureFlag } from '~/features/shared/feature-flags';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { useToast } from '~/hooks/use-toast';
+import { encodeToken } from '~/lib/cashu/token';
 import type { Currency } from '~/lib/money';
 import {
   LinkWithViewTransition,
@@ -77,7 +78,7 @@ function TokenAmountDisplay({
       type="button"
       className="z-10 transition-transform active:scale-95"
       onClick={() => {
-        copyToClipboard(getEncodedToken(claimableToken ?? token));
+        copyToClipboard(encodeToken(claimableToken ?? token));
         toast({
           title: 'Token copied to clipboard',
           duration: 1000,
@@ -316,7 +317,7 @@ export function PublicReceiveCashuToken({ token }: { token: Token }) {
 
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
 
-  const encodedToken = getEncodedToken(claimableToken ?? token);
+  const encodedToken = encodeToken(claimableToken ?? token);
 
   const handleClaimAsGuest = async () => {
     if (!claimableToken) {

--- a/app/features/send/share-cashu-token.tsx
+++ b/app/features/send/share-cashu-token.tsx
@@ -1,4 +1,4 @@
-import { type Token, getEncodedToken } from '@cashu/cashu-ts';
+import type { Token } from '@cashu/cashu-ts';
 import { Banknote, Link, Share } from 'lucide-react';
 import { useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
@@ -22,6 +22,7 @@ import {
 import useLocationData from '~/hooks/use-location';
 import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
+import { encodeToken } from '~/lib/cashu/token';
 import { canShare, shareContent } from '~/lib/share';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { tokenToMoney } from '../shared/cashu';
@@ -39,7 +40,7 @@ export function ShareCashuToken({ token }: Props) {
   const amount = tokenToMoney(token);
   const [showOk, setShowOk] = useState(false);
 
-  const encodedToken = getEncodedToken(token);
+  const encodedToken = encodeToken(token);
   const shareableLink = `${origin}/receive-cashu-token#${encodedToken}`;
   const shortToken = `${encodedToken.slice(0, 6)}...${encodedToken.slice(-5)}`;
   const shortShareableLink = `${origin}/receive-cashu-token#${shortToken}`;

--- a/app/features/shared/cashu.ts
+++ b/app/features/shared/cashu.ts
@@ -11,7 +11,6 @@ import {
   NetworkError,
   type Token,
   getDecodedToken,
-  getEncodedToken,
 } from '@cashu/cashu-ts';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
@@ -36,6 +35,7 @@ import {
   MintBlocklistSchema,
   buildMintValidator,
 } from '~/lib/cashu/mint-validation';
+import { encodeToken } from '~/lib/cashu/token';
 import { type Currency, type CurrencyUnit, Money } from '~/lib/money';
 import { measureOperation } from '~/lib/performance';
 import { computeSHA256 } from '~/lib/sha256';
@@ -161,14 +161,7 @@ export function getTokenHash(token: Token | string): Promise<string> {
   if (typeof token === 'string') {
     return computeSHA256(token);
   }
-  // Deep-clone proofs before encoding to prevent getEncodedToken from
-  // mutating proof.id (it truncates v2 keyset IDs to their short form).
-  // TODO: remove this workaround after upgrading to cashu-ts v4+ (fix merged in cashu-ts#536, unreleased as of v3.6.1)
-  const cloned: Token = {
-    ...token,
-    proofs: token.proofs.map((p) => ({ ...p })),
-  };
-  return computeSHA256(getEncodedToken(cloned));
+  return computeSHA256(encodeToken(token));
 }
 
 const mintBlocklist = MintBlocklistSchema.parse(

--- a/app/lib/cashu/token.ts
+++ b/app/lib/cashu/token.ts
@@ -4,6 +4,7 @@ import {
   type Token,
   type TokenMetadata,
   Wallet,
+  getEncodedToken,
   getTokenMetadata,
 } from '@cashu/cashu-ts';
 import { proofToY } from './proof';
@@ -31,6 +32,23 @@ export const getUnspentProofsFromToken = async (
     return state?.state === CheckStateEnum.UNSPENT;
   });
 };
+
+/**
+ * Encode a token without mutating the input.
+ *
+ * cashu-ts's getEncodedToken() mutates proof.id in place, truncating v2 keyset
+ * IDs to their short form. This wrapper deep-clones proofs before encoding.
+ *
+ * TODO: remove after upgrading to cashu-ts v4 (fixed in cashu-ts#536)
+ */
+export function encodeToken(
+  ...[token, opts]: Parameters<typeof getEncodedToken>
+): ReturnType<typeof getEncodedToken> {
+  return getEncodedToken(
+    { ...token, proofs: token.proofs.map((p) => ({ ...p })) },
+    opts,
+  );
+}
 
 const CASHU_TOKEN_REGEX = /cashu[AB][A-Za-z0-9_-]+={0,2}/;
 


### PR DESCRIPTION
At first I just had this for hashing our token, but also I just discovered that if you paste a token and click the amount which copies the token to your clipboard, then try to claim the keyset ID would be mutated from encoding. I just decided to not use getEncodedToken from cashu-ts and instead call our own safe version.

- Note: [cashu-ts v4 just released today](https://github.com/cashubtc/cashu-ts/blob/main/migration-4.0.0.md) which fixes this upstream, but I'm not ready to spend time on migrating that