### PR TITLE
fix(sentry): sanitize URLs in error events and span descriptions to prevent leaking cashu tokens and quote IDs

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -105,6 +105,27 @@ Sentry.init({
       (ex) => !ex.stacktrace?.frames?.length,
     );
     if (hasNoStackTrace) return null;
+
+    // Sanitize sensitive URL parts (fragment, path params, query values) on the
+    // error event itself and on breadcrumbs that capture page/fetch URLs.
+    if (event.request?.url) {
+      event.request.url = sanitizeUrl(event.request.url);
+    }
+    for (const breadcrumb of event.breadcrumbs ?? []) {
+      if (!breadcrumb.data) {
+        continue;
+      }
+      if (typeof breadcrumb.data.to === 'string') {
+        breadcrumb.data.to = sanitizeUrl(breadcrumb.data.to);
+      }
+      if (typeof breadcrumb.data.from === 'string') {
+        breadcrumb.data.from = sanitizeUrl(breadcrumb.data.from);
+      }
+      if (typeof breadcrumb.data.url === 'string') {
+        breadcrumb.data.url = sanitizeUrl(breadcrumb.data.url);
+      }
+    }
+
     return event;
   },
 
@@ -118,6 +139,16 @@ Sentry.init({
         span.data.url = sanitizedUrl;
       }
     }
+
+    // HTTP and navigation/pageload spans put URL-bearing text in description
+    // (e.g. "GET /mint/quote/bolt11/QID" or "/receive/cashu/token#TOKEN").
+    // Match shapes that look like a URL/path or "METHOD URL" so non-URL
+    // descriptions stay untouched.
+    const description = span.description;
+    if (description && /^([A-Z]+ )?(\/|https?:\/\/)/.test(description)) {
+      span.description = sanitizeUrl(description);
+    }
+
     return span;
   },
 });

--- a/app/instrument.server.ts
+++ b/app/instrument.server.ts
@@ -136,6 +136,15 @@ Sentry.init({
         span.data.url = sanitizedUrl;
       }
     }
+
+    // HTTP server spans set description to "<METHOD> <pathname>" (e.g.
+    // "POST /api/lnurlp/verify/<data>"). Sanitize URL-shaped descriptions
+    // so path-pattern data doesn't leak via the rendered span name.
+    const description = span.description;
+    if (description && /^([A-Z]+ )?(\/|https?:\/\/)/.test(description)) {
+      span.description = sanitizeUrl(description);
+    }
+
     return span;
   },
 
