### PR TITLE
Fix/qr share spacing

### DIFF
--- a/app/features/receive/receive-cashu.tsx
+++ b/app/features/receive/receive-cashu.tsx
@@ -167,7 +167,7 @@ export default function ReceiveCashu({ amount, account }: Props) {
           onClick={
             paymentRequest ? () => handleCopy(paymentRequest) : undefined
           }
-          className="gap-4"
+          className="gap-4 pt-2"
           size={256}
         />
         {mintingFee && (

--- a/app/features/receive/receive-spark.tsx
+++ b/app/features/receive/receive-spark.tsx
@@ -118,6 +118,7 @@ export default function ReceiveSpark({ amount, account }: Props) {
           error={errorMessage}
           isLoading={isLoading}
           onClick={quote ? () => handleCopy(quote.paymentRequest) : undefined}
+          className="pt-2"
         />
       </PageContent>
       {showOk && (

--- a/app/features/send/share-cashu-token.tsx
+++ b/app/features/send/share-cashu-token.tsx
@@ -24,30 +24,72 @@ import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
 import { encodeToken } from '~/lib/cashu/token';
 import { normalizeMintUrl } from '~/lib/cashu/utils';
+import type { Money } from '~/lib/money';
 import { canShare, shareContent } from '~/lib/share';
 import { LinkWithViewTransition } from '~/lib/transitions';
-import { tokenToMoney } from '../shared/cashu';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 
 type Props = {
-  token: Token;
+  amount: Money;
+  token?: Token;
 };
 
-export function ShareCashuToken({ token }: Props) {
+type ShareOption = {
+  value?: string;
+  description: string;
+  animate?: boolean;
+  toast: { title: string; description?: string };
+};
+
+const deriveTokenStrings = (token: Token, origin: string) => {
+  const encodedToken = encodeToken(token, { removeDleq: true });
+  const mintParam = encodeURIComponent(
+    normalizeMintUrl(token.mint).replace(/^https?:\/\//, ''),
+  );
+  const shortToken = `${encodedToken.slice(0, 6)}...${encodedToken.slice(-5)}`;
+  return {
+    encodedToken,
+    shortToken,
+    shareableLink: `${origin}/receive-cashu-token?mint=${mintParam}#${encodedToken}`,
+    shortShareableLink: `${origin}/receive-cashu-token#${shortToken}`,
+  };
+};
+
+export function ShareCashuToken({ amount, token }: Props) {
   const { toast } = useToast();
   const { origin } = useLocationData();
   const { redirectTo } = useRedirectTo('/');
   const [, copyToClipboard] = useCopyToClipboard();
-  const amount = tokenToMoney(token);
   const [showOk, setShowOk] = useState(false);
 
-  const encodedToken = encodeToken(token, { removeDleq: true });
-  const normalizedMint = normalizeMintUrl(token.mint);
-  const mintWithoutScheme = normalizedMint.replace(/^https?:\/\//, '');
-  const mintParam = encodeURIComponent(mintWithoutScheme);
-  const shareableLink = `${origin}/receive-cashu-token?mint=${mintParam}#${encodedToken}`;
-  const shortToken = `${encodedToken.slice(0, 6)}...${encodedToken.slice(-5)}`;
-  const shortShareableLink = `${origin}/receive-cashu-token#${shortToken}`;
+  const strings = token ? deriveTokenStrings(token, origin) : null;
+
+  const shareOptions: ShareOption[] = [
+    {
+      value: strings?.shareableLink,
+      description: 'Click to copy Shareable Link',
+      toast: {
+        title: 'Copied Shareable Link to clipboard',
+        description: strings?.shortShareableLink,
+      },
+    },
+    {
+      value: strings?.encodedToken,
+      animate: true,
+      description: 'Click to copy eCash Token',
+      toast: {
+        title: 'Copied eCash Token to clipboard',
+        description: strings?.shortToken,
+      },
+    },
+  ];
+
+  const handleCopy = (option: ShareOption) => {
+    if (!option.value) return;
+    copyToClipboard(option.value);
+    setShowOk(true);
+    toast({ ...option.toast, duration: 1000 });
+  };
 
   return (
     <Page>
@@ -63,10 +105,10 @@ export function ShareCashuToken({ token }: Props) {
             <button
               type="button"
               onClick={() => {
-                shareContent({
-                  url: shareableLink,
-                });
+                const link = shareOptions[0]?.value;
+                if (link) shareContent({ url: link });
               }}
+              className="flex h-6 w-6 appearance-none items-center justify-center"
             >
               <Share />
             </button>
@@ -75,40 +117,20 @@ export function ShareCashuToken({ token }: Props) {
       </PageHeader>
       <PageContent className="animate-in items-center gap-0 overflow-x-hidden overflow-y-hidden duration-300">
         <MoneyWithConvertedAmount money={amount} />
-        <div className="flex w-full flex-col items-center justify-center px-4 py-4 pb-8">
+        <div className="flex w-full flex-col items-center justify-center px-4 pt-6 pb-8">
           <Carousel opts={{ align: 'center', loop: true }}>
             <CarouselContent>
-              <CarouselItem>
-                <QRCode
-                  value={shareableLink}
-                  description="Click to copy Shareable Link"
-                  onClick={() => {
-                    copyToClipboard(shareableLink);
-                    setShowOk(true);
-                    toast({
-                      title: 'Copied Shareable Link to clipboard',
-                      description: shortShareableLink,
-                      duration: 1000,
-                    });
-                  }}
-                />
-              </CarouselItem>
-              <CarouselItem>
-                <QRCode
-                  value={encodedToken}
-                  animate={true}
-                  description="Click to copy eCash Token"
-                  onClick={() => {
-                    copyToClipboard(encodedToken);
-                    setShowOk(true);
-                    toast({
-                      title: 'Copied eCash Token to clipboard',
-                      description: shortToken,
-                      duration: 1000,
-                    });
-                  }}
-                />
-              </CarouselItem>
+              {shareOptions.map((option) => (
+                <CarouselItem key={option.description}>
+                  <QRCode
+                    value={option.value}
+                    isLoading={!option.value}
+                    animate={option.animate}
+                    description={option.description}
+                    onClick={() => handleCopy(option)}
+                  />
+                </CarouselItem>
+              ))}
             </CarouselContent>
             <CarouselControls>
               <Link className="h-5 w-5" />

--- a/app/routes/_protected.send.share.$swapId.tsx
+++ b/app/routes/_protected.send.share.$swapId.tsx
@@ -1,19 +1,9 @@
-import {
-  ClosePageButton,
-  Page,
-  PageContent,
-  PageHeader,
-  PageHeaderTitle,
-} from '~/components/page';
-import { QRCode } from '~/components/qr-code';
 import { toProof } from '~/features/accounts/cashu-account';
 import {
   useCashuSendSwap,
   useTrackCashuSendSwap,
 } from '~/features/send/cashu-send-swap-hooks';
 import { ShareCashuToken } from '~/features/send/share-cashu-token';
-import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
-import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { getCashuProtocolUnit } from '~/lib/cashu';
 import { useNavigateWithViewTransition } from '~/lib/transitions';
@@ -21,7 +11,6 @@ import type { Route } from './+types/_protected.send.share.$swapId';
 
 export default function SendShare({ params }: Route.ComponentProps) {
   const navigate = useNavigateWithViewTransition();
-  const { redirectTo } = useRedirectTo('/');
   const buildLinkWithSearchParams = useBuildLinkWithSearchParams();
 
   const { data: swap } = useCashuSendSwap(params.swapId);
@@ -41,34 +30,14 @@ export default function SendShare({ params }: Route.ComponentProps) {
     },
   });
 
-  // Skeleton view for DRAFT swaps. Once the swap is PENDING we have proofs to send and can show the token.
-  // Once the swap is COMPLETED the onCompleted callback will navigate to the transaction page.
-  if (swap.state !== 'PENDING' && swap.state !== 'COMPLETED') {
-    return (
-      <Page>
-        <PageHeader>
-          <ClosePageButton
-            to={redirectTo}
-            transition="slideDown"
-            applyTo="oldView"
-          />
-          <PageHeaderTitle>Send</PageHeaderTitle>
-        </PageHeader>
-        <PageContent className="animate-in items-center gap-0 overflow-x-hidden overflow-y-hidden duration-300">
-          <MoneyWithConvertedAmount money={swap.amountToSend} />
-          <div className="flex w-full flex-col items-center justify-center px-4 py-4 pb-8">
-            <QRCode isLoading={true} />
-          </div>
-        </PageContent>
-      </Page>
-    );
-  }
+  const token =
+    swap.state === 'PENDING' || swap.state === 'COMPLETED'
+      ? {
+          mint: swap.account.mintUrl,
+          proofs: swap.proofsToSend.map((p) => toProof(p)),
+          unit: getCashuProtocolUnit(swap.amountToSend.currency),
+        }
+      : undefined;
 
-  const token = {
-    mint: swap.account.mintUrl,
-    proofs: swap.proofsToSend.map((p) => toProof(p)),
-    unit: getCashuProtocolUnit(swap.amountToSend.currency),
-  };
-
-  return <ShareCashuToken token={token} />;
+  return <ShareCashuToken amount={swap.amountToSend} token={token} />;
 }


### PR DESCRIPTION
adds some more padding between the amounts and the qr code. 

On the ShareCashuToken screen, the skeleton view was initially separate from the actual component, causing a slight layout shift when transitioning between the skeleton and the displayed token. I updated the ShareCashuToken component to accept an undefined token, allowing the layout to be built only once. The only element that changes is the QR code, which simplifies maintaining a consistent layout.