### PR TITLE
fix(spark-send): reject new send quote when invoice already paid

### DIFF
--- a/app/features/send/spark-send-quote-repository.ts
+++ b/app/features/send/spark-send-quote-repository.ts
@@ -112,7 +112,12 @@ export class SparkSendQuoteRepository {
 
     if (error) {
       if (error.code === '23505') {
-        throw new DomainError('This invoice has already been paid');
+        // Hits the spark_send_quotes_payment_hash_active_unique partial index,
+        // which covers UNPAID, PENDING, and COMPLETED — so the existing quote
+        // could be in any of those states.
+        throw new DomainError(
+          'A payment for this invoice is already being processed or was completed',
+        );
       }
       throw new Error('Failed to create spark send quote', { cause: error });
     }

--- a/app/features/send/spark-send-quote-repository.ts
+++ b/app/features/send/spark-send-quote-repository.ts
@@ -8,6 +8,7 @@ import type {
 import { agicashDbClient } from '../agicash-db/database.client';
 import { SparkLightningSendDbDataSchema } from '../agicash-db/json-models';
 import { type Encryption, useEncryption } from '../shared/encryption';
+import { DomainError } from '../shared/error';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
 import { type SparkSendQuote, SparkSendQuoteSchema } from './spark-send-quote';
 
@@ -110,6 +111,9 @@ export class SparkSendQuoteRepository {
     const { data, error } = await query;
 
     if (error) {
+      if (error.code === '23505') {
+        throw new DomainError('This invoice has already been paid');
+      }
       throw new Error('Failed to create spark send quote', { cause: error });
     }
 

--- a/app/features/send/spark-send-quote-service.ts
+++ b/app/features/send/spark-send-quote-service.ts
@@ -1,7 +1,10 @@
 import { parseBolt11Invoice } from '~/lib/bolt11';
 import { Money } from '~/lib/money';
 import { measureOperation } from '~/lib/performance';
-import { isInsufficentBalanceError } from '~/lib/spark';
+import {
+  isInsufficentBalanceError,
+  isInvoiceAlreadyPaidError,
+} from '~/lib/spark';
 import type { SparkAccount } from '../accounts/account';
 import { DomainError } from '../shared/error';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
@@ -307,6 +310,10 @@ export class SparkSendQuoteService {
         }) as Money,
       });
     } catch (error) {
+      if (isInvoiceAlreadyPaidError(error)) {
+        throw new DomainError('Lightning invoice has already been paid.');
+      }
+
       if (isInsufficentBalanceError(error)) {
         const totalSats = sendQuote.amount
           .add(sendQuote.estimatedFee)

--- a/app/lib/spark/errors.ts
+++ b/app/lib/spark/errors.ts
@@ -1,8 +1,18 @@
 export const isInsufficentBalanceError = (error: unknown): error is Error => {
-  if (!(error instanceof Error)) return false;
+  if (!(error instanceof Error)) {
+    return false;
+  }
   const lower = error.message.toLowerCase();
   return (
     lower.includes('insufficient funds') ||
     lower.includes('insufficient balance')
   );
+};
+
+export const isInvoiceAlreadyPaidError = (error: unknown): error is Error => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const lower = error.message.toLowerCase();
+  return lower.includes('preimage request already exists');
 };

--- a/supabase/migrations/20260425181643_tighten_spark_send_payment_hash_uniqueness.sql
+++ b/supabase/migrations/20260425181643_tighten_spark_send_payment_hash_uniqueness.sql
@@ -1,0 +1,12 @@
+-- Tighten the partial unique index on spark_send_quotes(user_id, payment_hash)
+-- to also cover COMPLETED quotes. Previously only UNPAID and PENDING were
+-- covered, which let a user create a fresh UNPAID quote for an invoice they
+-- had already paid -- the second quote then hit Spark's AlreadyExists error
+-- forever. FAILED stays excluded so a user can legitimately retry an invoice
+-- whose previous attempt truly failed.
+
+drop index if exists "wallet"."spark_send_quotes_payment_hash_active_unique";
+
+create unique index "spark_send_quotes_payment_hash_active_unique"
+  on "wallet"."spark_send_quotes" ("user_id", "payment_hash")
+  where ("state" = any (array['UNPAID', 'PENDING', 'COMPLETED']::"wallet"."spark_send_quote_state"[]));


### PR DESCRIPTION
## Summary

- Tighten the partial unique index on `wallet.spark_send_quotes(user_id, payment_hash)` to also cover `COMPLETED`, closing the hole that let a fresh `UNPAID` quote be created for an invoice that had already been paid.
- Translate the Postgres `23505` from `create_spark_send_quote` to a `DomainError('This invoice has already been paid')` in the repo so the existing toast pipeline (`send-input.tsx:109-125`) surfaces a friendly 8s message and the mutation retry short-circuits.

`FAILED` stays excluded from the index so a user can still legitimately retry an invoice whose previous attempt truly failed.

## Background

A user (AGICASH-9X in Sentry) ended up with two `spark_send_quotes` rows for the same `payment_hash`: one `COMPLETED`, one `UNPAID`. The second quote's `initiateSend` looped on Spark's `AlreadyExists` error 13 times across navigations because the existing partial unique index only covered `UNPAID` and `PENDING` — `COMPLETED` was a hole, so the duplicate row was created when they re-pasted the invoice.

This mirrors the existing pattern for cashu token claims, which uses a unique constraint on `(token_hash, user_id)` and surfaces "This token has already been claimed" the same way.