### PR TITLE
fix(migration): disable broadcast trigger during denormalize backfill

### DIFF
--- a/supabase/migrations/20260420152512_denormalize_account_on_transactions.sql
+++ b/supabase/migrations/20260420152512_denormalize_account_on_transactions.sql
@@ -22,6 +22,9 @@ alter table wallet.transactions
   add column account_purpose wallet.account_purpose;
 
 -- 2. Backfill from the accounts table via FK join
+alter table wallet.transactions
+  disable trigger broadcast_transactions_changes_trigger;
+
 update wallet.transactions t
 set
   account_name = a.name,
@@ -29,6 +32,9 @@ set
   account_purpose = a.purpose
 from wallet.accounts a
 where t.account_id = a.id;
+
+alter table wallet.transactions
+  enable trigger broadcast_transactions_changes_trigger;
 
 -- 3. Enforce NOT NULL now that every row is populated
 alter table wallet.transactions


### PR DESCRIPTION
When I merged #1004 to master the [supabase deployment failed](https://github.com/MakePrisms/agicash/runs/72617683025)

The migration was never applied so merging this PR should trigger the migration to run again.

I remember we talked about this method of temporarily disabling realtime triggers not being ideal because a user could miss the update, but I asked Claude about it and seems fine:

"""
While the migration runs, any other writes to the transactions table are held in line by a database lock, so nobody else can change a transaction while the trigger is off. By the time anyone else's change actually goes through, the trigger is already back on and their broadcast fires normally.
"""

## Summary

- The denormalize migration from #1004 fails at `ALTER TABLE ... SET NOT NULL` in Supabase Preview with `SQLSTATE 55006 — pending trigger events`.
- Root cause: `broadcast_transactions_changes_trigger` is `DEFERRABLE INITIALLY DEFERRED`, so the backfill `UPDATE` queues one deferred event per row. Postgres won't allow `ALTER TABLE` on a table with pending trigger events in the same transaction.
- Fix: wrap the backfill with `disable trigger` / `enable trigger`. Side benefit — we don't broadcast a phantom `TRANSACTION_UPDATED` to every connected client for every existing row.

## Safe to re-apply
The failed migration rolled back atomically (nothing recorded in `supabase_migrations.schema_migrations`, no partial schema changes left), so this edit applies cleanly on every environment: preview, live, and fresh dev DBs.