### PR TITLE
fix: normalize mint URL in offer card image lookup

### DIFF
--- a/app/features/gift-cards/offer-card-images.ts
+++ b/app/features/gift-cards/offer-card-images.ts
@@ -8,7 +8,10 @@ const OFFER_CARD_IMAGES: Record<string, string> = {
 
 /**
  * Returns the offer card image for a given mint URL, if one exists.
+ * Normalizes the URL (lowercase + strip trailing slashes) so variations
+ * entered by users resolve to the same key.
  */
 export function getOfferCardImageByUrl(url: string): string | undefined {
-  return OFFER_CARD_IMAGES[url];
+  const normalized = url.toLowerCase().replace(/\/+$/, '');
+  return OFFER_CARD_IMAGES[normalized];
 }


### PR DESCRIPTION
## Summary
- Fixes a latent bug where offer card images didn't render for accounts whose `mintUrl` differed from the registry key by trailing slash or case
- Repro: a mint added via the UI with URL `https://squarealpha0421.agi.cash/` (trailing slash) did not render the offer image that PR #1007 added
- Root cause: `getOfferCardImageByUrl` did a plain `OFFER_CARD_IMAGES[url]` lookup; `add-mint-form.tsx` stores the URL as typed without normalization

## Fix
- Normalize the lookup argument: `url.toLowerCase().replace(/\/+$/, '')`
- Matches the existing normalization pattern in `app/lib/cashu/utils.ts`
- Registry keys are unchanged (no trailing slash)

## Test plan
- [ ] In the UI, add `https://squarealpha0421.agi.cash/` (with slash) and verify the offer card image renders on the gift-cards list
- [ ] Same for `https://squarealpha0421.agi.cash` (no slash)
- [ ] Biome + tsc pass on the edited file