### PR TITLE
fix(page-header): use grid layout so titles never wrap when they fit

### DIFF
--- a/app/components/page.tsx
+++ b/app/components/page.tsx
@@ -109,7 +109,10 @@ export function PageHeaderTitle({
   return (
     <PageHeaderItem position={position}>
       <h1
-        className={cn('flex items-center justify-start text-xl', className)}
+        className={cn(
+          'flex items-center justify-center text-center text-xl',
+          className,
+        )}
         {...props}
       >
         {children}
@@ -162,14 +165,17 @@ export function PageHeader({ children, className, ...props }: PageHeaderProps) {
 
   return (
     <header
-      className={cn('mb-4 flex w-full items-center justify-between', className)}
+      className={cn(
+        'mb-4 grid w-full grid-cols-[1fr_auto_1fr] items-center',
+        className,
+      )}
       {...props}
     >
-      <div className="flex items-center">{leftItems}</div>
-      <div className="-translate-x-1/2 absolute left-1/2 transform">
-        {centerItems}
+      <div className="flex items-center justify-self-start">{leftItems}</div>
+      <div className="flex items-center justify-self-center">{centerItems}</div>
+      <div className="flex items-center gap-2 justify-self-end">
+        {rightItems}
       </div>
-      <div className="flex items-center justify-end gap-2">{rightItems}</div>
     </header>
   );
 }

--- a/app/features/gift-cards/gift-card-details.tsx
+++ b/app/features/gift-cards/gift-card-details.tsx
@@ -54,7 +54,7 @@ export default function GiftCardDetails({ cardId }: GiftCardDetailsProps) {
 
   return (
     <Page className="px-0 pb-0">
-      <PageHeader className="absolute inset-x-0 top-0 z-[60] flex w-full items-center justify-between px-4 pt-4 pb-4">
+      <PageHeader className="absolute inset-x-0 top-0 z-[60] mb-0 px-4 pt-4 pb-4">
         <PageHeaderItem position="left">
           <button type="button" onClick={handleBack} aria-label="Close">
             <X />

--- a/app/features/gift-cards/gift-cards.tsx
+++ b/app/features/gift-cards/gift-cards.tsx
@@ -56,7 +56,7 @@ export function GiftCards() {
 
   return (
     <Page className="px-0 pb-0">
-      <PageHeader className="absolute inset-x-0 top-0 z-20 flex w-full items-center justify-between px-4 pt-4 pb-4">
+      <PageHeader className="absolute inset-x-0 top-0 z-20 mb-0 px-4 pt-4 pb-4">
         <ClosePageButton to="/" transition="slideLeft" applyTo="oldView" />
         <PageHeaderTitle>Gift Cards</PageHeaderTitle>
       </PageHeader>

--- a/app/features/gift-cards/offer-details.tsx
+++ b/app/features/gift-cards/offer-details.tsx
@@ -45,7 +45,7 @@ export default function OfferDetails({ offer }: OfferDetailsProps) {
 
   return (
     <Page className="px-0 pb-0">
-      <PageHeader className="absolute inset-x-0 top-0 z-[60] flex w-full items-center justify-between px-4 pt-4 pb-4">
+      <PageHeader className="absolute inset-x-0 top-0 z-[60] mb-0 px-4 pt-4 pb-4">
         <PageHeaderItem position="left">
           <button type="button" onClick={handleBack} aria-label="Close">
             <X />


### PR DESCRIPTION
## Summary
- Fix "Create Cashu Account" (and any other title that exceeds 50% of the viewport) wrapping to two lines on mobile when the row had plenty of horizontal space.
- Replace the absolutely-positioned title pattern in `PageHeader` with a 3-column grid layout that gives the title the *real* remaining space, so it wraps only when it genuinely doesn't fit.

## Screenshots

| Before | After |
|---|---|
| ![Before](https://github.com/MakePrisms/agicash/releases/download/pr-1034-screenshots/before.png) | ![After](https://github.com/MakePrisms/agicash/releases/download/pr-1034-screenshots/after.png) |

## Root cause
`app/components/page.tsx` rendered the title in an `absolute left-1/2 -translate-x-1/2` div with no width set. For an absolutely-positioned element, CSS shrink-to-fit computes `available width = containing block - left`, i.e. only the right half of the row. Any title wider than 50% of the row wrapped — "Create Cashu Account" (~230px) wrapped on a 390px viewport even though there was room for it on one line.

## Why grid instead of `whitespace-nowrap`
First instinct was to add `whitespace-nowrap` so the title takes its natural max-content width. That fixes the immediate bug but trades it for a worse one: on a viewport too narrow to fit the title (e.g. Galaxy Fold ~280px), the title would *overlap the back button* instead of wrapping. The old layout at least degraded gracefully by wrapping.

The desired behavior is:
- Title fits horizontally → one line (fix the eager 50% wrap)
- Title genuinely doesn't fit → wrap (preserve the old graceful degradation)

The new layout uses `grid grid-cols-[1fr_auto_1fr]`: side columns share the leftover space equally, and the auto center column sizes to content but is bounded by what the side columns can give up. So a title that fits the row stays on one line; a title too wide wraps. Side columns are equal, so for icon-only side items (every current usage) the title is geometrically centered — matching the original pixel-perfect centering.

## Considered tradeoffs
- **Asymmetric side widths**: `1fr_auto_1fr` keeps the title at viewport center only when 1fr columns are equal. They always are equal because all current PageHeader usages have icon-only or empty side items.
- **Right items wider than the column allows**: theoretical only. All current right items are single icon-sized buttons.
- **Wrapped lines alignment**: added `text-center` on the `h1` so wrapped lines stay centered (the old layout left them left-aligned, but wrapping there was unintended).
- **Gift-card pages override `PageHeader`'s className with `flex w-full justify-between`**. That override was a copy of the original default and now conflicts with grid. Without cleanup, the title was offset ~12px right because flex + 3 children + an empty right div distributes space unevenly. Dropped the redundant `flex w-full items-center justify-between` from those overrides — they only need the `absolute inset-x-0 top-0` overlay positioning.

## Verification
Tested at 390px (iPhone) and 240px (extreme narrow):
- 390px: "Create Cashu Account" fits on one line, centered.
- 240px: title wraps to 3 lines, stays centered, no overlap with back button.

Spot-checked: Send, Buy, Settings, Contacts, Edit Profile, Transactions, Gift Cards. All centered correctly with no regression. Confirmed via `getBoundingClientRect()` that the title center matches the header center exactly (offset = 0px).

## Test plan
- [ ] Viewport ≥ 320px: "Create Cashu Account" renders on a single centered line.
- [ ] Viewport < 280px (very narrow): title wraps, doesn't overlap the back button.
- [ ] Other PageHeader pages (Send, Receive, Settings, Buy, Gift Cards, Edit Profile, Contacts) — title centered, side icons at edges.
- [ ] Pages that pass a custom `className` to PageHeader (gift-cards/*) still position correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)