### PR TITLE
refactor(settings): remove USD from accounts UI

### DIFF
--- a/app/features/settings/accounts/add-mint-form.tsx
+++ b/app/features/settings/accounts/add-mint-form.tsx
@@ -1,43 +1,31 @@
 import type { MintKeyset } from '@cashu/cashu-ts';
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
-import { Controller, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import { useLocation, useNavigate } from 'react-router';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '~/components/ui/select';
 import { useAddCashuAccount } from '~/features/accounts/account-hooks';
 import {
   allMintKeysetsQueryOptions,
   cashuMintValidator,
   mintInfoQueryOptions,
 } from '~/features/shared/cashu';
-import { useUser } from '~/features/user/user-hooks';
 import { useToast } from '~/hooks/use-toast';
 import {
   type ExtendedMintInfo,
   getCashuProtocolUnit,
   getMintPurpose,
 } from '~/lib/cashu';
-import type { Currency } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 
 type FormValues = {
   name: string;
-  currency: Currency;
   mintUrl: string;
 };
 
-const currencies = [
-  { value: 'BTC', label: 'BTC' },
-  { value: 'USD', label: 'USD' },
-];
+const ACCOUNT_CURRENCY = 'BTC' as const;
+const ACCOUNT_UNIT = getCashuProtocolUnit(ACCOUNT_CURRENCY);
 
 type GetMintInfoAndKeysetsResult =
   | {
@@ -74,10 +62,8 @@ const getMintInfoAndKeysets = async (
 
 const validateMint = async (
   value: string,
-  formValues: FormValues,
   queryClient: QueryClient,
 ): Promise<string | true> => {
-  const unit = getCashuProtocolUnit(formValues.currency);
   const result = await getMintInfoAndKeysets(value, queryClient);
   if (!result.success) {
     return result.error;
@@ -85,7 +71,7 @@ const validateMint = async (
 
   return cashuMintValidator(
     value,
-    unit,
+    ACCOUNT_UNIT,
     result.data.mintInfo,
     result.data.keysets,
   );
@@ -95,21 +81,14 @@ export function AddMintForm() {
   const addAccount = useAddCashuAccount();
   const { toast } = useToast();
   const navigate = useNavigate();
-  const defaultCurrency = useUser((u) => u.defaultCurrency);
   const location = useLocation();
   const queryClient = useQueryClient();
 
   const {
     register,
     handleSubmit,
-    control,
-    getValues,
     formState: { isSubmitting, errors },
-  } = useForm<FormValues>({
-    defaultValues: {
-      currency: defaultCurrency,
-    },
-  });
+  } = useForm<FormValues>();
 
   const onSubmit = async (data: FormValues) => {
     try {
@@ -119,7 +98,7 @@ export function AddMintForm() {
       const purpose = getMintPurpose(mintInfo);
       await addAccount({
         name: data.name,
-        currency: data.currency,
+        currency: ACCOUNT_CURRENCY,
         mintUrl: data.mintUrl,
         type: 'cashu',
         purpose,
@@ -141,9 +120,6 @@ export function AddMintForm() {
       });
     }
   };
-
-  const currency = getValues('currency');
-  const unit = getCashuProtocolUnit(currency);
 
   return (
     <form
@@ -174,46 +150,6 @@ export function AddMintForm() {
       </div>
 
       <div className="grid gap-2">
-        <Label htmlFor="currency">Currency</Label>
-        <Controller
-          control={control}
-          name="currency"
-          rules={{ required: 'Currency is required' }}
-          render={({ field }) => (
-            <Select
-              onValueChange={field.onChange}
-              value={field.value}
-              name={field.name}
-            >
-              <SelectTrigger
-                id="currency"
-                aria-invalid={errors.currency ? 'true' : 'false'}
-              >
-                <SelectValue placeholder="Select a currency" />
-              </SelectTrigger>
-              <SelectContent>
-                {currencies.map((currency) => (
-                  <SelectItem key={currency.value} value={currency.value}>
-                    {currency.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        />
-        {errors.currency && (
-          <span
-            id="currencyError"
-            role="alert"
-            aria-labelledby="currencyError"
-            className="text-red-500 text-sm"
-          >
-            {errors.currency.message}
-          </span>
-        )}
-      </div>
-
-      <div className="grid gap-2">
         <Label htmlFor="mintUrl">Mint URL</Label>
         <Input
           id="mintUrl"
@@ -221,7 +157,7 @@ export function AddMintForm() {
           placeholder="Mint URL (https://...)"
           {...register('mintUrl', {
             required: 'Mint URL is required',
-            validate: (value) => validateMint(value, getValues(), queryClient),
+            validate: (value) => validateMint(value, queryClient),
           })}
         />
         {errors.mintUrl && (
@@ -238,7 +174,7 @@ export function AddMintForm() {
           Search at{' '}
           <a
             className="underline"
-            href={`https://bitcoinmints.com?show=cashu&units=${unit}`}
+            href={`https://bitcoinmints.com?show=cashu&units=${ACCOUNT_UNIT}`}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/app/features/settings/accounts/all-accounts.tsx
+++ b/app/features/settings/accounts/all-accounts.tsx
@@ -8,70 +8,17 @@ import {
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
-
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { getAccountBalance } from '~/features/accounts/account';
 import { useAccounts } from '~/features/accounts/account-hooks';
 import { BalanceOfflineHoverCard } from '~/features/accounts/balance-offline-hover-card';
 import { MoneyWithConvertedAmount } from '~/features/shared/money-with-converted-amount';
-import { useUser } from '~/features/user/user-hooks';
-import type { Currency } from '~/lib/money';
 import { LinkWithViewTransition } from '~/lib/transitions';
 
-function CurrencyAccounts({ currency }: { currency: Currency }) {
+export default function AllAccounts() {
   const { data: accounts } = useAccounts({
-    currency,
+    currency: 'BTC',
     purpose: 'transactional',
   });
-
-  return (
-    <div className="space-y-3">
-      {accounts.map((account) => {
-        const balance = getAccountBalance(account);
-
-        return (
-          <LinkWithViewTransition
-            key={account.id}
-            to={`/settings/accounts/${account.id}`}
-            transition="slideLeft"
-            applyTo="newView"
-            className="block"
-          >
-            <Card className="flex flex-col p-2 px-4 transition-colors hover:bg-muted/50">
-              <div className="flex items-center justify-between">
-                <h3>{account.name}</h3>
-                {balance !== null ? (
-                  <MoneyWithConvertedAmount money={balance} variant="inline" />
-                ) : (
-                  <BalanceOfflineHoverCard accountType={account.type} />
-                )}
-              </div>
-              {(account.isDefault || !account.isOnline) && (
-                <div className="mt-1 flex gap-2">
-                  {account.isDefault && <Badge>Default</Badge>}
-                  {!account.isOnline && <Badge>Offline</Badge>}
-                </div>
-              )}
-            </Card>
-          </LinkWithViewTransition>
-        );
-      })}
-    </div>
-  );
-}
-
-const tabs = [
-  { title: 'Bitcoin', value: 'BTC' },
-  { title: 'USD', value: 'USD' },
-] as const;
-
-const getTab = (currency: Currency) => {
-  return tabs.find((x) => x.value === currency) ?? tabs[0];
-};
-
-export default function AllAccounts() {
-  const defaultCurrency = useUser((x) => x.defaultCurrency);
-  const defaultTab = getTab(defaultCurrency);
 
   return (
     <>
@@ -84,22 +31,41 @@ export default function AllAccounts() {
         <PageHeaderTitle>Accounts</PageHeaderTitle>
       </PageHeader>
       <PageContent>
-        <Tabs defaultValue={defaultTab.value}>
-          <TabsList className="grid w-full grid-cols-2 bg-primary">
-            {tabs.map((tab) => (
-              <TabsTrigger value={tab.value} key={tab.value}>
-                {tab.title}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-          {tabs.map((tab) => (
-            <TabsContent value={tab.value} key={tab.value} className="mt-8">
-              <div className="scrollbar-none h-[calc(100vh-280px)] overflow-y-auto">
-                <CurrencyAccounts currency={tab.value} />
-              </div>
-            </TabsContent>
-          ))}
-        </Tabs>
+        <div className="scrollbar-none h-[calc(100vh-200px)] space-y-3 overflow-y-auto">
+          {accounts.map((account) => {
+            const balance = getAccountBalance(account);
+
+            return (
+              <LinkWithViewTransition
+                key={account.id}
+                to={`/settings/accounts/${account.id}`}
+                transition="slideLeft"
+                applyTo="newView"
+                className="block"
+              >
+                <Card className="flex flex-col p-2 px-4 transition-colors hover:bg-muted/50">
+                  <div className="flex items-center justify-between">
+                    <h3>{account.name}</h3>
+                    {balance !== null ? (
+                      <MoneyWithConvertedAmount
+                        money={balance}
+                        variant="inline"
+                      />
+                    ) : (
+                      <BalanceOfflineHoverCard accountType={account.type} />
+                    )}
+                  </div>
+                  {(account.isDefault || !account.isOnline) && (
+                    <div className="mt-1 flex gap-2">
+                      {account.isDefault && <Badge>Default</Badge>}
+                      {!account.isOnline && <Badge>Offline</Badge>}
+                    </div>
+                  )}
+                </Card>
+              </LinkWithViewTransition>
+            );
+          })}
+        </div>
       </PageContent>
 
       <div className="fixed inset-x-0 bottom-16 flex justify-center">


### PR DESCRIPTION
## Summary
- Remove the BTC/USD tabs from the settings accounts list — it now shows BTC transactional accounts directly.
- Remove the currency selector from the Add Cashu Account form — new accounts are hardcoded to BTC.

## Test plan
- [ ] Visit `/settings/accounts` — no tabs, BTC accounts list shown directly.
- [ ] Visit `/settings/accounts/create/cashu` — no currency dropdown; just Name and Mint URL fields.
- [ ] Add a BTC mint — succeeds, account is created with currency BTC.
- [ ] Try adding a USD-only mint URL — Mint URL field shows "Mint does not support this currency".