### PR TITLE
fix(receive): handle tokens with unsupported units gracefully

### DIFF
--- a/app/features/receive/unsupported-cashu-token-page.tsx
+++ b/app/features/receive/unsupported-cashu-token-page.tsx
@@ -1,0 +1,25 @@
+import {
+  ClosePageButton,
+  Page,
+  PageContent,
+  PageHeader,
+  PageHeaderTitle,
+} from '~/components/page';
+
+type Props = {
+  message: string;
+};
+
+export function UnsupportedCashuTokenPage({ message }: Props) {
+  return (
+    <Page>
+      <PageHeader>
+        <ClosePageButton to="/" transition="slideDown" applyTo="oldView" />
+        <PageHeaderTitle>Oops!</PageHeaderTitle>
+      </PageHeader>
+      <PageContent className="flex flex-col items-center justify-center text-center">
+        <p>{message}</p>
+      </PageContent>
+    </Page>
+  );
+}

--- a/app/lib/cashu/utils.ts
+++ b/app/lib/cashu/utils.ts
@@ -9,6 +9,7 @@ import {
   Wallet,
   splitAmount,
 } from '@cashu/cashu-ts';
+import type { Token } from '@cashu/cashu-ts';
 import type { DistributedOmit } from 'type-fest';
 import type { Currency, CurrencyUnit } from '../money';
 import {
@@ -16,7 +17,7 @@ import {
   type ExtendedMintQuoteBolt11Response,
   type MintPurpose,
 } from './protocol-extensions';
-import type { CashuProtocolUnit } from './types';
+import { CASHU_PROTOCOL_UNITS, type CashuProtocolUnit } from './types';
 
 const knownTestMints = [
   'https://testnut.cashu.space',
@@ -71,6 +72,26 @@ export const getCashuUnit = (currency: Currency) => {
  */
 export const getCashuProtocolUnit = (currency: Currency) => {
   return currencyToCashuProtocolUnit[currency];
+};
+
+export type CashuTokenValidation =
+  | { isTokenSupported: true }
+  | { isTokenSupported: false; message: string };
+
+/**
+ * Validates that a decoded Cashu token is one Agicash supports.
+ */
+export const validateCashuToken = (token: Token): CashuTokenValidation => {
+  if (
+    token.unit === undefined ||
+    !(token.unit in cashuProtocolUnitToCurrency)
+  ) {
+    return {
+      isTokenSupported: false,
+      message: `This token's unit isn't supported. Supported units: ${CASHU_PROTOCOL_UNITS.join(', ')}.`,
+    };
+  }
+  return { isTokenSupported: true };
 };
 
 /**

--- a/app/routes/_protected.receive.cashu_.token.tsx
+++ b/app/routes/_protected.receive.cashu_.token.tsx
@@ -15,6 +15,7 @@ import { ReceiveCashuTokenQuoteService } from '~/features/receive/receive-cashu-
 import { ReceiveCashuTokenService } from '~/features/receive/receive-cashu-token-service';
 import { SparkReceiveQuoteRepository } from '~/features/receive/spark-receive-quote-repository';
 import { SparkReceiveQuoteService } from '~/features/receive/spark-receive-quote-service';
+import { UnsupportedCashuTokenPage } from '~/features/receive/unsupported-cashu-token-page';
 import {
   decodeCashuToken,
   getCashuCryptography,
@@ -31,6 +32,7 @@ import { getUserFromCacheOrThrow } from '~/features/user/user-hooks';
 import { WriteUserRepository } from '~/features/user/user-repository';
 import { UserService } from '~/features/user/user-service';
 import { toast } from '~/hooks/use-toast';
+import { validateCashuToken } from '~/lib/cashu';
 import type { Route } from './+types/_protected.receive.cashu_.token';
 import { ReceiveCashuTokenSkeleton } from './receive-cashu-token-skeleton';
 
@@ -114,6 +116,15 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
     throw redirect('/receive');
   }
 
+  const validation = validateCashuToken(token);
+
+  if (!validation.isTokenSupported) {
+    return {
+      isTokenSupported: false as const,
+      message: validation.message,
+    };
+  }
+
   const location = new URL(request.url);
   const selectedAccountId =
     location.searchParams.get('selectedAccountId') ?? undefined;
@@ -151,7 +162,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
     throw redirect(redirectTo);
   }
 
-  return { token, selectedAccountId };
+  return { isTokenSupported: true as const, token, selectedAccountId };
 }
 
 clientLoader.hydrate = true as const;
@@ -163,14 +174,16 @@ export function HydrateFallback() {
 export default function ProtectedReceiveCashuToken({
   loaderData,
 }: Route.ComponentProps) {
-  const { token, selectedAccountId } = loaderData;
+  if (!loaderData.isTokenSupported) {
+    return <UnsupportedCashuTokenPage message={loaderData.message} />;
+  }
 
   return (
     <Page>
       <Suspense fallback={<ReceiveCashuTokenSkeleton />}>
         <ReceiveCashuToken
-          token={token}
-          preferredReceiveAccountId={selectedAccountId}
+          token={loaderData.token}
+          preferredReceiveAccountId={loaderData.selectedAccountId}
         />
       </Suspense>
     </Page>

--- a/app/routes/_public.receive-cashu-token.tsx
+++ b/app/routes/_public.receive-cashu-token.tsx
@@ -3,9 +3,11 @@ import { Page } from '~/components/page';
 import { getGiftCardByUrl } from '~/features/gift-cards/use-discover-cards';
 import { LoadingScreen } from '~/features/loading/LoadingScreen';
 import { PublicReceiveCashuToken } from '~/features/receive/receive-cashu-token';
+import { UnsupportedCashuTokenPage } from '~/features/receive/unsupported-cashu-token-page';
 import { decodeCashuToken } from '~/features/shared/cashu';
 import { getQueryClient } from '~/features/shared/query-client';
 import { authQueryOptions } from '~/features/user/auth';
+import { validateCashuToken } from '~/lib/cashu';
 import { normalizeMintUrl } from '~/lib/cashu/utils';
 import type { Route } from './+types/_public.receive-cashu-token';
 
@@ -88,7 +90,16 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
     throw redirect('/home');
   }
 
-  return { token };
+  const validation = validateCashuToken(token);
+
+  if (!validation.isTokenSupported) {
+    return {
+      isTokenSupported: false as const,
+      message: validation.message,
+    };
+  }
+
+  return { isTokenSupported: true as const, token };
 }
 
 clientLoader.hydrate = true as const;
@@ -100,11 +111,13 @@ export function HydrateFallback() {
 export default function ReceiveCashuTokenPage({
   loaderData,
 }: Route.ComponentProps) {
-  const { token } = loaderData;
+  if (!loaderData.isTokenSupported) {
+    return <UnsupportedCashuTokenPage message={loaderData.message} />;
+  }
 
   return (
     <Page>
-      <PublicReceiveCashuToken token={token} />
+      <PublicReceiveCashuToken token={loaderData.token} />
     </Page>
   );
 }


### PR DESCRIPTION
On master when a user inputs a token with an unsupported unit the app crashes:

<img width="433" height="232" alt="image" src="https://github.com/user-attachments/assets/48c02d3d-063a-41c3-9190-9baf889ffbb5" />

This PR makes the UI handle the error by not building the source account (because we can't convert the token amount to Money) and rendering the error display.

You can test with this token which has a unit of `eur`:
```
cashuBo2FteBtodHRwczovL3Rlc3RudXQuY2FzaHUuc3BhY2VhdWNldXJhdIGiYWlIAcl-4uZMFwhhcIWkYWEQYXN4QDY1NGU2ZjAzOTUyNTkyNmYwYjQ2ZmFkMGEyOWUxY2EwMzUxMDRmYmY3NTc0MmJmZTBjMTBlOWQ0ZGY0Y2IwMWFhY1ghA4PYroqlkDOr2wihN_PetoV7Hb1dN25CaJZCZ7CF1ahMYWSjYWVYIP9C1b64EWSH0kIazyN5WqP7oJiWQCOBHr_kja2kLpzMYXNYIASN9_hjQrcZwmRwOyISoxoNZuUMyOCLvy8mKnu5JWmqYXJYIB7jqp4iJAWwFfq8SJzGe6-kevml5alCTsMjMTNbBAaepGFhAmFzeEA1Y2Y0MDE1ZmMwNDk2MmViYWZmMDcxZWQwNDRmOGYyZDk4M2JkZmVmNzZhMTdlOWJjYzU0YzI5YTJkOWMyNGRiYWNYIQMPFDvthb0w8HDtbMmpR0ORqr8BwYJYdkWr1cP0b8p5JWFko2FlWCC9T_88HKPnuVHo1u4te6fiaiyS6TdFWo74zkDmAjHTO2FzWCAKqbxFulHwz01jNRCDK748GooahWNNQyE-NiznhQpwymFyWCDWqVP-gzwg9ZUsWP_L28elZcHuTDVUt2xjAQLVxPfEK6RhYQFhc3hANmYxYjBlZDllNDkyYjc5MWYzMzAzYWYzODlmNmVkMDFkMzlhMGRmZjlkNGZlYjkxZTYwM2EzOTdmMDRiMjVlZmFjWCEDyZiV9Sn-894-AjeMXzfEPbnqqJ4if7Cw_iTX5w3Wp4JhZKNhZVgg4m9L5Eh6llNlHe90Kf7k-2YwqM4dzyGG6NiV5cUAVUJhc1ggK4J7iE0YcgOpuCkt6XUQhxxvuppag3CdOBDkBrzuK0thclggjgrYOYB_opSy68FryfAUD9VCa7uKrozMIc7b5L2infSkYWEBYXN4QGIzZWUxMWVjY2IwNGU1NTcxMzRkMWQyNTA3MzBkMGY4MDgxZmFhYWY5YWM5MjNmNTM3NzJkNWIwMDBmYTZjMWFhY1ghAm3WP40PcibFplJzG3iCH9VxXvQ1XxZe8LqVqVo76l55YWSjYWVYIC_qkOlb6hHKFhk5F2XDvsWHeEcFPWeSXNnbL7W8zwCxYXNYID3abf4Y6uVnTZ6VQjVl6_8F34dHcNHMfbYmrecJG8BgYXJYIIhMmTXTFzoA3Glimd5neChXTIMR7ldeVzJLTwIMTCEMpGFhAWFzeEA5N2RlMmZlYzVkNDVmZDdiNmEwN2JjNTQxZmM5YmU3MmYzN2MwZDFjZDYyZDY2NjVkYTUzZDNiM2U4N2ZjMzQ5YWNYIQJZpl2d91gtJ49IzcOlUGmREDHCqmyn3zFJDIhx_KeskGFko2FlWCCA6PGKut-yg8MOoUjXnlrPf6_6nGS_9qrPeemyxAI3kWFzWCDSJ2GGdWHvd3M3NKS-7JZkjI1oIYu18VMFiLOHxzxBOmFyWCAXf2UiTFEpMxJJXkWcvj5BWKo95QCSPXdeEI_OZFNoLA
```