### PR TITLE
fix(home): protect balance spacing on short mobile screens

### DIFF
--- a/app/features/pwa/use-should-show-pwa-prompt.ts
+++ b/app/features/pwa/use-should-show-pwa-prompt.ts
@@ -1,4 +1,5 @@
-import { useLocalStorage, useMediaQuery } from 'usehooks-ts';
+import { useLocalStorage } from 'usehooks-ts';
+import useIsPwa from '~/hooks/use-is-pwa';
 import useUserAgent from '~/hooks/use-user-agent';
 
 type DismissedValue =
@@ -65,10 +66,9 @@ export default function useShouldShowPwaPrompt(): Return {
   const { shouldShow, handleDontShowAgain, handleDismissTemporarily } =
     useShouldShowPrompt(key);
   const { isMobile } = useUserAgent();
-  // true if the app is already installed
-  const isStandalone = useMediaQuery('(display-mode: standalone)');
+  const isPwa = useIsPwa();
 
-  const shouldShowPwaPrompt = shouldShow && isMobile && !isStandalone;
+  const shouldShowPwaPrompt = shouldShow && isMobile && !isPwa;
 
   return {
     shouldShowPwaPrompt,

--- a/app/hooks/use-is-pwa.ts
+++ b/app/hooks/use-is-pwa.ts
@@ -1,0 +1,6 @@
+import { useMediaQuery } from 'usehooks-ts';
+
+/** Returns true when the app is running as an installed PWA (standalone display mode). */
+export default function useIsPwa(): boolean {
+  return useMediaQuery('(display-mode: standalone)');
+}

--- a/app/routes/_protected._index.tsx
+++ b/app/routes/_protected._index.tsx
@@ -16,9 +16,11 @@ import { DefaultCurrencySwitcher } from '~/features/accounts/default-currency-sw
 import { CASH_APP_LOGO_URL } from '~/features/buy/cash-app';
 import { InstallPwaPrompt } from '~/features/pwa/install-pwa-prompt';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
+import useIsPwa from '~/hooks/use-is-pwa';
 import { useHasTransactionsPendingAck } from '~/features/transactions/transaction-hooks';
 import { useUser } from '~/features/user/user-hooks';
 import { LinkWithViewTransition } from '~/lib/transitions';
+import { cn } from '~/lib/utils';
 
 export const links: LinksFunction = () => [
   // This icon is used in the PWA dialog and prefetched here to avoid a flash while loading
@@ -34,6 +36,7 @@ export default function Index() {
   const defaultUsdAccountId = useUser((user) => user.defaultUsdAccountId);
   const defaultCurrency = useDefaultAccount().currency;
   const hasTransactionsPendingAck = useHasTransactionsPendingAck();
+  const isPwa = useIsPwa();
 
   return (
     <Page>
@@ -77,8 +80,8 @@ export default function Index() {
         </PageHeaderItem>
       </PageHeader>
 
-      <PageContent className="absolute inset-0 mx-auto flex flex-col items-center justify-center gap-32">
-        <div className="flex flex-col items-center gap-4">
+      <PageContent className="mx-auto items-center justify-between pt-20 sm:justify-center sm:gap-32 sm:py-0">
+        <div className={cn(isPwa && 'pt-[30px]')}>
           <MoneyWithConvertedAmount
             money={defaultCurrency === 'BTC' ? balanceBTC : balanceUSD}
           />
@@ -90,7 +93,7 @@ export default function Index() {
           <div />
         )}
 
-        <div className="flex w-72 flex-col gap-4">
+        <div className={cn('flex w-72 flex-col gap-4', isPwa && 'pb-20')}>
           <div className="grid grid-cols-2 gap-4">
             <LinkWithViewTransition
               to="/receive"


### PR DESCRIPTION
## Summary
- Replace mobile absolute-centered layout with `flex justify-between` + `pt-20` so the balance/selector/buttons stack stays clear of the header on short viewports.
- Preserve the original desktop layout (`sm:justify-center sm:gap-32 sm:py-0`).
- Extract `useIsPwa` (`(display-mode: standalone)` media query) from the existing inline usage in `use-should-show-pwa-prompt`.
- When running as an installed PWA, add extra inner spacing — `pt-[30px]` on the balance and `pb-20` on the buttons — so neither the balance hugs the header nor the buttons sit too low above the home indicator.

## Test plan
- [ ] Mobile browser (<640px): balance stays clear of the header at varying heights, buttons not jammed against bottom
- [ ] Mobile single-currency user (no selector): layout still balanced
- [ ] Installed PWA (iOS/Android): balance has comfortable top gap, buttons sit well above the home indicator
- [ ] Desktop (≥640px): matches master — balance, selector, buttons centered with `gap-32`