### PR TITLE
fix: normalize mint URLs at insert to prevent duplicate accounts

### DIFF
--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -1,6 +1,7 @@
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
 import { z } from 'zod';
+import { normalizeMintUrl } from '~/lib/cashu';
 import { ProofSchema } from '~/lib/cashu/types';
 import type { Currency } from '~/lib/money';
 import {
@@ -122,7 +123,7 @@ export class AccountRepository {
     let details = {};
     if (accountInput.type === 'cashu') {
       details = CashuAccountDetailsDbDataSchema.parse({
-        mint_url: accountInput.mintUrl,
+        mint_url: normalizeMintUrl(accountInput.mintUrl),
         is_test_mint: accountInput.isTestMint,
         keyset_counters: accountInput.keysetCounters,
       } satisfies z.input<typeof CashuAccountDetailsDbDataSchema>);

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -1,6 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
 import type { z } from 'zod';
+import { normalizeMintUrl } from '~/lib/cashu';
 import type { Currency } from '~/lib/money';
 import type { Account, RedactedAccount } from '../accounts/account';
 import {
@@ -187,7 +188,7 @@ export class WriteUserRepository {
       details: (() => {
         if (account.type === 'cashu') {
           return CashuAccountDetailsDbDataSchema.parse({
-            mint_url: account.mintUrl,
+            mint_url: normalizeMintUrl(account.mintUrl),
             is_test_mint: account.isTestMint,
             keyset_counters: {},
           } satisfies z.input<typeof CashuAccountDetailsDbDataSchema>);

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -265,6 +265,14 @@ export const getCashuWallet = (
 };
 
 /**
+ * Normalize a mint URL by trimming whitespace, lowercasing, and stripping
+ * trailing slashes. Use this whenever a mint URL is stored or compared so
+ * variants like `https://Mint.io/` and `https://mint.io` match.
+ */
+export const normalizeMintUrl = (mintUrl: string): string =>
+  mintUrl.trim().toLowerCase().replace(/\/+$/, '');
+
+/**
  * Check if a mint is a test mint by checking if the mint is in the list of
  * known test mints.
  *
@@ -276,9 +284,7 @@ export const getCashuWallet = (
  * @returns True if the mint is a known test mint
  */
 export const checkIsTestMint = (mintUrl: string): boolean => {
-  // Normalize URL by removing trailing slash and converting to lowercase
-  const normalizedUrl = mintUrl.toLowerCase().replace(/\/+$/, '');
-  return knownTestMints.includes(normalizedUrl);
+  return knownTestMints.includes(normalizeMintUrl(mintUrl));
 };
 
 /**
@@ -288,8 +294,5 @@ export const checkIsTestMint = (mintUrl: string): boolean => {
  * @returns True if the mint URLs are equal
  */
 export const areMintUrlsEqual = (a: string, b: string) => {
-  return (
-    a.toLowerCase().replace(/\/+$/, '').trim() ===
-    b.toLowerCase().replace(/\/+$/, '').trim()
-  );
+  return normalizeMintUrl(a) === normalizeMintUrl(b);
 };


### PR DESCRIPTION
## Summary

Mint URLs were persisted as the user typed them, so `https://mint.io/` and `https://mint.io` ended up as two separate `wallet.accounts` rows for the same mint — bypassing the `(user_id, currency, mint_url)` partial unique index, which keys on the raw JSONB string.

This PR normalizes (lowercase + trim + strip trailing slashes) at both persistence chokepoints so all writes land in canonical form. Existing data is untouched; only new inserts are protected.

- `AccountRepository.create` (single insert — settings add-mint, gift-card add, offers)
- `WriteUserRepository.upsert` (bulk onboarding insert via `upsert_user_with_accounts` RPC)

The duplicated normalization logic that already lived inside `checkIsTestMint` and `areMintUrlsEqual` is extracted into a shared `normalizeMintUrl` helper that both delegate to.

## Why now

Spotted in production for one user: two `wallet.accounts` rows for `m7.mountainlake.io` — `jj` (with trailing slash) and `hhh` (without). Sentry logs and the screenshot of their accounts table showed the bug clearly. App-side comparisons all use `areMintUrlsEqual`, so the duplicates are silent storage drift today, but they will eventually surface as confusing UX (two account tiles for the same mint, ambiguous default selection).

## Out of scope (intentional)

- DB-level enforcement (functional unique index on `lower(rtrim(details->>'mint_url', '/'))`) — recommended follow-up. Requires a one-shot dedup of existing duplicate rows before the index can be created.
- No data migration of existing un-normalized rows. Reads continue to use `areMintUrlsEqual` which normalizes both sides, so old rows stay accessible.