### PR TITLE
feat: generic event system and welcome email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ LNURL_SERVER_ENCRYPTION_KEY="a8861cc3e5b3caf5573fbba2da2851a4e608a836eef10074be3
 # LNVoltz + USD: This mint has a bug that does not allow USD ecash to be melted. The current version is "Nutshell/0.18.1"
 VITE_CASHU_MINT_BLOCKLIST='[{"mintUrl":"https://mint.lnvoltz.com","unit":"usd"}]'
 VITE_GIFT_CARDS='[{"url":"https://blockandbean.agi.cash","name":"Block and Bean","currency":"BTC"},{"url":"https://pubkey.agi.cash","name":"Pubkey","currency":"BTC"},{"url":"https://maple.agi.cash","name":"Maple","currency":"BTC"},{"url":"https://compass.agi.cash","name":"Compass Coffee","currency":"BTC"},{"url":"https://pinkowl.agi.cash","name":"Pink Owl Coffee","currency":"BTC"},{"url":"https://shack.agi.cash","name":"The Shack","currency":"BTC"}]'
+
+# Event system (webhook from Supabase triggers)
+WEBHOOK_SECRET=dev-webhook-secret
+RESEND_API_KEY=
+RESEND_WELCOME_TEMPLATE_ID=51320094-3fc9-416f-9c4a-de4fff0fc5e2

--- a/README.md
+++ b/README.md
@@ -175,6 +175,41 @@ resolve the issue and push migrations from your machine by doing:
 
 Steps 2 and 3 can be skipped if you have already logged in and linked the project before.
 
+### Event system
+
+The app uses a generic DB-driven event system: any table can emit events by attaching a trigger that calls
+`wallet.emit_event('event.type')`. The trigger signs the payload with HMAC-SHA256 and posts it to the app's
+`/api/events` route, which verifies the signature and dispatches to handlers (e.g. sending a welcome email via Resend).
+
+The trigger function reads two values at runtime:
+- `app.webhook_base_url` — a Postgres setting (GUC) holding the base URL of the app
+- `webhook_secret` — a vault secret holding the shared HMAC secret (must match the `WEBHOOK_SECRET` env var on the app side)
+
+If either value is missing the function logs a warning and no-ops, so triggers won't block inserts/updates
+but events will not be delivered.
+
+**Local dev:** both values are seeded automatically by `supabase/seed.sql` when you run `bun run supabase start`
+or `bun supabase db reset`. No manual setup needed.
+
+**Hosted envs (next, prod, preview branches):** both values must be set ONCE per environment. Run the
+following in the Supabase SQL editor against the target environment's database, substituting the correct URL
+and a fresh secret:
+
+```sql
+-- 1. set the base URL for webhook delivery
+alter database postgres set app.webhook_base_url = 'https://agi.cash';
+
+-- 2. create the HMAC secret
+select vault.create_secret(
+  '<paste-32-byte-random-hex-here>',
+  'webhook_secret',
+  'HMAC shared secret for webhook signatures'
+);
+```
+
+The same secret value must also be set as the `WEBHOOK_SECRET` env var on the app side (in Vercel for hosted
+envs, in `.env` for local dev).
+
 
 ## Code style & formatting
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The app uses a generic DB-driven event system: any table can emit events by atta
 `/api/events` route, which verifies the signature and dispatches to handlers (e.g. sending a welcome email via Resend).
 
 The trigger function reads two values at runtime:
-- `app.webhook_base_url` — a Postgres setting (GUC) holding the base URL of the app
+- `wallet.app_config.webhook_base_url` — a row in the `wallet.app_config` table holding the base URL of the app
 - `webhook_secret` — a vault secret holding the shared HMAC secret (must match the `WEBHOOK_SECRET` env var on the app side)
 
 If either value is missing the function logs a warning and no-ops, so triggers won't block inserts/updates
