### PR TITLE
fix: initialize fallback cashu wallets before melt

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -2,6 +2,7 @@ import {
   HttpResponseError,
   MintOperationError,
   type MintQuoteBolt11Response,
+  NetworkError,
   type WebSocketSupport,
 } from '@cashu/cashu-ts';
 import {
@@ -14,6 +15,7 @@ import {
 } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  type ExtendedCashuWallet,
   MintQuoteSubscriptionManager,
   getCashuUnit,
   getCashuWallet,
@@ -35,6 +37,7 @@ import {
   useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbCashuReceiveQuote } from '../agicash-db/database';
+import { getInitializedCashuWallet } from '../shared/cashu';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
 import { useTransactionsCache } from '../transactions/transaction-hooks';
 import { useUser } from '../user/user-hooks';
@@ -581,6 +584,7 @@ export function useProcessCashuReceiveQuoteTasks() {
   const pendingQuotesCache = usePendingCashuReceiveQuotesCache();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
   const transactionsCache = useTransactionsCache();
+  const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
     mutationFn: async (quoteId: string) => {
@@ -673,9 +677,18 @@ export function useProcessCashuReceiveQuoteTasks() {
         quote.tokenReceiveData.tokenAmount.currency,
       );
 
-      const sourceWallet = sourceAccount
-        ? sourceAccount.wallet
-        : getCashuWallet(sourceMintUrl, { unit: cashuUnit });
+      let sourceWallet: ExtendedCashuWallet;
+      if (sourceAccount) {
+        sourceWallet = sourceAccount.wallet;
+      } else {
+        const { wallet, isOnline } = await getInitializedCashuWallet({
+          queryClient,
+          mintUrl: sourceMintUrl,
+          currency: quote.tokenReceiveData.tokenAmount.currency,
+        });
+        if (!isOnline) throw new NetworkError('Source mint is offline');
+        sourceWallet = wallet;
+      }
 
       await sourceWallet.meltProofsIdempotent(
         {

--- a/app/features/receive/spark-receive-quote-hooks.ts
+++ b/app/features/receive/spark-receive-quote-hooks.ts
@@ -1,5 +1,5 @@
 import { LightningReceiveRequestStatus } from '@buildonspark/spark-sdk/types';
-import { MintOperationError } from '@cashu/cashu-ts';
+import { MintOperationError, NetworkError } from '@cashu/cashu-ts';
 import {
   type QueryClient,
   useMutation,
@@ -8,6 +8,7 @@ import {
 } from '@tanstack/react-query';
 import { useEffect, useMemo } from 'react';
 import {
+  type ExtendedCashuWallet,
   getCashuUnit,
   getCashuWallet,
   sumProofs,
@@ -23,6 +24,7 @@ import {
   useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbSparkReceiveQuote } from '../agicash-db/database';
+import { getInitializedCashuWallet } from '../shared/cashu';
 import { sparkBalanceQueryKey, sparkDebugLog } from '../shared/spark';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
 import { useTransactionsCache } from '../transactions/transaction-hooks';
@@ -603,9 +605,18 @@ export function useProcessSparkReceiveQuoteTasks() {
         quote.tokenReceiveData.tokenAmount.currency,
       );
 
-      const sourceWallet = sourceAccount
-        ? sourceAccount.wallet
-        : getCashuWallet(sourceMintUrl, { unit: cashuUnit });
+      let sourceWallet: ExtendedCashuWallet;
+      if (sourceAccount) {
+        sourceWallet = sourceAccount.wallet;
+      } else {
+        const { wallet, isOnline } = await getInitializedCashuWallet({
+          queryClient,
+          mintUrl: sourceMintUrl,
+          currency: quote.tokenReceiveData.tokenAmount.currency,
+        });
+        if (!isOnline) throw new NetworkError('Source mint is offline');
+        sourceWallet = wallet;
+      }
 
       await sourceWallet.meltProofsIdempotent(
         {


### PR DESCRIPTION
This bug occurs when you try to do a cross account receive where the token is from an account that you do not have added. I think this has been there since we upgraded to cashu-ts v3.

When a Cashu token is being melted from a mint that the user does not already have as a local Cashu account, the fallback code created a raw `getCashuWallet(...)` instance and called `meltProofsIdempotent(...)`. In `cashu-ts` v3 this can fail with `Wallet has no bound keyset` because the wallet was never initialized with mint keysets. `Wallet.meltProofsBolt11` [calls `
get keysetId()`](https://github.com/cashubtc/cashu-ts/blob/226096850d720098c69d834937ac09a0a9da85ff/src/wallet/Wallet.ts#L410-L444) which results in this error:

<img width="1228" height="656" alt="image" src="https://github.com/user-attachments/assets/4f8a1a09-ea31-4523-a4d3-00499c70c0eb" />

I confirmed by first reproducing this error and then adding the sending account and the error resolved. I then reproduced the error locally and implemented this fix which also resolved the issue.
