### PR TITLE
feat: gate gift-card mint terms via /accept-terms route (option B)

### DIFF
--- a/app/features/gift-cards/add-gift-card.tsx
+++ b/app/features/gift-cards/add-gift-card.tsx
@@ -19,6 +19,8 @@ import {
   WalletCardBackgroundImage,
 } from '~/components/wallet-card';
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
+import { shouldAcceptGiftCardMintTerms } from '~/features/user/user';
+import { useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
 import type { Currency } from '~/lib/money';
 import type { GiftCardInfo } from './use-discover-cards';
@@ -56,6 +58,7 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
+  const user = useUser();
   const isTransitioning = useViewTransitionState('/gift-cards');
 
   const handleBack = () => {
@@ -66,6 +69,15 @@ export function AddGiftCard({ giftCard }: AddGiftCardProps) {
   };
 
   const handleAddCard = async () => {
+    if (shouldAcceptGiftCardMintTerms(user)) {
+      const searchParams = new URLSearchParams({
+        redirectTo: window.location.pathname,
+        requireGiftCardMintTerms: 'true',
+      });
+      navigate(`/accept-terms?${searchParams.toString()}`);
+      return;
+    }
+
     setIsAdding(true);
     try {
       await addGiftCard({

--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -45,6 +45,8 @@ import {
   pendingGiftCardMintTermsStorage,
   pendingWalletTermsStorage,
 } from '../user/pending-terms-storage';
+import { shouldAcceptGiftCardMintTerms } from '../user/user';
+import { useUser } from '../user/user-hooks';
 import { useCreateCashuReceiveSwap } from './cashu-receive-swap-hooks';
 import {
   useCashuTokenWithClaimableProofs,
@@ -130,8 +132,36 @@ export default function ReceiveToken({
     addAndSetReceiveAccount,
   } = useReceiveCashuTokenAccounts(token, preferredReceiveAccountId);
   const giftCard = getGiftCardByUrl(sourceAccount.mintUrl);
+  const user = useUser();
 
   const isReceiveAccountKnown = receiveAccount?.isUnknown === false;
+
+  const handleClaim = () => {
+    if (!claimableToken || !receiveAccount) {
+      return;
+    }
+
+    if (
+      accountRequiresGiftCardTermsAcceptance(sourceAccount) &&
+      shouldAcceptGiftCardMintTerms(user)
+    ) {
+      const linkTo = buildLinkWithSearchParams('/accept-terms', {
+        requireGiftCardMintTerms: 'true',
+        redirectTo: window.location.pathname,
+      });
+      navigate(
+        { ...linkTo, hash: window.location.hash },
+        { transition: 'slideUp', applyTo: 'newView' },
+      );
+      return;
+    }
+
+    claimTokenMutation({
+      token: claimableToken,
+      sourceAccount,
+      receiveAccount,
+    });
+  };
 
   const { mutateAsync: createCashuReceiveSwap } = useCreateCashuReceiveSwap();
   const { mutateAsync: createCrossAccountReceiveQuotes } =
@@ -199,6 +229,9 @@ export default function ReceiveToken({
     },
   });
 
+  const isClaimLoading =
+    claimTokenStatus === 'pending' || claimTokenStatus === 'success';
+
   return (
     <>
       <PageHeader className="z-10">
@@ -263,18 +296,10 @@ export default function ReceiveToken({
         <PageFooter className="pb-14">
           <Button
             disabled={receiveAccount.isSelectable === false}
-            onClick={() => {
-              claimTokenMutation({
-                token: claimableToken,
-                sourceAccount,
-                receiveAccount,
-              });
-            }}
+            onClick={handleClaim}
             className="w-[200px]"
             // loading while the mutation is running or while waiting for navigation after mutation success
-            loading={
-              claimTokenStatus === 'pending' || claimTokenStatus === 'success'
-            }
+            loading={isClaimLoading}
           >
             {isReceiveAccountKnown ? 'Claim' : 'Add Mint and Claim'}
           </Button>

--- a/app/routes/_protected.accept-terms.tsx
+++ b/app/routes/_protected.accept-terms.tsx
@@ -1,13 +1,18 @@
 import { useState } from 'react';
-import { redirect, useNavigate } from 'react-router';
+import { redirect, useNavigate, useSearchParams } from 'react-router';
 import { Page, PageContent } from '~/components/page';
 import { AcceptTerms } from '~/features/user/accept-terms';
 import { useSignOut } from '~/features/user/auth';
-import { shouldAcceptTerms } from '~/features/user/user';
+import {
+  shouldAcceptGiftCardMintTerms,
+  shouldAcceptTerms,
+} from '~/features/user/user';
 import {
   getUserFromCacheOrThrow,
   useUpdateUser,
+  useUser,
 } from '~/features/user/user-hooks';
+import type { UpdateUser } from '~/features/user/user-repository';
 import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
 import type { Route } from './+types/_protected.accept-terms';
@@ -17,9 +22,15 @@ const acceptTermsRouteGuard: Route.ClientMiddlewareFunction = async (
   next,
 ) => {
   const user = getUserFromCacheOrThrow();
+  const location = new URL(request.url);
+  const requireGiftCardMintTerms =
+    location.searchParams.get('requireGiftCardMintTerms') === 'true';
 
-  if (!shouldAcceptTerms(user)) {
-    const location = new URL(request.url);
+  const userMustAcceptWalletTerms = shouldAcceptTerms(user);
+  const userMustAcceptGiftCardMintTerms =
+    requireGiftCardMintTerms && shouldAcceptGiftCardMintTerms(user);
+
+  if (!userMustAcceptWalletTerms && !userMustAcceptGiftCardMintTerms) {
     const redirectTo = location.searchParams.get('redirectTo') || '/';
     throw redirect(`${redirectTo}${window.location.hash}`);
   }
@@ -33,16 +44,30 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
 
 export default function AcceptTermsRoute() {
   const { toast } = useToast();
+  const user = useUser();
   const { mutateAsync: updateUser } = useUpdateUser();
   const { signOut, isSigningOut } = useSignOut();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { redirectTo } = useRedirectTo('/');
   const [isAccepting, setIsAccepting] = useState(false);
+
+  const requireGiftCardMintTerms =
+    searchParams.get('requireGiftCardMintTerms') === 'true';
+  const userMustAcceptWalletTerms = shouldAcceptTerms(user);
+  const userMustAcceptGiftCardMintTerms =
+    requireGiftCardMintTerms && shouldAcceptGiftCardMintTerms(user);
 
   const handleAccept = async () => {
     setIsAccepting(true);
     try {
-      await updateUser({ termsAcceptedAt: new Date().toISOString() });
+      const now = new Date().toISOString();
+      const updates: UpdateUser = {};
+      if (userMustAcceptWalletTerms) updates.termsAcceptedAt = now;
+      if (userMustAcceptGiftCardMintTerms) {
+        updates.giftCardMintTermsAcceptedAt = now;
+      }
+      await updateUser(updates);
       navigate(`${redirectTo}${window.location.hash}`);
     } catch (e) {
       console.error('Failed to accept terms', { cause: e });
@@ -60,10 +85,14 @@ export default function AcceptTermsRoute() {
     <Page>
       <PageContent className="justify-center">
         <AcceptTerms
-          requireWalletTerms
-          requireGiftCardMintTerms={false}
+          requireWalletTerms={userMustAcceptWalletTerms}
+          requireGiftCardMintTerms={userMustAcceptGiftCardMintTerms}
           onAccept={handleAccept}
-          onBack={signOut}
+          // The wallet-terms gate fires for users who arrived here without
+          // going through the signup form (primarily new users from Google
+          // OAuth login). They have no meaningful "back" — layout middleware
+          // would just loop them — so Back signs them out.
+          onBack={userMustAcceptWalletTerms ? signOut : () => navigate(-1)}
           loading={isAccepting || isSigningOut}
         />
       </PageContent>


### PR DESCRIPTION
## Summary

Mints with \`purpose=gift-card\` or \`offer\` now require a separate terms-of-service acceptance before a user can add the account or claim a token that would create one. Wallet terms (the existing \`/accept-terms\` route) are unchanged.

**Alternative to #1005** — same feature, same infrastructure (stacked on #988), but the click gates **navigate to \`/accept-terms?requireGiftCardMintTerms=true\`** instead of rendering \`<AcceptTerms>\` inline. The existing wallet-terms route is extended to also handle gift-card-mint terms, driven by the URL flag.

Tradeoff vs #1005: one consent screen for the whole app (layout + click gates both route through it), but accept → navigate back → re-tap Continue is an extra step.

## Changes

- **Click gates** (\`AddGiftCard\`, \`ReceiveToken\`): if \`accountRequiresGiftCardTermsAcceptance(sourceAccount) && shouldAcceptGiftCardMintTerms(user)\`, navigate to \`/accept-terms\` with \`redirectTo=<current pathname>\` and \`requireGiftCardMintTerms=true\` instead of firing the action. Guest-signup paths (\`SignupOptions\`, \`PublicReceiveCashuToken\`) keep their inline \`<AcceptTerms>\` step since no user record exists yet.
- **\`/accept-terms\` route**: route guard reads the URL flag and checks both \`shouldAcceptTerms\` (wallet) and \`shouldAcceptGiftCardMintTerms\` (gift-card-mint, only if flag is set); redirects away only if neither is pending. Component reads the same flag, passes dynamic \`requireWalletTerms\`/\`requireGiftCardMintTerms\` to \`<AcceptTerms>\`, and writes all pending timestamps in a single \`useUpdateUser\` mutation.
- **Back button** on \`/accept-terms\`: signs out when wallet terms are pending (user landed here without signing the baseline — primarily new Google OAuth); otherwise \`navigate(-1)\` back to the triggering screen.

## Test plan

- [ ] Existing user, gift-card-mint terms not accepted: Add gift card → redirects to \`/accept-terms?requireGiftCardMintTerms=true&redirectTo=/gift-cards/...\` with one checkbox (gift-card-mint) → accept → navigates back to the Add screen → tap Add again → card adds
- [ ] Same with token claim from a gift-card mint token
- [ ] Existing user with gift-card-mint terms already accepted: Add / Claim straight through, no redirect
- [ ] Existing user, non-gift-card mint token: Claim straight through, no redirect
- [ ] New Google OAuth user (no wallet terms yet) who then hits a gift-card click gate: \`/accept-terms?requireGiftCardMintTerms=true\` shows **both** checkboxes; accepting writes both timestamps in one mutation
- [ ] New Google OAuth user landing on \`/accept-terms\` without the flag (normal login flow): only wallet checkbox; Back signs out
- [ ] Existing user with wallet terms already accepted, hits \`/accept-terms?requireGiftCardMintTerms=true\`: only gift-card-mint checkbox; Back is \`navigate(-1)\` (no sign-out)
- [ ] \`/accept-terms\` with no flag, for a user who already accepted wallet terms: guard redirects away immediately
- [ ] Error during \`updateUser\`: toast, stay on screen, button not stuck in loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)