### PR TITLE
fix: strip DLEQ proofs from copied tokens

### DIFF
--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -78,7 +78,9 @@ function TokenAmountDisplay({
       type="button"
       className="z-10 transition-transform active:scale-95"
       onClick={() => {
-        copyToClipboard(encodeToken(claimableToken ?? token));
+        copyToClipboard(
+          encodeToken(claimableToken ?? token, { removeDleq: true }),
+        );
         toast({
           title: 'Token copied to clipboard',
           duration: 1000,
@@ -317,7 +319,9 @@ export function PublicReceiveCashuToken({ token }: { token: Token }) {
 
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
 
-  const encodedToken = encodeToken(claimableToken ?? token);
+  const encodedToken = encodeToken(claimableToken ?? token, {
+    removeDleq: true,
+  });
 
   const handleClaimAsGuest = async () => {
     if (!claimableToken) {

--- a/app/features/send/share-cashu-token.tsx
+++ b/app/features/send/share-cashu-token.tsx
@@ -40,7 +40,7 @@ export function ShareCashuToken({ token }: Props) {
   const amount = tokenToMoney(token);
   const [showOk, setShowOk] = useState(false);
 
-  const encodedToken = encodeToken(token);
+  const encodedToken = encodeToken(token, { removeDleq: true });
   const shareableLink = `${origin}/receive-cashu-token#${encodedToken}`;
   const shortToken = `${encodedToken.slice(0, 6)}...${encodedToken.slice(-5)}`;
   const shortShareableLink = `${origin}/receive-cashu-token#${shortToken}`;


### PR DESCRIPTION
## Summary
- Pass `{ removeDleq: true }` to `encodeToken()` in all user-facing copy/share flows
- Strips DLEQ proofs from cashu tokens when users copy or share them, reducing token size and removing unnecessary cryptographic data that recipients don't need

Closes #997

## Changes
- `app/features/send/share-cashu-token.tsx` — strip DLEQ when encoding token for QR/copy/share
- `app/features/receive/receive-cashu-token.tsx` — strip DLEQ when copying token to clipboard (2 call sites)

Internal uses of `encodeToken` (e.g. `getTokenHash` in `cashu.ts`) are left unchanged since they don't produce user-facing tokens.