### PR TITLE
fix: match melt change signatures by DLEQ instead of position

### DIFF
--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -6,6 +6,7 @@ import {
 import type { Big } from 'big.js';
 import { decodeBolt11, parseBolt11Invoice } from '~/lib/bolt11';
 import { getCashuUnit, sumProofs } from '~/lib/cashu';
+import { matchBlindSignaturesToOutputData } from '~/lib/cashu/blind-signature-matching';
 import { type Currency, Money } from '~/lib/money';
 import type { CashuAccount } from '../accounts/account';
 import { type CashuProof, toProof } from '../accounts/cashu-account';
@@ -418,10 +419,11 @@ export class CashuSendQuoteService {
     const cashuUnit = getCashuUnit(account.currency);
     const wallet = account.wallet;
 
-    // We are creating output data here in the same way that cashu-ts does in the meltProofs function.
-    // This is needed because we need the deterministic output data to be able to convert the change signatures to proofs.
-    // See https://github.com/cashubtc/cashu-ts/issues/287 for more details. If cashu-ts eventually exposes the way to create
-    // blank outputs we will be able to simplify this.
+    // Re-derive the deterministic output data used for NUT-08 change blanks.
+    // The change BlindSignatures from the mint may be in non-deterministic order
+    // (both CDK and Nutshell return them from a SQL query without ORDER BY),
+    // so we match them to OutputData via DLEQ verification rather than positional pairing.
+    // See https://github.com/cashubtc/cashu-ts/issues/287 for why we re-derive OutputData here.
     await wallet.keyChain.ensureKeysetKeys(sendQuote.keysetId);
     const keyset = wallet.getKeyset(sendQuote.keysetId);
     const amounts = sendQuote.numberOfChangeOutputs
@@ -434,8 +436,9 @@ export class CashuSendQuoteService {
       keyset,
       amounts,
     );
-    const changeProofs =
-      meltQuote.change?.map((s, i) => outputData[i].toProof(s, keyset)) ?? [];
+    const changeProofs = meltQuote.change?.length
+      ? matchBlindSignaturesToOutputData(meltQuote.change, outputData, keyset)
+      : [];
 
     const amountSpent = new Money({
       amount: sumProofs(sendQuote.proofs) - sumProofs(changeProofs),

--- a/app/lib/cashu/blind-signature-matching.test.ts
+++ b/app/lib/cashu/blind-signature-matching.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  OutputData,
+  type SerializedBlindedSignature,
+  createBlindSignature,
+  createDLEQProof,
+  pointFromHex,
+} from '@cashu/cashu-ts';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { bytesToHex } from '@noble/hashes/utils';
+import { matchBlindSignaturesToOutputData } from './blind-signature-matching';
+
+/**
+ * Test helpers — simulate mint-side signing so we get real DLEQ proofs.
+ */
+const KEYSET_ID = '00test_keyset_id';
+
+// Generate a deterministic private key for testing
+const PRIVATE_KEY = secp256k1.utils.randomPrivateKey();
+const PUBLIC_KEY = secp256k1.getPublicKey(PRIVATE_KEY, true);
+const PUBLIC_KEY_HEX = bytesToHex(PUBLIC_KEY);
+
+// Build a keyset with the same key for all denominations (sufficient for testing)
+const TEST_KEYSET = {
+  id: KEYSET_ID,
+  keys: Object.fromEntries(
+    [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096].map((amount) => [
+      String(amount),
+      PUBLIC_KEY_HEX,
+    ]),
+  ),
+};
+
+function mintSign(
+  B_: ReturnType<typeof pointFromHex>,
+  amount: number,
+): SerializedBlindedSignature {
+  const blindSig = createBlindSignature(B_, PRIVATE_KEY, amount, KEYSET_ID);
+  const dleq = createDLEQProof(B_, PRIVATE_KEY);
+  return {
+    id: blindSig.id,
+    amount: blindSig.amount,
+    C_: blindSig.C_.toHex(),
+    dleq: {
+      s: bytesToHex(dleq.s),
+      e: bytesToHex(dleq.e),
+    },
+  };
+}
+
+function createTestOutputData(
+  amounts: number[],
+  seed: Uint8Array,
+  counter = 0,
+) {
+  return OutputData.createDeterministicData(
+    amounts.reduce((a, b) => a + b, 0),
+    seed,
+    counter,
+    TEST_KEYSET,
+    amounts,
+  );
+}
+
+function signOutputData(
+  outputData: OutputData[],
+  amounts: number[],
+): SerializedBlindedSignature[] {
+  return outputData.map((od, i) => {
+    const B_ = pointFromHex(od.blindedMessage.B_);
+    return mintSign(B_, amounts[i]);
+  });
+}
+
+const TEST_SEED = new Uint8Array(32).fill(42);
+
+describe('matchBlindSignaturesToOutputData', () => {
+  test('matches correctly ordered signatures', () => {
+    const amounts = [1024, 512, 16, 8, 2];
+    const outputData = createTestOutputData(amounts, TEST_SEED);
+    const signatures = signOutputData(outputData, amounts);
+
+    const proofs = matchBlindSignaturesToOutputData(
+      signatures,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(5);
+    expect(proofs.map((p) => p.amount)).toEqual(amounts);
+  });
+
+  test('matches reversed signatures', () => {
+    const amounts = [1024, 512, 16, 8, 2];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 10);
+    const signatures = signOutputData(outputData, amounts);
+
+    const reversed = [...signatures].reverse();
+    const proofs = matchBlindSignaturesToOutputData(
+      reversed,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(5);
+    // Proofs should match the reversed signature order (each proof matches its signature)
+    expect(proofs.map((p) => p.amount)).toEqual([...amounts].reverse());
+    // But each proof's secret should match the CORRECT OutputData, not the positional one
+    for (const proof of proofs) {
+      expect(proof.dleq).toBeDefined();
+    }
+  });
+
+  test('matches shuffled signatures', () => {
+    const amounts = [2048, 1024, 512, 16, 8, 2];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 20);
+    const signatures = signOutputData(outputData, amounts);
+
+    // Shuffle: [2, 1024, 8, 2048, 512, 16]
+    const shuffled = [
+      signatures[5],
+      signatures[1],
+      signatures[4],
+      signatures[0],
+      signatures[2],
+      signatures[3],
+    ];
+
+    const proofs = matchBlindSignaturesToOutputData(
+      shuffled,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(6);
+    // Each proof should have a valid DLEQ (verified during matching)
+    for (const proof of proofs) {
+      expect(proof.dleq).toBeDefined();
+    }
+  });
+
+  test('matches single signature', () => {
+    const amounts = [1024];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 30);
+    const signatures = signOutputData(outputData, amounts);
+
+    const proofs = matchBlindSignaturesToOutputData(
+      signatures,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(1);
+    expect(proofs[0].amount).toBe(1024);
+  });
+
+  test('matches empty signatures', () => {
+    const outputData = createTestOutputData([1], TEST_SEED, 40);
+
+    const proofs = matchBlindSignaturesToOutputData(
+      [],
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(0);
+  });
+
+  test('matches fewer signatures than output data (partial change)', () => {
+    const amounts = [2048, 1024, 512, 16, 8, 2];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 50);
+    const allSignatures = signOutputData(outputData, amounts);
+
+    // Mint only signed first 3 (the change amount only needed 3 outputs)
+    const partialSignatures = allSignatures.slice(0, 3);
+
+    const proofs = matchBlindSignaturesToOutputData(
+      partialSignatures,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    expect(proofs).toHaveLength(3);
+    expect(proofs.map((p) => p.amount)).toEqual([2048, 1024, 512]);
+  });
+
+  test('throws when signature has no DLEQ', () => {
+    const amounts = [1024, 512];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 60);
+    const signatures = signOutputData(outputData, amounts);
+
+    // Remove DLEQ from one signature
+    const { dleq: _, ...noDleq } = signatures[0];
+
+    expect(() =>
+      matchBlindSignaturesToOutputData(
+        [noDleq as SerializedBlindedSignature, signatures[1]],
+        outputData,
+        TEST_KEYSET,
+      ),
+    ).toThrow('DLEQ');
+  });
+
+  test('throws when signature cannot be matched', () => {
+    const amounts = [1024, 512];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 70);
+    const signatures = signOutputData(outputData, amounts);
+
+    // Create a signature from a completely different OutputData
+    const otherOutputData = createTestOutputData([256], TEST_SEED, 999);
+    const otherSig = signOutputData(otherOutputData, [256]);
+
+    expect(() =>
+      matchBlindSignaturesToOutputData(
+        [signatures[0], otherSig[0]],
+        outputData,
+        TEST_KEYSET,
+      ),
+    ).toThrow('No matching OutputData');
+  });
+
+  test('produces identical proofs regardless of signature order', () => {
+    const amounts = [1024, 512, 8];
+    const outputData = createTestOutputData(amounts, TEST_SEED, 80);
+    const signatures = signOutputData(outputData, amounts);
+
+    const orderedProofs = matchBlindSignaturesToOutputData(
+      signatures,
+      outputData,
+      TEST_KEYSET,
+    );
+
+    const reversedProofs = matchBlindSignaturesToOutputData(
+      [...signatures].reverse(),
+      outputData,
+      TEST_KEYSET,
+    );
+
+    // Same set of proofs regardless of input order
+    const sortBySecret = (proofs: typeof orderedProofs) =>
+      [...proofs].sort((a, b) => a.secret.localeCompare(b.secret));
+
+    expect(sortBySecret(orderedProofs)).toEqual(sortBySecret(reversedProofs));
+  });
+});

--- a/app/lib/cashu/blind-signature-matching.ts
+++ b/app/lib/cashu/blind-signature-matching.ts
@@ -1,0 +1,89 @@
+import {
+  type HasKeysetKeys,
+  type OutputData,
+  type Proof,
+  type SerializedBlindedSignature,
+  pointFromHex,
+  verifyDLEQProof_reblind,
+} from '@cashu/cashu-ts';
+import { hexToBytes } from '@noble/hashes/utils';
+
+/**
+ * Match blind signatures to output data using DLEQ verification.
+ *
+ * Mints may return blind signatures in non-deterministic order (e.g., when
+ * fetched from a database without ORDER BY). This function matches each
+ * signature to its corresponding OutputData by trial-unblinding and verifying
+ * the DLEQ proof, rather than relying on positional pairing.
+ *
+ * Requires NUT-12 (DLEQ proofs) on all signatures.
+ *
+ * @throws If any signature is missing a DLEQ proof or cannot be matched.
+ */
+export function matchBlindSignaturesToOutputData(
+  signatures: SerializedBlindedSignature[],
+  outputData: OutputData[],
+  keyset: HasKeysetKeys,
+): Proof[] {
+  const unmatched = new Set(outputData.map((_, i) => i));
+  const result: Proof[] = [];
+  const matchedIndices: number[] = [];
+
+  for (let sigIdx = 0; sigIdx < signatures.length; sigIdx++) {
+    const sig = signatures[sigIdx];
+    if (!sig.dleq) {
+      throw new Error(
+        'Cannot match blind signatures without DLEQ proofs (NUT-12)',
+      );
+    }
+
+    let matched = false;
+
+    for (const i of unmatched) {
+      const od = outputData[i];
+      const proof = od.toProof(sig, keyset);
+
+      if (!proof.dleq) {
+        continue;
+      }
+
+      const K = pointFromHex(keyset.keys[sig.amount]);
+      const C = pointFromHex(proof.C);
+
+      const isValid = verifyDLEQProof_reblind(
+        new TextEncoder().encode(proof.secret),
+        {
+          s: hexToBytes(proof.dleq.s),
+          e: hexToBytes(proof.dleq.e),
+          r: od.blindingFactor,
+        },
+        C,
+        K,
+      );
+
+      if (isValid) {
+        result.push(proof);
+        matchedIndices.push(i);
+        unmatched.delete(i);
+        matched = true;
+        break;
+      }
+    }
+
+    if (!matched) {
+      throw new Error(
+        `No matching OutputData found for blind signature (amount=${sig.amount})`,
+      );
+    }
+  }
+
+  // Detect if positional pairing would have been wrong
+  const wasReordered = matchedIndices.some((odIdx, sigIdx) => odIdx !== sigIdx);
+  if (wasReordered) {
+    console.warn(
+      'Blind signatures were out of order — DLEQ matching corrected the pairing.',
+    );
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Melt change `BlindSignature`s from mints may arrive in non-deterministic order (both CDK and Nutshell query their signatures table without `ORDER BY`)
- The previous positional pairing (`outputData[i].toProof(change[i])`) would unblind with the wrong blinding factor, producing proofs with valid secrets but cryptographically invalid signatures
- These corrupted proofs are permanently unspendable and cause a crash loop when the wallet tries to use them

## Fix

Introduces `matchBlindSignaturesToOutputData()` which matches each `BlindSignature` to its correct `OutputData` by trial-unblinding and verifying the DLEQ proof (NUT-12), rather than relying on positional order.

Logs a warning when reordering is detected so we can track occurrences in Sentry.

## Affected paths

| Endpoint | Risk | Protected? |
|---|---|---|
| POST /v1/melt/bolt11 (sync) | None — in-memory ordered | cashu-ts internal |
| POST /v1/melt/bolt11 (saga recovery) | **High** — DB-loaded B_ with no ORDER BY | **Yes — this PR** |
| GET /v1/melt/quote/{id} | **High** — no ORDER BY | **Yes — this PR** |
| WebSocket PAID (initial) | Low if sync, **High** if saga recovery | **Yes — this PR** |
| WebSocket PAID (reconnect) | **High** — `change: None`, falls back to GET | **Yes — this PR** |

## Evidence

Confirmed across 3 mints and multiple users:
- minibits (Nutshell 0.20.0) — AGICASH-8P, AGICASH-8N
- squarealpha (CDK) — AGICASH-8F
- squarealpha0421 (CDK) — new case Apr 22