### PR TITLE
fix(oauth): restore ? separator when rebuilding post-OAuth redirect URL

### DIFF
--- a/app/routes/_auth.oauth.$provider.tsx
+++ b/app/routes/_auth.oauth.$provider.tsx
@@ -76,7 +76,8 @@ export async function clientLoader({
   const searchParams = new URLSearchParams(oauthLoginSession.search);
   const redirectTo = searchParams.get('redirectTo') ?? '/';
   searchParams.delete('redirectTo');
-  const url = `${redirectTo}${searchParams.toString()}${oauthLoginSession.hash}`;
+  const passthroughSearch = searchParams.size > 0 ? `?${searchParams}` : '';
+  const url = `${redirectTo}${passthroughSearch}${oauthLoginSession.hash}`;
 
   oauthLoginSessionStorage.remove(oauthLoginSession.sessionId);
 


### PR DESCRIPTION
## Summary
- OAuth callback reassembled the pre-OAuth URL with `${redirectTo}${searchParams.toString()}${hash}` — but `URLSearchParams.toString()` has no leading `?`, so any remaining search param concatenated directly onto `redirectTo`.
- For gift-card claimers who clicked "Log In and Claim" (adds `requireGiftCardMintTerms=true`) then "Log in with Google," the post-callback URL became `/receive/cashu/tokenrequireGiftCardMintTerms=true#<token>`, which matches no route → "Not Found," token in the hash lost.
- Fix prepends `?` only when there are remaining params.

## Evidence
Sentry confirms the malformed path hit production on 2026-04-24:
- Trace `9c3b02239f2876ae4c90189fcb8bd630` — `GET /receive/cashu/tokenrequireGiftCardMintTerms=true`
- Trace `43b31ac3005753d46f8d1058fef41d22` — same

These are the browser reload requests after the initial client-side redirect landed on the 404 boundary.

## Test plan
- [ ] Share a gift-card token link (`/receive-cashu-token#<token>`) to an incognito window
- [ ] Click "Log In and Claim" → "Log in with Google" with a brand-new Google account
- [ ] Verify the post-OAuth landing is `/receive/cashu/token?requireGiftCardMintTerms=true#<token>`, the wallet TOS prompt appears (because login flow doesn't pre-accept terms), then the gift-card mint TOS prompt appears inline on the claim page, and the token can be claimed
- [ ] Repeat with an existing Google account that has not yet accepted gift-card mint terms — should proceed straight to the inline mint-terms prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)