### PR TITLE
fix(accept-terms): clarify wallet/mint terms wording and fix mint links

### DIFF
--- a/app/features/user/accept-terms.tsx
+++ b/app/features/user/accept-terms.tsx
@@ -67,7 +67,7 @@ export function AcceptTerms({
                 htmlFor="terms-checkbox"
                 className="text-muted-foreground text-xs leading-5"
               >
-                By clicking the checkbox, (i) I hereby accept the{' '}
+                By clicking the checkbox, (i) I hereby accept the wallet{' '}
                 <LinkWithViewTransition
                   to={{
                     pathname: '/terms',
@@ -80,7 +80,7 @@ export function AcceptTerms({
                   TERMS OF SERVICE
                 </LinkWithViewTransition>{' '}
                 and agree to be bound by them; and (ii) I acknowledge receipt of
-                the{' '}
+                the wallet{' '}
                 <LinkWithViewTransition
                   to={{
                     pathname: '/privacy',
@@ -113,19 +113,32 @@ export function AcceptTerms({
                 htmlFor="gift-card-mint-terms-checkbox"
                 className="text-muted-foreground text-xs leading-5"
               >
-                By clicking the checkbox, I hereby accept the{' '}
+                By clicking the checkbox, (i) I hereby accept the mint{' '}
                 <LinkWithViewTransition
                   to={{
-                    pathname: '/terms',
+                    pathname: '/mint-terms',
                     search: `redirectTo=${location.pathname}`,
                   }}
                   transition="slideUp"
                   applyTo="newView"
                   className="text-foreground underline"
                 >
-                  MINT TERMS OF SERVICE
+                  TERMS OF SERVICE
                 </LinkWithViewTransition>{' '}
-                and agree to be bound by them.
+                and agree to be bound by them; and (ii) I acknowledge receipt of
+                the mint{' '}
+                <LinkWithViewTransition
+                  to={{
+                    pathname: '/mint-privacy',
+                    search: `redirectTo=${location.pathname}`,
+                  }}
+                  transition="slideUp"
+                  applyTo="newView"
+                  className="text-foreground underline"
+                >
+                  Privacy Notice
+                </LinkWithViewTransition>
+                .
               </Label>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Gift-card-mint terms checkbox now links to `/mint-terms` and `/mint-privacy` (previously linked to the wallet `/terms` route, and had no Privacy Notice link at all).
- Parallels the wallet-terms copy: "(i) I hereby accept the [mint|wallet] TERMS OF SERVICE and agree to be bound by them; and (ii) I acknowledge receipt of the [mint|wallet] Privacy Notice."