@@ -148,6 +157,26 @@ Sentry.init({
 
     if (status !== undefined && status >= 400 && status < 500) {
       return null;
+    }
+
+    // Sanitize sensitive URL parts on the error event itself and on
+    // breadcrumbs that capture outgoing HTTP / navigation URLs.
+    if (event.request?.url) {
+      event.request.url = sanitizeUrl(event.request.url);
+    }
+    for (const breadcrumb of event.breadcrumbs ?? []) {
+      if (!breadcrumb.data) {
+        continue;
+      }
+      if (typeof breadcrumb.data.to === 'string') {
+        breadcrumb.data.to = sanitizeUrl(breadcrumb.data.to);
+      }
+      if (typeof breadcrumb.data.from === 'string') {
+        breadcrumb.data.from = sanitizeUrl(breadcrumb.data.from);
+      }
+      if (typeof breadcrumb.data.url === 'string') {
+        breadcrumb.data.url = sanitizeUrl(breadcrumb.data.url);
+      }
     }
 
     return event;

--- a/app/tracing-utils.ts
+++ b/app/tracing-utils.ts
@@ -15,13 +15,22 @@ export function getTracesSampleRate(): number {
 }
 
 /**
- * Sanitizes URLs to remove sensitive path parameters and query param values before sending
- * to tracing/analytics platforms. This prevents quote IDs, verification codes, and other
- * sensitive data from being logged.
+ * Sanitizes URLs to remove sensitive path parameters, query param values, and URL
+ * fragments (hashes) before sending to tracing/analytics platforms. This prevents
+ * quote IDs, verification codes, cashu tokens, and other sensitive data from being
+ * logged.
  */
 export function sanitizeUrl(url: string): string {
+  // Redact URL fragment (hash) since it can contain sensitive data such as
+  // cashu tokens, but keep the "#<redacted>" marker so it stays visible that
+  // a fragment was present.
+  const hashIndex = url.indexOf('#');
+  const beforeFragment = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const fragmentSuffix =
+    hashIndex !== -1 && hashIndex < url.length - 1 ? '#<redacted>' : '';
+
   // Separate path from query string
-  const [path, queryString] = url.split('?');
+  const [path, queryString] = beforeFragment.split('?');
 
   // Sanitize path segments
   const sanitizedPath = path
@@ -36,7 +45,7 @@ export function sanitizeUrl(url: string): string {
 
   // Redact query param values while preserving param names
   if (!queryString) {
-    return sanitizedPath;
+    return `${sanitizedPath}${fragmentSuffix}`;
   }
 
   const sanitizedQuery = queryString
@@ -51,5 +60,5 @@ export function sanitizeUrl(url: string): string {
     })
     .join('&');
 
-  return `${sanitizedPath}?${sanitizedQuery}`;
+  return `${sanitizedPath}?${sanitizedQuery}${fragmentSuffix}`;
 }


### PR DESCRIPTION
## Summary
Sentry's browser and server SDKs leak sensitive URL parts to the org via paths that were not being sanitized:

- **Client error events** carry the page URL on \`event.request.url\` (sourced from \`window.location.href\`, fragment included), plus auto-instrumented navigation/fetch breadcrumbs with their own URLs in \`data.to\` / \`data.from\` / \`data.url\`. Cashu token receive URLs (\`/receive/cashu/token#<TOKEN>\`) carry the token in the fragment, and mint quote IDs / verify-email codes / lnurlp data are in path segments — all of which were being sent to Sentry on every error.
- **Span descriptions** are populated by the SDK with strings like \`"GET /mint/quote/bolt11/QID"\` or \`"/receive/cashu/token#TOKEN"\` for HTTP and navigation/pageload spans. The previous \`beforeSendSpan\` only redacted \`span.data['http.url']\` / \`span.data.url\`, so the description still leaked the same bits via performance traces (and polluted aggregation by making every quote ID its own group).
- **Server-side Sentry** has its own \`Sentry.init\` in \`app/instrument.server.ts\` with a separate \`beforeSend\` and \`beforeSendSpan\`. Neither sanitized \`event.request.url\` or \`span.description\`, so server-side errors on routes like \`/verify-email/CODE\` or \`/api/lnurlp/verify/<encrypted_data>\` leaked the path components, and the SDK's per-request span name (\`"<METHOD> <pathname>"\`) leaked the same.

Fix:
- Move fragment stripping into \`sanitizeUrl\` so the existing path-pattern and query-value redactions apply uniformly. Single funnel for errors, breadcrumbs, span data, and span descriptions.
- In the **client** \`beforeSend\`, run \`sanitizeUrl\` over \`event.request.url\` and breadcrumb \`data.to\` / \`data.from\` / \`data.url\`.
- In both **client and server** \`beforeSendSpan\`, additionally run \`sanitizeUrl\` over \`span.description\` (gated to URL-shaped strings — \`/...\`, \`https?://...\`, or \`METHOD URL\` — so non-URL descriptions stay untouched).
- In the **server** \`beforeSend\`, run \`sanitizeUrl\` over \`event.request.url\` (after the existing 4xx filter).

Existing in-flight events with leaked tokens should be considered exposed; recipients should be encouraged to claim and senders to rotate where applicable.

## Test plan
- [ ] In production-like build, trigger an error on a route with a hash (e.g. \`/receive/cashu/token#…\`) and confirm the resulting Sentry event's \`request.url\` is fragment-free.
- [ ] Trigger an error after a fetch to a mint quote URL (\`/melt/quote/{method}/{quote_id}\` or \`/mint/quote/{method}/{quote_id}\`) and confirm the breadcrumb URL and the corresponding span's \`description\` both show \`<quote-id>\` instead of the real ID.
- [ ] Confirm history navigation breadcrumbs to/from a \`#…\` route also have fragments stripped.
- [ ] Existing \`beforeSend\` no-stack-trace drop still works (client) and 4xx filter still works (server).
- [ ] Pageload/navigation spans on \`/receive/cashu/token#…\` no longer carry the fragment in \`description\` or \`data.url\`.
- [ ] Trigger a server-side error on \`/verify-email/CODE\` or \`/api/lnurlp/verify/DATA\` and confirm \`event.request.url\` and the request span's \`description\` redact the path component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)