### PR TITLE
feat: support multiple offers in the UI

### DIFF
--- a/app/features/gift-cards/discover-gift-cards.tsx
+++ b/app/features/gift-cards/discover-gift-cards.tsx
@@ -1,11 +1,4 @@
-import { useEffect, useRef } from 'react';
-import {
-  Link,
-  useLocation,
-  useNavigate,
-  useViewTransitionState,
-} from 'react-router';
-import { z } from 'zod';
+import { Link, useNavigate, useViewTransitionState } from 'react-router';
 import {
   WalletCard,
   WalletCardBackgroundImage,
@@ -13,40 +6,11 @@ import {
 import useUserAgent from '~/hooks/use-user-agent';
 import { cn } from '~/lib/utils';
 import type { GiftCardInfo } from './gift-card-config';
-
-const DiscoverCardsLocationStateSchema = z.object({
-  discoverScrollPosition: z.number(),
-});
-
-/**
- * Restores scroll position from navigation state when returning from add-gift-card page.
- * Returns the current scroll position for passing to child Link components.
- */
-function useRestoreScrollPosition() {
-  const location = useLocation();
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const scrollPositionRef = useRef(0);
-
-  // Restore scroll position from navigation state
-  useEffect(() => {
-    const result = DiscoverCardsLocationStateSchema.safeParse(location.state);
-    if (result.success && scrollRef.current) {
-      scrollRef.current.scrollLeft = result.data.discoverScrollPosition;
-    }
-  }, [location.state]);
-
-  const handleScroll = () => {
-    if (scrollRef.current) {
-      scrollPositionRef.current = scrollRef.current.scrollLeft;
-    }
-  };
-
-  return { scrollRef, scrollPositionRef, handleScroll };
-}
+import { useRestoreScrollPosition } from './use-restore-scroll-position';
 
 type DiscoverCardLinkProps = {
   card: GiftCardInfo;
-  scrollPositionRef: React.RefObject<number>;
+  getScrollState: () => object;
   children: React.ReactNode;
 };
 
@@ -56,7 +20,7 @@ type DiscoverCardLinkProps = {
  */
 function DiscoverCardLink({
   card,
-  scrollPositionRef,
+  getScrollState,
   children,
 }: DiscoverCardLinkProps) {
   const navigate = useNavigate();
@@ -67,12 +31,7 @@ function DiscoverCardLink({
   // Use onClick to capture scroll position at click time, not render time
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    navigate(to, {
-      viewTransition: true,
-      state: {
-        discoverScrollPosition: scrollPositionRef.current,
-      } satisfies z.input<typeof DiscoverCardsLocationStateSchema>,
-    });
+    navigate(to, { viewTransition: true, state: getScrollState() });
   };
 
   return (
@@ -101,8 +60,9 @@ type DiscoverSectionProps = {
 export function DiscoverGiftCards({ giftCards }: DiscoverSectionProps) {
   const { isMobile } = useUserAgent();
   const isTransitioning = useViewTransitionState('/gift-cards/:accountId');
-  const { scrollRef, scrollPositionRef, handleScroll } =
-    useRestoreScrollPosition();
+  const { scrollRef, handleScroll, getScrollState } = useRestoreScrollPosition(
+    'discoverScrollPosition',
+  );
 
   return (
     <div
@@ -128,7 +88,7 @@ export function DiscoverGiftCards({ giftCards }: DiscoverSectionProps) {
               <DiscoverCardLink
                 key={`${card.url}:${card.currency}`}
                 card={card}
-                scrollPositionRef={scrollPositionRef}
+                getScrollState={getScrollState}
               >
                 <WalletCard
                   size="sm"

--- a/app/features/gift-cards/gift-cards.tsx
+++ b/app/features/gift-cards/gift-cards.tsx
@@ -17,7 +17,7 @@ import { DiscoverGiftCards } from './discover-gift-cards';
 import { EmptyState } from './empty-state';
 import { getGiftCardImageByUrl } from './gift-card-images';
 import { GiftCardItem } from './gift-card-item';
-import { OfferItem } from './offer-item';
+import { OffersSection } from './offers-section';
 import { useDiscoverGiftCards } from './use-discover-cards';
 
 /**
@@ -34,9 +34,6 @@ export function GiftCards() {
   const isGiftCardTransitioning = useViewTransitionState(
     '/gift-cards/:accountId',
   );
-  const isOfferCardTransitioning = useViewTransitionState(
-    '/gift-cards/offers/:accountId',
-  );
 
   const hasCards = accounts.length > 0;
   const stackedHeight =
@@ -45,10 +42,6 @@ export function GiftCards() {
 
   const handleCardClick = (account: CashuAccount) => {
     navigate(`/gift-cards/${account.id}`, { viewTransition: true });
-  };
-
-  const handleOfferClick = (account: CashuAccount) => {
-    navigate(`/gift-cards/offers/${account.id}`, { viewTransition: true });
   };
 
   return (
@@ -64,35 +57,7 @@ export function GiftCards() {
             <DiscoverGiftCards giftCards={giftCardsToDiscover} />
           )}
 
-          {offerCards.length > 0 && (
-            <div className="flex w-full shrink-0 flex-col items-center px-4 pb-8">
-              <h2 className="mb-3 w-full text-white">Offers</h2>
-              <div
-                className="flex w-full flex-col gap-3"
-                style={{ maxWidth: CARD_WIDTH }}
-              >
-                {offerCards.map((account) => (
-                  <button
-                    key={account.id}
-                    type="button"
-                    onClick={() => handleOfferClick(account)}
-                    aria-label={`View ${account.name} offer`}
-                    className="w-full"
-                    style={{
-                      viewTransitionName: isOfferCardTransitioning
-                        ? `offer-${account.id}`
-                        : undefined,
-                    }}
-                  >
-                    <OfferItem
-                      account={account}
-                      image={getGiftCardImageByUrl(account.mintUrl)}
-                    />
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
+          <OffersSection offers={offerCards} />
 
           {hasCards ? (
             <div className="flex w-full shrink-0 flex-col items-center pb-8">

--- a/app/features/gift-cards/offers-section.tsx
+++ b/app/features/gift-cards/offers-section.tsx
@@ -75,13 +75,10 @@ export function OffersSection({ offers }: OffersSectionProps) {
     'offersScrollPosition',
   );
 
-  const navigateToOffer = (
-    account: CashuAccount,
-    includeScrollState: boolean,
-  ) => {
+  const navigateToOffer = (account: CashuAccount) => {
     navigate(`/gift-cards/offers/${account.id}`, {
       viewTransition: true,
-      state: includeScrollState ? getScrollState() : undefined,
+      state: getScrollState(),
     });
   };
 
@@ -96,7 +93,7 @@ export function OffersSection({ offers }: OffersSectionProps) {
           <OfferCardButton
             account={offer}
             isTransitioning={isTransitioning}
-            onClick={() => navigateToOffer(offer, false)}
+            onClick={() => navigateToOffer(offer)}
             className="w-full"
           />
         </div>
@@ -114,7 +111,7 @@ export function OffersSection({ offers }: OffersSectionProps) {
               key={offer.id}
               account={offer}
               isTransitioning={isTransitioning}
-              onClick={() => navigateToOffer(offer, false)}
+              onClick={() => navigateToOffer(offer)}
               className="min-w-0 flex-1"
             />
           ))}
@@ -144,7 +141,7 @@ export function OffersSection({ offers }: OffersSectionProps) {
                 account={offer}
                 size="sm"
                 isTransitioning={isTransitioning}
-                onClick={() => navigateToOffer(offer, true)}
+                onClick={() => navigateToOffer(offer)}
                 cardClassName={cn(
                   index === 0 && 'ml-4 sm:ml-0',
                   index === offers.length - 1 && 'mr-4 sm:mr-0',

--- a/app/features/gift-cards/offers-section.tsx
+++ b/app/features/gift-cards/offers-section.tsx
@@ -1,0 +1,159 @@
+import { useNavigate, useViewTransitionState } from 'react-router';
+import {
+  WalletCard,
+  WalletCardBackgroundImage,
+  WalletCardBlank,
+  WalletCardOverlay,
+} from '~/components/wallet-card';
+import type { CashuAccount } from '~/features/accounts/account';
+import useUserAgent from '~/hooks/use-user-agent';
+import { cn } from '~/lib/utils';
+import { CARD_WIDTH } from './card-stack-constants';
+import { getGiftCardImageByUrl } from './gift-card-images';
+import { useRestoreScrollPosition } from './use-restore-scroll-position';
+
+type OfferCardButtonProps = {
+  account: CashuAccount;
+  size?: 'default' | 'sm';
+  isTransitioning: boolean;
+  onClick: () => void;
+  className?: string;
+  cardClassName?: string;
+};
+
+function OfferCardButton({
+  account,
+  size = 'default',
+  isTransitioning,
+  onClick,
+  className,
+  cardClassName,
+}: OfferCardButtonProps) {
+  const image = getGiftCardImageByUrl(account.mintUrl);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`View ${account.name} offer`}
+      className={cn('block', className)}
+      style={{
+        viewTransitionName: isTransitioning ? `offer-${account.id}` : undefined,
+      }}
+    >
+      <WalletCard
+        size={size}
+        className={cn(size === 'default' && 'w-full max-w-none', cardClassName)}
+      >
+        {image ? (
+          <WalletCardBackgroundImage src={image} alt={account.name} />
+        ) : (
+          <>
+            <WalletCardBlank />
+            <WalletCardOverlay className="flex items-center justify-center px-4">
+              <span className="truncate text-card-foreground text-lg">
+                {account.name}
+              </span>
+            </WalletCardOverlay>
+          </>
+        )}
+      </WalletCard>
+    </button>
+  );
+}
+
+type OffersSectionProps = {
+  offers: CashuAccount[];
+};
+
+export function OffersSection({ offers }: OffersSectionProps) {
+  const navigate = useNavigate();
+  const isTransitioning = useViewTransitionState(
+    '/gift-cards/offers/:accountId',
+  );
+  const { isMobile } = useUserAgent();
+  const { scrollRef, handleScroll, getScrollState } = useRestoreScrollPosition(
+    'offersScrollPosition',
+  );
+
+  const navigateToOffer = (
+    account: CashuAccount,
+    includeScrollState: boolean,
+  ) => {
+    navigate(`/gift-cards/offers/${account.id}`, {
+      viewTransition: true,
+      state: includeScrollState ? getScrollState() : undefined,
+    });
+  };
+
+  if (offers.length === 0) return null;
+
+  if (offers.length === 1) {
+    const offer = offers[0];
+    return (
+      <div className="flex w-full shrink-0 flex-col items-center px-4 pb-8">
+        <h2 className="mb-3 w-full text-white">Offers</h2>
+        <div className="w-full" style={{ maxWidth: CARD_WIDTH }}>
+          <OfferCardButton
+            account={offer}
+            isTransitioning={isTransitioning}
+            onClick={() => navigateToOffer(offer, false)}
+            className="w-full"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (offers.length === 2) {
+    return (
+      <div className="flex w-full shrink-0 flex-col items-center px-4 pb-8">
+        <h2 className="mb-3 w-full text-white">Offers</h2>
+        <div className="flex w-full gap-3" style={{ maxWidth: CARD_WIDTH }}>
+          {offers.map((offer) => (
+            <OfferCardButton
+              key={offer.id}
+              account={offer}
+              isTransitioning={isTransitioning}
+              onClick={() => navigateToOffer(offer, false)}
+              className="min-w-0 flex-1"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full shrink-0 pb-8">
+      <h2 className="mb-3 px-4 text-white">Offers</h2>
+      <div className="sm:px-4">
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className={cn(
+            'overflow-x-auto pb-1',
+            isMobile
+              ? 'scrollbar-none'
+              : '[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:h-1.5',
+          )}
+        >
+          <div className="flex w-max gap-3 pb-2">
+            {offers.map((offer, index) => (
+              <OfferCardButton
+                key={offer.id}
+                account={offer}
+                size="sm"
+                isTransitioning={isTransitioning}
+                onClick={() => navigateToOffer(offer, true)}
+                cardClassName={cn(
+                  index === 0 && 'ml-4 sm:ml-0',
+                  index === offers.length - 1 && 'mr-4 sm:mr-0',
+                )}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/features/gift-cards/use-restore-scroll-position.ts
+++ b/app/features/gift-cards/use-restore-scroll-position.ts
@@ -1,0 +1,39 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useLocation } from 'react-router';
+import { z } from 'zod';
+
+/**
+ * Persists and restores the horizontal scroll position of a container across
+ * navigations, keyed by `stateKey` in `location.state`. Pass `getScrollState()`
+ * as the `state` argument to `navigate(...)` when leaving the page so the
+ * position gets restored on back navigation.
+ */
+export function useRestoreScrollPosition<K extends string>(stateKey: K) {
+  const location = useLocation();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollPositionRef = useRef(0);
+
+  const schema = useMemo(
+    () => z.object({ [stateKey]: z.number() }),
+    [stateKey],
+  );
+
+  useEffect(() => {
+    const result = schema.safeParse(location.state);
+    if (result.success && scrollRef.current) {
+      const value = (result.data as Record<K, number>)[stateKey];
+      scrollRef.current.scrollLeft = value;
+    }
+  }, [location.state, schema, stateKey]);
+
+  const handleScroll = () => {
+    if (scrollRef.current) {
+      scrollPositionRef.current = scrollRef.current.scrollLeft;
+    }
+  };
+
+  const getScrollState = () =>
+    ({ [stateKey]: scrollPositionRef.current }) as Record<K, number>;
+
+  return { scrollRef, handleScroll, getScrollState };
+}

--- a/app/features/gift-cards/use-restore-scroll-position.ts
+++ b/app/features/gift-cards/use-restore-scroll-position.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
 import { z } from 'zod';
 
@@ -13,18 +13,15 @@ export function useRestoreScrollPosition<K extends string>(stateKey: K) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const scrollPositionRef = useRef(0);
 
-  const schema = useMemo(
-    () => z.object({ [stateKey]: z.number() }),
-    [stateKey],
-  );
-
   useEffect(() => {
-    const result = schema.safeParse(location.state);
+    const result = z
+      .object({ [stateKey]: z.number() })
+      .safeParse(location.state);
+
     if (result.success && scrollRef.current) {
-      const value = (result.data as Record<K, number>)[stateKey];
-      scrollRef.current.scrollLeft = value;
+      scrollRef.current.scrollLeft = result.data[stateKey];
     }
-  }, [location.state, schema, stateKey]);
+  }, [location.state, stateKey]);
 
   const handleScroll = () => {
     if (scrollRef.current) {
@@ -32,8 +29,12 @@ export function useRestoreScrollPosition<K extends string>(stateKey: K) {
     }
   };
 
-  const getScrollState = () =>
-    ({ [stateKey]: scrollPositionRef.current }) as Record<K, number>;
+  const getScrollState = () => ({
+    ...(typeof location.state === 'object' && location.state !== null
+      ? location.state
+      : {}),
+    [stateKey]: scrollPositionRef.current,
+  });
 
   return { scrollRef, handleScroll, getScrollState };
 }


### PR DESCRIPTION
Render the offers section on the gift cards page differently based on offer count: 1 offer stays full-sized, 2 offers go side-by-side at half width, 3+ become a horizontal scroll carousel at discover-card size.

Extract the discover section's scroll-position-restoration hook into a shared useRestoreScrollPosition keyed by location.state name, used by both DiscoverGiftCards and the new OffersSection.