@@ -197,7 +197,7 @@ and a fresh secret:
 
 ```sql
 -- 1. set the base URL for webhook delivery
-alter database postgres set app.webhook_base_url = 'https://agi.cash';
+insert into "wallet"."app_config" ("key", "value") values ('webhook_base_url', 'https://agi.cash');
 
 -- 2. create the HMAC secret
 select vault.create_secret(

--- a/app/features/email/welcome-email-service.ts
+++ b/app/features/email/welcome-email-service.ts
@@ -23,17 +23,10 @@ export async function sendWelcomeEmail(data: {
   const resendWelcomeTemplateId = process.env.RESEND_WELCOME_TEMPLATE_ID;
 
   if (!resendApiKey || !resendWelcomeTemplateId) {
-    const err = new Error(
-      'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
+    Sentry.captureException(
+      new Error('Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID'),
+      { extra: { code: 'server_misconfigured', userId } },
     );
-    console.error('events webhook failed welcome email', {
-      code: 'server_misconfigured',
-      message: err.message,
-      userId,
-    });
-    Sentry.captureException(err, {
-      extra: { code: 'server_misconfigured', userId },
-    });
     return;
   }
 
@@ -67,12 +60,6 @@ export async function sendWelcomeEmail(data: {
       userId,
     });
   } catch (error) {
-    console.error('events webhook failed welcome email', {
-      code: 'email_send_failed',
-      userId,
-      message: error instanceof Error ? error.message : String(error),
-      error,
-    });
     Sentry.captureException(error, {
       extra: { code: 'email_send_failed', userId },
     });

--- a/app/features/email/welcome-email-service.ts
+++ b/app/features/email/welcome-email-service.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-router';
 import ky from 'ky';
 
 const RESEND_API_URL = 'https://api.resend.com/emails';
@@ -22,10 +23,16 @@ export async function sendWelcomeEmail(data: {
   const resendWelcomeTemplateId = process.env.RESEND_WELCOME_TEMPLATE_ID;
 
   if (!resendApiKey || !resendWelcomeTemplateId) {
+    const err = new Error(
+      'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
+    );
     console.error('events webhook failed welcome email', {
       code: 'server_misconfigured',
-      message: 'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
+      message: err.message,
       userId,
+    });
+    Sentry.captureException(err, {
+      extra: { code: 'server_misconfigured', userId },
     });
     return;
   }
@@ -65,6 +72,9 @@ export async function sendWelcomeEmail(data: {
       userId,
       message: error instanceof Error ? error.message : String(error),
       error,
+    });
+    Sentry.captureException(error, {
+      extra: { code: 'email_send_failed', userId },
     });
   }
 }

--- a/app/features/email/welcome-email-service.ts
+++ b/app/features/email/welcome-email-service.ts
@@ -1,0 +1,70 @@
+import ky from 'ky';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+const EMAIL_FROM = 'Agicash <noreply@emails.agi.cash>';
+const EMAIL_SUBJECT = 'Welcome to Agicash';
+
+export async function sendWelcomeEmail(data: {
+  id: string;
+  email: string | null;
+}): Promise<void> {
+  if (!data.email) {
+    console.info('events webhook skipped welcome email', {
+      code: 'no_email',
+      message: 'User has no email address',
+    });
+    return;
+  }
+
+  const { id: userId, email } = data;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const resendWelcomeTemplateId = process.env.RESEND_WELCOME_TEMPLATE_ID;
+
+  if (!resendApiKey || !resendWelcomeTemplateId) {
+    console.error('events webhook failed welcome email', {
+      code: 'server_misconfigured',
+      message: 'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
+      userId,
+    });
+    return;
+  }
+
+  try {
+    await ky
+      .post(RESEND_API_URL, {
+        headers: {
+          Authorization: `Bearer ${resendApiKey}`,
+          'Idempotency-Key': `welcome-email/${userId}`,
+        },
+        json: {
+          from: EMAIL_FROM,
+          to: [email],
+          subject: EMAIL_SUBJECT,
+          template: {
+            id: resendWelcomeTemplateId,
+            variables: { email },
+          },
+        },
+        retry: {
+          limit: 2,
+          statusCodes: [408, 429, 500, 502, 503, 504],
+          backoffLimit: 3000,
+        },
+        timeout: 10_000,
+      })
+      .json();
+
+    console.info('events webhook sent welcome email', {
+      code: 'email_sent',
+      userId,
+    });
+  } catch (error) {
+    console.error('events webhook failed welcome email', {
+      code: 'email_send_failed',
+      userId,
+      message: error instanceof Error ? error.message : String(error),
+      error,
+    });
+  }
+}

--- a/app/routes/api.events.ts
+++ b/app/routes/api.events.ts
@@ -2,20 +2,13 @@ import { timingSafeEqual } from 'node:crypto';
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha2';
 import { bytesToHex } from '@noble/hashes/utils';
-import ky from 'ky';
 import { z } from 'zod';
 import type { AgicashDbUser } from '~/features/agicash-db/database';
+import { sendWelcomeEmail } from '~/features/email/welcome-email-service';
 import { safeJsonParse } from '~/lib/json';
 import type { Route } from './+types/api.events';
 
-const RESEND_API_URL = 'https://api.resend.com/emails';
-const EMAIL_FROM = 'Agicash <noreply@emails.agi.cash>';
-const EMAIL_SUBJECT = 'Welcome to Agicash';
 const MAX_SIGNATURE_AGE_SECONDS = 300;
-const KNOWN_EVENT_TYPES: Set<string> = new Set([
-  'user.created',
-  'user.upgraded',
-]);
 
 // -- Schemas --
 
@@ -24,25 +17,25 @@ const userDataSchema = z.object({
   email: z.string().nullable(),
 }) satisfies z.ZodType<Pick<AgicashDbUser, 'id' | 'email'>>;
 
-type UserData = Pick<AgicashDbUser, 'id' | 'email'>;
-
-const eventBase = {
-  id: z.string().uuid(),
-  time: z.iso.datetime(),
-};
-
-const eventSchema = z.discriminatedUnion('type', [
+const eventSchema = z.intersection(
   z.object({
-    ...eventBase,
-    type: z.literal('user.created'),
-    data: userDataSchema,
+    id: z.uuid(),
+    time: z.iso.datetime(),
   }),
-  z.object({
-    ...eventBase,
-    type: z.literal('user.upgraded'),
-    data: userDataSchema,
-  }),
-]);
+  z.union([
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('user.created'),
+        data: userDataSchema,
+      }),
+      z.object({
+        type: z.literal('user.upgraded'),
+        data: userDataSchema,
+      }),
+    ]),
+    z.object({ type: z.string(), data: z.unknown() }),
+  ]),
+);
 
 type AppEvent = z.infer<typeof eventSchema>;
 
@@ -53,14 +46,6 @@ function json(body: Record<string, unknown>, status: number) {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
-}
-
-function extractEventType(body: unknown): string | null {
-  if (!body || typeof body !== 'object' || !('type' in body)) {
-    return null;
-  }
-
-  return typeof body.type === 'string' ? body.type : null;
 }
 
 function verifySignature(
@@ -109,74 +94,18 @@ type EventHandler = {
   run: () => Promise<void>;
 };
 
-async function handleWelcomeEmail(data: UserData): Promise<void> {
-  if (!data.email) {
-    console.info('events webhook skipped welcome email', {
-      code: 'no_email',
-      message: 'User has no email address',
-    });
-    return;
-  }
+type KnownEvent = Extract<AppEvent, { type: 'user.created' | 'user.upgraded' }>;
 
-  const { id: userId, email } = data;
-
-  const resendApiKey = process.env.RESEND_API_KEY;
-  const resendWelcomeTemplateId = process.env.RESEND_WELCOME_TEMPLATE_ID;
-
-  if (!resendApiKey || !resendWelcomeTemplateId) {
-    console.error('events webhook failed welcome email', {
-      code: 'server_misconfigured',
-      message: 'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
-      userId,
-    });
-    return;
-  }
-
-  try {
-    await ky
-      .post(RESEND_API_URL, {
-        headers: {
-          Authorization: `Bearer ${resendApiKey}`,
-          'Idempotency-Key': `welcome-email/${userId}`,
-        },
-        json: {
-          from: EMAIL_FROM,
-          to: [email],
-          subject: EMAIL_SUBJECT,
-          template: {
-            id: resendWelcomeTemplateId,
-            variables: { email },
-          },
-        },
-        retry: {
-          limit: 2,
-          statusCodes: [408, 429, 500, 502, 503, 504],
-          backoffLimit: 3000,
-        },
-        timeout: 10_000,
-      })
-      .json();
-
-    console.info('events webhook sent welcome email', {
-      code: 'email_sent',
-      userId,
-    });
-  } catch (error) {
-    console.error('events webhook failed welcome email', {
-      code: 'email_send_failed',
-      userId,
-      message: error instanceof Error ? error.message : String(error),
-      error,
-    });
-  }
+function isKnownEvent(event: AppEvent): event is KnownEvent {
+  return event.type === 'user.created' || event.type === 'user.upgraded';
 }
 
-function getHandlers(event: AppEvent): EventHandler[] {
+function getHandlers(event: KnownEvent): EventHandler[] {
   switch (event.type) {
     case 'user.created':
     case 'user.upgraded':
       return [
-        { name: 'welcome-email', run: () => handleWelcomeEmail(event.data) },
+        { name: 'welcome-email', run: () => sendWelcomeEmail(event.data) },
       ];
   }
 }
@@ -213,22 +142,23 @@ export async function action({ request }: Route.ActionArgs) {
 
   const parsed = eventSchema.safeParse(jsonResult.data);
   if (!parsed.success) {
-    const type = extractEventType(jsonResult.data);
-
-    // Unknown event types return 200 for forward compatibility —
-    // the DB may emit new types before handlers are added
-    if (type && !KNOWN_EVENT_TYPES.has(type)) {
-      console.info('events webhook ignored unknown event type', { type });
-      return json({ ok: true, ignored: true, type }, 200);
-    }
-
-    console.error('events webhook invalid event payload', {
+    console.warn('events webhook invalid event payload', {
       error: z.flattenError(parsed.error),
     });
     return json({ error: 'Invalid event' }, 400);
   }
 
   const event = parsed.data;
+
+  // Unknown event types return 200 for forward compatibility —
+  // the DB may emit new types before handlers are added
+  if (!isKnownEvent(event)) {
+    console.info('events webhook ignored unknown event type', {
+      type: event.type,
+    });
+    return json({ ok: true, ignored: true, type: event.type }, 200);
+  }
+
   const handlers = getHandlers(event);
 
   const settled = await Promise.allSettled(

--- a/app/routes/api.events.ts
+++ b/app/routes/api.events.ts
@@ -1,0 +1,264 @@
+import { timingSafeEqual } from 'node:crypto';
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex } from '@noble/hashes/utils';
+import ky from 'ky';
+import { z } from 'zod';
+import type { AgicashDbUser } from '~/features/agicash-db/database';
+import { safeJsonParse } from '~/lib/json';
+import type { Route } from './+types/api.events';
+
+const RESEND_API_URL = 'https://api.resend.com/emails';
+const EMAIL_FROM = 'Agicash <noreply@emails.agi.cash>';
+const EMAIL_SUBJECT = 'Welcome to Agicash';
+const MAX_SIGNATURE_AGE_SECONDS = 300;
+const KNOWN_EVENT_TYPES: Set<string> = new Set([
+  'user.created',
+  'user.upgraded',
+]);
+
+// -- Schemas --
+
+const userDataSchema = z.object({
+  id: z.string().uuid(),
+  email: z.string().nullable(),
+}) satisfies z.ZodType<Pick<AgicashDbUser, 'id' | 'email'>>;
+
+type UserData = Pick<AgicashDbUser, 'id' | 'email'>;
+
+const eventBase = {
+  id: z.string().uuid(),
+  time: z.iso.datetime(),
+};
+
+const eventSchema = z.discriminatedUnion('type', [
+  z.object({
+    ...eventBase,
+    type: z.literal('user.created'),
+    data: userDataSchema,
+  }),
+  z.object({
+    ...eventBase,
+    type: z.literal('user.upgraded'),
+    data: userDataSchema,
+  }),
+]);
+
+type AppEvent = z.infer<typeof eventSchema>;
+
+// -- Helpers --
+
+function json(body: Record<string, unknown>, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function extractEventType(body: unknown): string | null {
+  if (!body || typeof body !== 'object' || !('type' in body)) {
+    return null;
+  }
+
+  return typeof body.type === 'string' ? body.type : null;
+}
+
+function verifySignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+): { valid: boolean; reason?: string } {
+  const parts = Object.fromEntries(
+    signatureHeader.split(',').map((part) => {
+      const [key, ...rest] = part.trim().split('=');
+      return [key, rest.join('=')];
+    }),
+  );
+
+  const timestamp = parts.t;
+  const signature = parts.v1;
+
+  if (!timestamp || !signature) {
+    return { valid: false, reason: 'Missing timestamp or signature' };
+  }
+
+  const age = Math.floor(Date.now() / 1000) - Number.parseInt(timestamp, 10);
+  if (Number.isNaN(age) || Math.abs(age) > MAX_SIGNATURE_AGE_SECONDS) {
+    return { valid: false, reason: 'Signature expired' };
+  }
+
+  const expected = bytesToHex(hmac(sha256, secret, `${timestamp}.${rawBody}`));
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  const signatureBuffer = Buffer.from(signature, 'utf8');
+
+  if (expectedBuffer.length !== signatureBuffer.length) {
+    return { valid: false, reason: 'Invalid signature' };
+  }
+
+  if (!timingSafeEqual(expectedBuffer, signatureBuffer)) {
+    return { valid: false, reason: 'Invalid signature' };
+  }
+
+  return { valid: true };
+}
+
+// -- Handlers --
+
+type EventHandler = {
+  name: string;
+  run: () => Promise<void>;
+};
+
+async function handleWelcomeEmail(data: UserData): Promise<void> {
+  if (!data.email) {
+    console.info('events webhook skipped welcome email', {
+      code: 'no_email',
+      message: 'User has no email address',
+    });
+    return;
+  }
+
+  const { id: userId, email } = data;
+
+  const resendApiKey = process.env.RESEND_API_KEY;
+  const resendWelcomeTemplateId = process.env.RESEND_WELCOME_TEMPLATE_ID;
+
+  if (!resendApiKey || !resendWelcomeTemplateId) {
+    console.error('events webhook failed welcome email', {
+      code: 'server_misconfigured',
+      message: 'Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID',
+      userId,
+    });
+    return;
+  }
+
+  try {
+    await ky
+      .post(RESEND_API_URL, {
+        headers: {
+          Authorization: `Bearer ${resendApiKey}`,
+          'Idempotency-Key': `welcome-email/${userId}`,
+        },
+        json: {
+          from: EMAIL_FROM,
+          to: [email],
+          subject: EMAIL_SUBJECT,
+          template: {
+            id: resendWelcomeTemplateId,
+            variables: { email },
+          },
+        },
+        retry: {
+          limit: 2,
+          statusCodes: [408, 429, 500, 502, 503, 504],
+          backoffLimit: 3000,
+        },
+        timeout: 10_000,
+      })
+      .json();
+
+    console.info('events webhook sent welcome email', {
+      code: 'email_sent',
+      userId,
+    });
+  } catch (error) {
+    console.error('events webhook failed welcome email', {
+      code: 'email_send_failed',
+      userId,
+      message: error instanceof Error ? error.message : String(error),
+      error,
+    });
+  }
+}
+
+function getHandlers(event: AppEvent): EventHandler[] {
+  switch (event.type) {
+    case 'user.created':
+    case 'user.upgraded':
+      return [
+        { name: 'welcome-email', run: () => handleWelcomeEmail(event.data) },
+      ];
+  }
+}
+
+// -- Action --
+
+export async function action({ request }: Route.ActionArgs) {
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.error('events webhook missing WEBHOOK_SECRET env var');
+    return json({ error: 'Server misconfigured' }, 500);
+  }
+
+  const signatureHeader = request.headers.get('X-Webhook-Signature');
+  if (!signatureHeader) {
+    return json({ error: 'Missing signature' }, 401);
+  }
+
+  const rawBody = await request.text();
+
+  const { valid, reason } = verifySignature(
+    rawBody,
+    signatureHeader,
+    webhookSecret,
+  );
+  if (!valid) {
+    return json({ error: reason ?? 'Unauthorized' }, 401);
+  }
+
+  const jsonResult = safeJsonParse(rawBody);
+  if (!jsonResult.success) {
+    return json({ error: 'Invalid JSON' }, 400);
+  }
+
+  const parsed = eventSchema.safeParse(jsonResult.data);
+  if (!parsed.success) {
+    const type = extractEventType(jsonResult.data);
+
+    // Unknown event types return 200 for forward compatibility —
+    // the DB may emit new types before handlers are added
+    if (type && !KNOWN_EVENT_TYPES.has(type)) {
+      console.info('events webhook ignored unknown event type', { type });
+      return json({ ok: true, ignored: true, type }, 200);
+    }
+
+    console.error('events webhook invalid event payload', {
+      error: z.flattenError(parsed.error),
+    });
+    return json({ error: 'Invalid event' }, 400);
+  }
+
+  const event = parsed.data;
+  const handlers = getHandlers(event);
+
+  const settled = await Promise.allSettled(
+    handlers.map((handler) => handler.run()),
+  );
+  const failedHandlers = settled.flatMap((result, index) =>
+    result.status === 'rejected'
+      ? [
+          {
+            handler: handlers[index]?.name ?? 'unknown',
+            message: String(result.reason),
+          },
+        ]
+      : [],
+  );
+
+  if (failedHandlers.length > 0) {
+    console.error('events webhook handler execution failures', {
+      eventId: event.id,
+      eventType: event.type,
+      failures: failedHandlers,
+    });
+  }
+
+  console.info('events webhook handled event', {
+    eventId: event.id,
+    eventType: event.type,
+    handlerCount: handlers.length,
+    failedHandlerCount: failedHandlers.length,
+  });
+
+  return json({ ok: true }, 200);
+}

--- a/app/routes/api.events.ts
+++ b/app/routes/api.events.ts
@@ -33,7 +33,14 @@ const eventSchema = z.intersection(
         data: userDataSchema,
       }),
     ]),
-    z.object({ type: z.string(), data: z.unknown() }),
+    // Fallback for forward compatibility with unknown event types.
+    // Refine rejects known types so a known type with malformed data fails
+    // the whole parse rather than falling through here as `data: unknown`.
+    z
+      .object({ type: z.string(), data: z.unknown() })
+      .refine((v) => v.type !== 'user.created' && v.type !== 'user.upgraded', {
+        message: 'known event type with invalid data',
+      }),
   ]),
 );
 

--- a/supabase/database.types.ts
+++ b/supabase/database.types.ts
@@ -59,6 +59,21 @@ export type Database = {
           },
         ]
       }
+      app_config: {
+        Row: {
+          key: string
+          value: string
+        }
+        Insert: {
+          key: string
+          value: string
+        }
+        Update: {
+          key?: string
+          value?: string
+        }
+        Relationships: []
+      }
       cashu_proofs: {
         Row: {
           account_id: string

--- a/supabase/migrations/20260413222901_generic_event_system.sql
+++ b/supabase/migrations/20260413222901_generic_event_system.sql
@@ -9,11 +9,21 @@
 -- signed message: <timestamp>.<json_payload>
 --
 -- reads two values at runtime:
---   app.webhook_base_url  — Postgres setting (GUC) holding the base URL of the app
---   webhook_secret        — vault secret holding the shared HMAC secret
+--   wallet.app_config.webhook_base_url  — row holding the base URL of the app
+--   vault secret "webhook_secret"       — shared HMAC secret
 --
 -- local dev is seeded automatically by supabase/seed.sql.
 -- see README "Event system" section for per-environment setup.
+
+-- Table: app_config
+-- key-value store for non-secret runtime configuration. secrets go in vault.
+create table if not exists "wallet"."app_config" (
+  "key" "text" primary key,
+  "value" "text" not null
+);
+
+-- RLS: no client-role access. triggers (security definer) bypass RLS.
+alter table "wallet"."app_config" enable row level security;
 
 create or replace function "wallet"."emit_event"()
 returns "trigger"
@@ -31,7 +41,10 @@ declare
   v_body_text  text;
   v_signature  text;
 begin
-  v_base_url := current_setting('app.webhook_base_url', true);
+  select value into v_base_url
+    from wallet.app_config
+   where key = 'webhook_base_url'
+   limit 1;
 
   select decrypted_secret into v_secret
     from vault.decrypted_secrets
@@ -39,7 +52,7 @@ begin
    limit 1;
 
   if v_base_url is null or v_secret is null then
-    raise warning 'emit_event: configuration missing (app.webhook_base_url setting or webhook_secret vault entry)';
+    raise warning 'emit_event: configuration missing (wallet.app_config.webhook_base_url or webhook_secret vault entry)';
     return coalesce(new, old);
   end if;
 

--- a/supabase/migrations/20260413222901_generic_event_system.sql
+++ b/supabase/migrations/20260413222901_generic_event_system.sql
@@ -1,0 +1,97 @@
+-- generic event system
+--
+-- replaces per-event webhook functions with a single reusable trigger function.
+-- any table can emit events by attaching a trigger that calls wallet.emit_event('event.type').
+--
+-- event envelope: { id, type, time, data }
+-- auth: HMAC-SHA256 signature in X-Webhook-Signature header
+-- format: t=<unix_epoch>,v1=<hex_hmac>
+-- signed message: <timestamp>.<json_payload>
+--
+-- vault secrets required:
+--   webhook_base_url  — base URL of the app (e.g. https://agi.cash)
+--   webhook_secret    — shared HMAC secret
+
+create or replace function wallet.emit_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  _event_type text := TG_ARGV[0];
+  _id         text;
+  _base_url   text;
+  _secret     text;
+  _timestamp  text;
+  _payload    jsonb;
+  _body_text  text;
+  _signature  text;
+begin
+  select decrypted_secret into _base_url
+    from vault.decrypted_secrets
+   where name = 'webhook_base_url'
+   limit 1;
+
+  select decrypted_secret into _secret
+    from vault.decrypted_secrets
+   where name = 'webhook_secret'
+   limit 1;
+
+  if _base_url is null or _secret is null then
+    raise warning 'emit_event: vault secrets missing (webhook_base_url or webhook_secret)';
+    return coalesce(new, old);
+  end if;
+
+  _id := gen_random_uuid()::text;
+  _timestamp := extract(epoch from now())::bigint::text;
+
+  _payload := jsonb_build_object(
+    'id',   _id,
+    'type', _event_type,
+    'time', to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+    'data', row_to_json(coalesce(new, old))
+  );
+
+  -- convert to text once so the same bytes are signed and sent
+  _body_text := _payload::text;
+
+  _signature := encode(
+    extensions.hmac(
+      _timestamp || '.' || _body_text,
+      _secret,
+      'sha256'
+    ),
+    'hex'
+  );
+
+  -- use the text overload so the exact bytes we signed are the exact bytes sent
+  -- (the jsonb overload would round-trip through jsonb serialization)
+  perform net.http_post(
+    url                  := _base_url || '/api/events',
+    body                 := _body_text,
+    content_type         := 'application/json',
+    headers              := jsonb_build_object(
+      'X-Webhook-Signature', 't=' || _timestamp || ',v1=' || _signature
+    ),
+    timeout_milliseconds := 10000
+  );
+
+  return coalesce(new, old);
+
+exception when others then
+  raise warning 'emit_event(%): failed to send webhook: %', _event_type, sqlerrm;
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger on_user_created
+  after insert on wallet.users
+  for each row
+  execute function wallet.emit_event('user.created');
+
+create trigger on_user_upgraded
+  after update of email on wallet.users
+  for each row
+  when (old.email is null and new.email is not null)
+  execute function wallet.emit_event('user.upgraded');

--- a/supabase/migrations/20260413222901_generic_event_system.sql
+++ b/supabase/migrations/20260413222901_generic_event_system.sql
@@ -93,7 +93,10 @@ begin
   return coalesce(new, old);
 
 exception when others then
-  raise warning 'emit_event(%): failed to send webhook: %', v_event_type, sqlerrm;
+  -- catches errors from config reads, hmac signing, or net.http_post
+  -- argument validation. actual delivery failures (timeout, HTTP errors,
+  -- DNS) are async and recorded in net._http_response, not here.
+  raise warning 'emit_event(%): failed to queue webhook: %', v_event_type, sqlerrm;
   return coalesce(new, old);
 end;
 $function$;

--- a/supabase/migrations/20260413222901_generic_event_system.sql
+++ b/supabase/migrations/20260413222901_generic_event_system.sql
@@ -8,58 +8,58 @@
 -- format: t=<unix_epoch>,v1=<hex_hmac>
 -- signed message: <timestamp>.<json_payload>
 --
--- vault secrets required:
---   webhook_base_url  — base URL of the app (e.g. https://agi.cash)
---   webhook_secret    — shared HMAC secret
+-- reads two values at runtime:
+--   app.webhook_base_url  — Postgres setting (GUC) holding the base URL of the app
+--   webhook_secret        — vault secret holding the shared HMAC secret
+--
+-- local dev is seeded automatically by supabase/seed.sql.
+-- see README "Event system" section for per-environment setup.
 
-create or replace function wallet.emit_event()
-returns trigger
+create or replace function "wallet"."emit_event"()
+returns "trigger"
 language plpgsql
 security definer
 set search_path = ''
-as $$
+as $function$
 declare
-  _event_type text := TG_ARGV[0];
-  _id         text;
-  _base_url   text;
-  _secret     text;
-  _timestamp  text;
-  _payload    jsonb;
-  _body_text  text;
-  _signature  text;
+  v_event_type text := TG_ARGV[0];
+  v_id         text;
+  v_base_url   text;
+  v_secret     text;
+  v_timestamp  text;
+  v_payload    jsonb;
+  v_body_text  text;
+  v_signature  text;
 begin
-  select decrypted_secret into _base_url
-    from vault.decrypted_secrets
-   where name = 'webhook_base_url'
-   limit 1;
+  v_base_url := current_setting('app.webhook_base_url', true);
 
-  select decrypted_secret into _secret
+  select decrypted_secret into v_secret
     from vault.decrypted_secrets
    where name = 'webhook_secret'
    limit 1;
 
-  if _base_url is null or _secret is null then
-    raise warning 'emit_event: vault secrets missing (webhook_base_url or webhook_secret)';
+  if v_base_url is null or v_secret is null then
+    raise warning 'emit_event: configuration missing (app.webhook_base_url setting or webhook_secret vault entry)';
     return coalesce(new, old);
   end if;
 
-  _id := gen_random_uuid()::text;
-  _timestamp := extract(epoch from now())::bigint::text;
+  v_id := gen_random_uuid()::text;
+  v_timestamp := extract(epoch from now())::bigint::text;
 
-  _payload := jsonb_build_object(
-    'id',   _id,
-    'type', _event_type,
+  v_payload := jsonb_build_object(
+    'id',   v_id,
+    'type', v_event_type,
     'time', to_char(now() at time zone 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
     'data', row_to_json(coalesce(new, old))
   );
 
   -- convert to text once so the same bytes are signed and sent
-  _body_text := _payload::text;
+  v_body_text := v_payload::text;
 
-  _signature := encode(
+  v_signature := encode(
     extensions.hmac(
-      _timestamp || '.' || _body_text,
-      _secret,
+      v_timestamp || '.' || v_body_text,
+      v_secret,
       'sha256'
     ),
     'hex'
@@ -68,11 +68,11 @@ begin
   -- use the text overload so the exact bytes we signed are the exact bytes sent
   -- (the jsonb overload would round-trip through jsonb serialization)
   perform net.http_post(
-    url                  := _base_url || '/api/events',
-    body                 := _body_text,
+    url                  := v_base_url || '/api/events',
+    body                 := v_body_text,
     content_type         := 'application/json',
     headers              := jsonb_build_object(
-      'X-Webhook-Signature', 't=' || _timestamp || ',v1=' || _signature
+      'X-Webhook-Signature', 't=' || v_timestamp || ',v1=' || v_signature
     ),
     timeout_milliseconds := 10000
   );
@@ -80,18 +80,18 @@ begin
   return coalesce(new, old);
 
 exception when others then
-  raise warning 'emit_event(%): failed to send webhook: %', _event_type, sqlerrm;
+  raise warning 'emit_event(%): failed to send webhook: %', v_event_type, sqlerrm;
   return coalesce(new, old);
 end;
-$$;
+$function$;
 
 create trigger on_user_created
-  after insert on wallet.users
+  after insert on "wallet"."users"
   for each row
-  execute function wallet.emit_event('user.created');
+  execute function "wallet"."emit_event"('user.created');
 
 create trigger on_user_upgraded
-  after update of email on wallet.users
+  after update of email on "wallet"."users"
   for each row
   when (old.email is null and new.email is not null)
-  execute function wallet.emit_event('user.upgraded');
+  execute function "wallet"."emit_event"('user.upgraded');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -8,7 +8,7 @@ update "wallet"."feature_flags" set "enabled" = true where "key" in (
   'DEBUG_LOGGING_SPARK'
 );
 
--- Dev-default vault secrets for the event system (webhook triggers)
+-- Dev-default config for the event system (webhook triggers)
 -- These are fake values for local development only — never use in production.
-select vault.create_secret('http://127.0.0.1:3000', 'webhook_base_url', 'Base URL for webhook event delivery');
+alter database postgres set app.webhook_base_url = 'http://127.0.0.1:3000';
 select vault.create_secret('dev-webhook-secret', 'webhook_secret', 'HMAC shared secret for webhook signatures');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -7,3 +7,8 @@ update "wallet"."feature_flags" set "enabled" = true where "key" in (
   'GIFT_CARDS',
   'DEBUG_LOGGING_SPARK'
 );
+
+-- Dev-default vault secrets for the event system (webhook triggers)
+-- These are fake values for local development only — never use in production.
+select vault.create_secret('http://127.0.0.1:3000', 'webhook_base_url', 'Base URL for webhook event delivery');
+select vault.create_secret('dev-webhook-secret', 'webhook_secret', 'HMAC shared secret for webhook signatures');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -10,5 +10,5 @@ update "wallet"."feature_flags" set "enabled" = true where "key" in (
 
 -- Dev-default config for the event system (webhook triggers)
 -- These are fake values for local development only — never use in production.
-alter database postgres set app.webhook_base_url = 'http://127.0.0.1:3000';
+insert into "wallet"."app_config" ("key", "value") values ('webhook_base_url', 'http://127.0.0.1:3000');
 select vault.create_secret('dev-webhook-secret', 'webhook_secret', 'HMAC shared secret for webhook signatures');


### PR DESCRIPTION
## Summary

- Adds a reusable DB trigger function (`wallet.emit_event`) that any table can use to emit typed events via webhook
- API route (`/api/events`) verifies HMAC-SHA256 signatures and dispatches to handlers
- Event envelope: `{ id, type, time, data }` — close to CloudEvents, typed with Zod discriminated union
- First handler: welcome email via Resend on `user.created` / `user.upgraded`

### Signing

- HMAC-SHA256 with Stripe-style `t=<epoch>,v1=<hex>` header
- Uses pg_net text overload so the exact bytes signed are the exact bytes sent (no jsonb round-trip)
- Integer epoch timestamp avoids ambiguous dot separator
- Verification uses `crypto.timingSafeEqual`
- 
