### PR TITLE
feat: gift-card mint terms of service gate (option A)

### DIFF
--- a/app/features/gift-cards/add-gift-card.tsx
+++ b/app/features/gift-cards/add-gift-card.tsx
@@ -19,6 +19,9 @@ import {
   WalletCardBackgroundImage,
 } from '~/components/wallet-card';
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
+import { AcceptTerms } from '~/features/user/accept-terms';
+import { shouldAcceptGiftCardMintTerms } from '~/features/user/user';
+import { useUpdateUser, useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
 import type { Currency } from '~/lib/money';
 import type { GiftCardInfo } from './use-discover-cards';
@@ -52,10 +55,13 @@ type AddGiftCardProps = {
  */
 export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   const [isAdding, setIsAdding] = useState(false);
+  const [showTerms, setShowTerms] = useState(false);
   const addGiftCard = useAddGiftCard();
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
+  const user = useUser();
+  const { mutateAsync: updateUser } = useUpdateUser();
   const isTransitioning = useViewTransitionState('/gift-cards');
 
   const handleBack = () => {
@@ -65,7 +71,7 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
     });
   };
 
-  const handleAddCard = async () => {
+  const runAdd = async () => {
     setIsAdding(true);
     try {
       await addGiftCard({
@@ -91,6 +97,47 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
       setIsAdding(false);
     }
   };
+
+  const handleAddCard = async () => {
+    if (shouldAcceptGiftCardMintTerms(user)) {
+      setShowTerms(true);
+      return;
+    }
+    await runAdd();
+  };
+
+  if (showTerms) {
+    return (
+      <Page>
+        <PageContent className="justify-center">
+          <AcceptTerms
+            requireWalletTerms={false}
+            requireGiftCardMintTerms
+            onAccept={async () => {
+              setIsAdding(true);
+              try {
+                await updateUser({
+                  giftCardMintTermsAcceptedAt: new Date().toISOString(),
+                });
+              } catch {
+                setIsAdding(false);
+                toast({
+                  title: 'Error',
+                  description: 'Failed to accept terms. Please try again.',
+                  variant: 'destructive',
+                });
+                return;
+              }
+              setShowTerms(false);
+              await runAdd();
+            }}
+            onBack={() => setShowTerms(false)}
+            loading={isAdding}
+          />
+        </PageContent>
+      </Page>
+    );
+  }
 
   return (
     <Page className="relative">

--- a/app/features/gift-cards/add-gift-card.tsx
+++ b/app/features/gift-cards/add-gift-card.tsx
@@ -21,7 +21,7 @@ import {
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
 import { AcceptTerms } from '~/features/user/accept-terms';
 import { shouldAcceptGiftCardMintTerms } from '~/features/user/user';
-import { useUpdateUser, useUser } from '~/features/user/user-hooks';
+import { useAcceptTerms, useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
 import type { Currency } from '~/lib/money';
 import type { GiftCardInfo } from './use-discover-cards';
@@ -61,7 +61,7 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   const location = useLocation();
   const { toast } = useToast();
   const user = useUser();
-  const { mutateAsync: updateUser } = useUpdateUser();
+  const acceptTerms = useAcceptTerms();
   const isTransitioning = useViewTransitionState('/gift-cards');
 
   const handleBack = () => {
@@ -116,9 +116,7 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
             onAccept={async () => {
               setIsAdding(true);
               try {
-                await updateUser({
-                  giftCardMintTermsAcceptedAt: new Date().toISOString(),
-                });
+                await acceptTerms({ giftCardTerms: true });
               } catch {
                 setIsAdding(false);
                 toast({

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -45,6 +45,8 @@ import {
   pendingGiftCardMintTermsStorage,
   pendingWalletTermsStorage,
 } from '../user/pending-terms-storage';
+import { shouldAcceptGiftCardMintTerms } from '../user/user';
+import { useUpdateUser, useUser } from '../user/user-hooks';
 import { useCreateCashuReceiveSwap } from './cashu-receive-swap-hooks';
 import {
   useCashuTokenWithClaimableProofs,
@@ -130,6 +132,10 @@ export default function ReceiveToken({
     addAndSetReceiveAccount,
   } = useReceiveCashuTokenAccounts(token, preferredReceiveAccountId);
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
+  const user = useUser();
+  const { mutateAsync: updateUser } = useUpdateUser();
+  const [showTerms, setShowTerms] = useState(false);
+  const [isAcceptingTerms, setIsAcceptingTerms] = useState(false);
 
   const isReceiveAccountKnown = receiveAccount?.isUnknown === false;
 
@@ -199,6 +205,66 @@ export default function ReceiveToken({
     },
   });
 
+  const isClaimLoading =
+    claimTokenStatus === 'pending' || claimTokenStatus === 'success';
+
+  const runClaim = () => {
+    if (!claimableToken || !receiveAccount) return;
+    claimTokenMutation({
+      token: claimableToken,
+      sourceAccount,
+      receiveAccount,
+    });
+  };
+
+  const handleClaim = () => {
+    if (!claimableToken || !receiveAccount) {
+      return;
+    }
+
+    if (
+      accountRequiresGiftCardTermsAcceptance(sourceAccount) &&
+      shouldAcceptGiftCardMintTerms(user)
+    ) {
+      setShowTerms(true);
+      return;
+    }
+
+    runClaim();
+  };
+
+  if (showTerms) {
+    return (
+      <PageContent className="justify-center">
+        <AcceptTerms
+          requireWalletTerms={false}
+          requireGiftCardMintTerms
+          onAccept={async () => {
+            setIsAcceptingTerms(true);
+            try {
+              await updateUser({
+                giftCardMintTermsAcceptedAt: new Date().toISOString(),
+              });
+            } catch {
+              setIsAcceptingTerms(false);
+              toast({
+                title: 'Failed to accept terms',
+                description: 'Please try again',
+                variant: 'destructive',
+              });
+              return;
+            }
+            setShowTerms(false);
+            setIsAcceptingTerms(false);
+            runClaim();
+          }}
+          onBack={() => setShowTerms(false)}
+          loading={isClaimLoading || isAcceptingTerms}
+        />
+      </PageContent>
+    );
+  }
+
   return (
     <>
       <PageHeader className="z-10">
@@ -263,18 +329,10 @@ export default function ReceiveToken({
         <PageFooter className="pb-14">
           <Button
             disabled={receiveAccount.isSelectable === false}
-            onClick={() => {
-              claimTokenMutation({
-                token: claimableToken,
-                sourceAccount,
-                receiveAccount,
-              });
-            }}
+            onClick={handleClaim}
             className="w-[200px]"
             // loading while the mutation is running or while waiting for navigation after mutation success
-            loading={
-              claimTokenStatus === 'pending' || claimTokenStatus === 'success'
-            }
+            loading={isClaimLoading}
           >
             {isReceiveAccountKnown ? 'Claim' : 'Add Mint and Claim'}
           </Button>

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -46,7 +46,7 @@ import {
   pendingWalletTermsStorage,
 } from '../user/pending-terms-storage';
 import { shouldAcceptGiftCardMintTerms } from '../user/user';
-import { useUpdateUser, useUser } from '../user/user-hooks';
+import { useAcceptTerms, useUser } from '../user/user-hooks';
 import { useCreateCashuReceiveSwap } from './cashu-receive-swap-hooks';
 import {
   useCashuTokenWithClaimableProofs,
@@ -135,7 +135,7 @@ export default function ReceiveToken({
   } = useReceiveCashuTokenAccounts(token, preferredReceiveAccountId);
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
   const user = useUser();
-  const { mutateAsync: updateUser } = useUpdateUser();
+  const acceptTerms = useAcceptTerms();
   const [step, setStep] = useState<ReceiveStep>('show-claim');
   const [isAcceptingTerms, setIsAcceptingTerms] = useState(false);
 
@@ -245,9 +245,7 @@ export default function ReceiveToken({
           onAccept={async () => {
             setIsAcceptingTerms(true);
             try {
-              await updateUser({
-                giftCardMintTermsAcceptedAt: new Date().toISOString(),
-              });
+              await acceptTerms({ giftCardTerms: true });
             } catch {
               setIsAcceptingTerms(false);
               toast({

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -66,6 +66,8 @@ type Props = {
   preferredReceiveAccountId?: string;
 };
 
+type ReceiveStep = 'show-claim' | 'accept-terms';
+
 /**
  * Shared component for displaying the token amount with copy functionality
  */
@@ -134,7 +136,7 @@ export default function ReceiveToken({
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
   const user = useUser();
   const { mutateAsync: updateUser } = useUpdateUser();
-  const [showTerms, setShowTerms] = useState(false);
+  const [step, setStep] = useState<ReceiveStep>('show-claim');
   const [isAcceptingTerms, setIsAcceptingTerms] = useState(false);
 
   const isReceiveAccountKnown = receiveAccount?.isUnknown === false;
@@ -205,6 +207,7 @@ export default function ReceiveToken({
     },
   });
 
+  // loading while the mutation is running or while waiting for navigation after mutation success
   const isClaimLoading =
     claimTokenStatus === 'pending' || claimTokenStatus === 'success';
 
@@ -226,14 +229,14 @@ export default function ReceiveToken({
       accountRequiresGiftCardTermsAcceptance(sourceAccount) &&
       shouldAcceptGiftCardMintTerms(user)
     ) {
-      setShowTerms(true);
+      setStep('accept-terms');
       return;
     }
 
     runClaim();
   };
 
-  if (showTerms) {
+  if (step === 'accept-terms') {
     return (
       <PageContent className="justify-center">
         <AcceptTerms
@@ -254,11 +257,11 @@ export default function ReceiveToken({
               });
               return;
             }
-            setShowTerms(false);
+            setStep('show-claim');
             setIsAcceptingTerms(false);
             runClaim();
           }}
-          onBack={() => setShowTerms(false)}
+          onBack={() => setStep('show-claim')}
           loading={isClaimLoading || isAcceptingTerms}
         />
       </PageContent>
@@ -331,7 +334,6 @@ export default function ReceiveToken({
             disabled={receiveAccount.isSelectable === false}
             onClick={handleClaim}
             className="w-[200px]"
-            // loading while the mutation is running or while waiting for navigation after mutation success
             loading={isClaimLoading}
           >
             {isReceiveAccountKnown ? 'Claim' : 'Add Mint and Claim'}

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -195,7 +195,7 @@ export const useVerifyEmail = (): ((code: string) => Promise<void>) => {
   return mutateAsync;
 };
 
-export const useUpdateUser = () => {
+const useUpdateUser = () => {
   const queryClient = useQueryClient();
   const userId = useUser((user) => user.id);
   const userRepository = useWriteUserRepository();
@@ -238,6 +238,24 @@ export const useUpdateUsername = () => {
 
   return useCallback(
     (username: string) => updateUser({ username }),
+    [updateUser],
+  );
+};
+
+export const useAcceptTerms = () => {
+  const { mutateAsync: updateUser } = useUpdateUser();
+
+  return useCallback(
+    ({
+      walletTerms,
+      giftCardTerms,
+    }: { walletTerms?: boolean; giftCardTerms?: boolean }) => {
+      const now = new Date().toISOString();
+      const updates: UpdateUser = {};
+      if (walletTerms) updates.termsAcceptedAt = now;
+      if (giftCardTerms) updates.giftCardMintTermsAcceptedAt = now;
+      return updateUser(updates);
+    },
     [updateUser],
   );
 };

--- a/app/routes/_protected.accept-terms.tsx
+++ b/app/routes/_protected.accept-terms.tsx
@@ -6,7 +6,7 @@ import { useSignOut } from '~/features/user/auth';
 import { shouldAcceptTerms } from '~/features/user/user';
 import {
   getUserFromCacheOrThrow,
-  useUpdateUser,
+  useAcceptTerms,
 } from '~/features/user/user-hooks';
 import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
@@ -33,7 +33,7 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
 
 export default function AcceptTermsRoute() {
   const { toast } = useToast();
-  const { mutateAsync: updateUser } = useUpdateUser();
+  const acceptTerms = useAcceptTerms();
   const { signOut, isSigningOut } = useSignOut();
   const navigate = useNavigate();
   const { redirectTo } = useRedirectTo('/');
@@ -42,7 +42,7 @@ export default function AcceptTermsRoute() {
   const handleAccept = async () => {
     setIsAccepting(true);
     try {
-      await updateUser({ termsAcceptedAt: new Date().toISOString() });
+      await acceptTerms({ walletTerms: true });
       navigate(`${redirectTo}${window.location.hash}`);
     } catch (e) {
       console.error('Failed to accept terms', { cause: e });


### PR DESCRIPTION
## Summary

Mints with \`purpose=gift-card\` or \`offer\` now require a separate terms-of-service acceptance before a user can add the account or claim a token that would create one. Wallet terms (the existing \`/accept-terms\` route) are unchanged.

**Alternative to #1006** — same feature, same infrastructure (stacked on #988), but the click gates render \`<AcceptTerms>\` **inline** on the action page instead of navigating to \`/accept-terms?requireGiftCardMintTerms=true\`. A local \`showTerms\` flag flips the same screen into the terms prompt; \`onAccept\` writes the timestamp and runs the queued action in one closure — no navigation, no re-tap.

Tradeoff vs #1006: one fewer round-trip in the click-gate flow, but two places in the app now know how to render \`<AcceptTerms>\` (the route and the click gates) instead of one.

## Changes

- **Click-gated flows** (\`AddGiftCard\`, \`ReceiveToken\`): if \`accountRequiresGiftCardTermsAcceptance(sourceAccount) && shouldAcceptGiftCardMintTerms(user)\`, the action (\`runAdd\` / \`runClaim\`) is deferred and \`setShowTerms(true)\` is called. \`showTerms\` gates an early return that renders \`<AcceptTerms requireWalletTerms={false} requireGiftCardMintTerms />\`. \`onAccept\` calls \`useUpdateUser\` with \`giftCardMintTermsAcceptedAt\` and then invokes the original \`run*\` action.
- **Double-submit guard**: \`AddGiftCard\` extends its existing \`isAdding\` flag through the terms step; \`ReceiveToken\` uses a local \`isAcceptingTerms\` flag (since its loading state is derived from the mutation status and doesn't cover the preceding \`updateUser\` call).
- \`/accept-terms\` route stays wallet-terms-only — the only case that genuinely needs a route (layout middleware can't render a component); click gates don't have that constraint.
- Public guest flows (\`SignupOptions\`, \`PublicReceiveCashuToken\`) still use \`pendingTermsStorage\` since no user record exists yet at signup time. That's infrastructure on #988, not this PR.

## Test plan

- [ ] Existing user, gift-card-mint terms not accepted: tap card → Add → inline terms screen → accept → card adds (no re-tap, no navigation)
- [ ] Same with token claim from a gift-card mint token
- [ ] Existing user with gift-card-mint terms already accepted: Add / Claim straight through, no terms screen
- [ ] Existing user, non-gift-card mint token: Claim straight through, no terms screen
- [ ] Back on the inline terms step: returns to the action page, no state loss, card/token still selected
- [ ] Google OAuth new user: lands on \`/accept-terms\` → only wallet-terms checkbox → Back signs out; Continue writes \`termsAcceptedAt\` and lands on home
- [ ] Signup via email/Google from a gift-card token link: signup form shows both checkboxes (infrastructure on #988)
- [ ] Guest claim from a gift-card token link: \`PublicReceiveCashuToken\` inline terms shows both checkboxes (infrastructure on #988)
- [ ] Error mid-accept (network fails during \`updateUser\`): toast, stay on terms screen, button not stuck in loading
- [ ] Double-tap Continue during \`updateUser\` latency: button disabled, no duplicate mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)