### PR TITLE
fix: transaction details crash for expired accounts

### DIFF
--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -291,6 +291,28 @@ export function useAccount<T extends AccountType = AccountType>(id: string) {
   return account;
 }
 
+/**
+ * Hook to lazily load an account by ID.
+ * Checks the active accounts cache first, then falls back to fetching
+ * directly from the database (which includes expired accounts).
+ */
+export function useAccountLazy(id: string) {
+  const accountRepository = useAccountRepository();
+  const accountsCache = useAccountsCache();
+
+  const { data } = useSuspenseQuery({
+    queryKey: ['account-lazy', id],
+    queryFn: async () => {
+      const cached = accountsCache.get(id);
+      if (cached) return cached;
+      return accountRepository.get(id);
+    },
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  return data;
+}
+
 type AccountTypeMap = {
   cashu: CashuAccount;
   spark: SparkAccount;

--- a/app/features/accounts/account-hooks.ts
+++ b/app/features/accounts/account-hooks.ts
@@ -292,25 +292,27 @@ export function useAccount<T extends AccountType = AccountType>(id: string) {
 }
 
 /**
- * Hook to lazily load an account by ID.
- * Checks the active accounts cache first, then falls back to fetching
- * directly from the database (which includes expired accounts).
+ * Hook to load an account by ID, including inactive/expired accounts.
+ * Prefers the reactive accounts cache (kept fresh by realtime events) and
+ * falls back to a direct DB fetch for accounts not in the cache.
+ *
+ * The fallback cache is only populated for accounts the realtime pipeline
+ * has dropped — which today means expired accounts. Expired is a terminal
+ * state, so the fallback value doesn't need to be refreshed.
  */
 export function useAccountLazy(id: string) {
-  const accountRepository = useAccountRepository();
-  const accountsCache = useAccountsCache();
+  const { data: accounts } = useAccounts();
+  const activeAccount = accounts.find((a) => a.id === id);
 
-  const { data } = useSuspenseQuery({
-    queryKey: ['account-lazy', id],
-    queryFn: async () => {
-      const cached = accountsCache.get(id);
-      if (cached) return cached;
-      return accountRepository.get(id);
-    },
+  const accountRepository = useAccountRepository();
+  const { data: fallbackAccount } = useSuspenseQuery({
+    queryKey: [AccountsCache.Key, 'by-id', id],
+    queryFn: () => accountRepository.get(id),
     staleTime: Number.POSITIVE_INFINITY,
+    initialData: activeAccount,
   });
 
-  return data;
+  return activeAccount ?? fallbackAccount;
 }
 
 type AccountTypeMap = {

--- a/app/features/transactions/transaction-additional-details.tsx
+++ b/app/features/transactions/transaction-additional-details.tsx
@@ -10,7 +10,7 @@ import {
 } from '~/components/page';
 import { proofToY } from '~/lib/cashu';
 import type { CashuAccount } from '../accounts/account';
-import { useAccount } from '../accounts/account-hooks';
+import { useAccountLazy } from '../accounts/account-hooks';
 import { type CashuProof, toProof } from '../accounts/cashu-account';
 import { useCashuReceiveQuoteRepository } from '../receive/cashu-receive-quote-repository';
 import { useCashuReceiveSwapRepository } from '../receive/cashu-receive-swap-repository';
@@ -206,7 +206,7 @@ export function TransactionAdditionalDetails({
   transactionId,
 }: { transactionId: string }) {
   const { data: transaction } = useTransaction(transactionId);
-  const account = useAccount(transaction.accountId);
+  const account = useAccountLazy(transaction.accountId);
 
   if (account.type !== 'cashu') {
     return <div>Account is not a cashu account</div>;

--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -16,7 +16,7 @@ import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
 import { isThisWeek, isToday, isYesterday } from '~/lib/date';
 import { LinkWithViewTransition } from '~/lib/transitions';
-import { useAccount } from '../accounts/account-hooks';
+import { useAccountLazy } from '../accounts/account-hooks';
 import { AccountIcon } from '../accounts/account-icons';
 import { getErrorMessage } from '../shared/error';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
@@ -96,7 +96,7 @@ export function TransactionDetails({
   const [searchParams] = useSearchParams();
   const showOkButton = searchParams.get('showOkButton') === 'true';
   const { redirectTo } = useRedirectTo('/');
-  const account = useAccount(transaction.accountId);
+  const account = useAccountLazy(transaction.accountId);
   const { toast } = useToast();
   const { mutate: acknowledgeTransaction } = useAcknowledgeTransaction();
 


### PR DESCRIPTION
## Summary
- Transaction detail pages crash when the referenced account has expired (`useAccount` throws because expired accounts are filtered out of the active accounts cache)
- Adds `useAccountLazy` hook that checks the cache first, then falls back to `accountRepository.get(id)` which fetches any account regardless of state
- Swaps `useAccount` → `useAccountLazy` in `transaction-details.tsx` and `transaction-additional-details.tsx`

No database migration. `getAll()` still fetches active accounts only. The 200-account client limit is untouched.

## Test plan
- [ ] Create an offer account, make a transaction, let the account expire
- [ ] Open transaction history, tap the transaction — verify details render with account name and icon
- [ ] Verify the additional details page loads
- [ ] Confirm active account transactions still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)