### PR TITLE
fix(receive): use random outputs for cross-account melt change

### DIFF
--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -696,6 +696,9 @@ export function useProcessCashuReceiveQuoteTasks() {
           amount: quote.amount.toNumber(cashuUnit),
         },
         quote.tokenReceiveData.tokenProofs,
+        undefined,
+        // See claim-cashu-token-service.ts for rationale on random outputs.
+        { type: 'random' },
       );
     },
     retry: (failureCount, error) => {

--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -187,6 +187,13 @@ export class ClaimCashuTokenService {
       await sourceAccount.wallet.meltProofsIdempotent(
         quotes.cashuMeltQuote,
         token.proofs,
+        undefined,
+        // Use random outputs for change to avoid counter collisions with the
+        // source account's persisted keyset counter. The change is currently
+        // discarded (see CashuTokenMeltData), so deterministic recovery is
+        // unused. If we ever start keeping change here, switch to a reserved
+        // deterministic counter persisted on the receive quote.
+        { type: 'random' },
       );
 
       // We don't want to fail the entire claim flow if completing the receive fails because the background processing

--- a/app/features/receive/spark-receive-quote-hooks.ts
+++ b/app/features/receive/spark-receive-quote-hooks.ts
@@ -624,6 +624,9 @@ export function useProcessSparkReceiveQuoteTasks() {
           amount: quote.amount.toNumber(cashuUnit),
         },
         quote.tokenReceiveData.tokenProofs,
+        undefined,
+        // See claim-cashu-token-service.ts for rationale on random outputs.
+        { type: 'random' },
       );
     },
     retry: (failureCount, error) => {


### PR DESCRIPTION
## Summary

Cross-account cashu token claims (cashu→cashu different mint, or cashu→spark) fail with mint error 10002 *"outputs already signed"* whenever the user has previously used the source mint's keyset.

This PR passes `{ type: 'random' }` as the `outputType` for the change outputs in the three call sites that initiate the source-mint melt during a cross-account claim:

- `app/features/receive/claim-cashu-token-service.ts` (foreground claim)
- `app/features/receive/cashu-receive-quote-hooks.ts` (background retry, cashu destination)
- `app/features/receive/spark-receive-quote-hooks.ts` (background retry, spark destination)

## Root cause

`meltProofsIdempotent` was called with no `outputType`. In cashu-ts v3, when the wallet has a `bip39seed`, `wallet.defaultOutputType()` returns `{ type: 'deterministic', counter: 0 }`, backed by an in-memory `EphemeralCounterSource` that is **never seeded from our persisted `account.keysetCounters`**. The first call therefore reserves counter `0`, generating blinded outputs that collide with whatever the user already minted/used at counter 0 on that keyset → mint returns 10002.

Send and same-mint receive paths are unaffected because they pass an explicit `{ type: 'deterministic', counter: <reserved-from-DB> }` (see `cashu-send-quote-service.ts:346-356`).

## When this was introduced

- The cross-account claim flow has called melt with no `outputType` since PR #346 (May 2025).
- It only **started failing** after the cashu-ts v2 → v3 upgrade in commit `13428f72` (March 19, 2026).

In v2, `createOutputData` fell through to `createRandomData` whenever no counter was passed, so cross-account claims silently used random outputs and never collided. In v3, `defaultOutputType()` was rewritten to prefer deterministic counter 0 whenever a seed is present:

```js
// v3: lib/cashu-ts.es.js:6097
defaultOutputType() {
  return ... this._seed ? { type: "deterministic", counter: 0 } : { type: "random" };
}
```

This is a silent breaking change in cashu-ts v3 — the v3 migration notes claim `meltProofsIdempotent` "works unchanged" but the default-output behavior shifted underneath us.

## Why random outputs is safe here

The change outputs from this melt are **already discarded** today. From `app/features/receive/cashu-token-melt-data.ts`:

> "For cashu token receives over lightning, we are currently not returning the change to the user."

The melt response is awaited but never destructured — no proofs are saved, no counter is advanced, no NUT-13 restore is needed. Switching to `{ type: 'random' }`:

- restores the v2 semantics that worked for ~10 months
- doesn't lose anything we were keeping
- is a small, scoped, easily-reverted change

The architecturally-correct fix (reserving and persisting a deterministic counter on the source account, mirroring `create_cashu_send_quote`) requires a DB migration and is the right move *if* we ever decide to start keeping change here. That can land separately.

## Test plan

- [ ] Mint or receive any token to a Cashu account so its keyset counter advances past 0
- [ ] Receive an external cashu token from the same mint → choose Spark as destination → verify it completes (previously: 10002)
- [ ] Receive an external cashu token from one Cashu account → choose a different Cashu account as destination → verify it completes (previously: 10002)
- [ ] Same-mint claim still works (regression check on the unmodified `cashu-receive-swap` path)
- [ ] Existing Lightning send still works (regression check on `cashu-send-quote-service.ts`)