### PR TITLE
fix(transactions): use rolling time windows for history labels

### DIFF
--- a/app/features/transactions/transaction-details.tsx
+++ b/app/features/transactions/transaction-details.tsx
@@ -14,7 +14,7 @@ import { accountOfflineToast } from '~/features/accounts/utils';
 import type { Transaction } from '~/features/transactions/transaction';
 import { useRedirectTo } from '~/hooks/use-redirect-to';
 import { useToast } from '~/hooks/use-toast';
-import { isThisWeek, isToday, isYesterday } from '~/lib/date';
+import { getStartOfDayNDaysAgo, isToday, isYesterday } from '~/lib/date';
 import { LinkWithViewTransition } from '~/lib/transitions';
 import { useAccountOrNull } from '../accounts/account-hooks';
 import { AccountIcon } from '../accounts/account-icons';
@@ -28,12 +28,13 @@ import {
 
 /**
  * Formats a timestamp into a human-readable relative time string with specific time of day.
- * Uses calendar day boundaries in the user's local timezone.
+ * Uses rolling day boundaries in the user's local timezone so labels reflect actual elapsed time
+ * rather than calendar week boundaries.
  * Examples:
  * - "Today at 2:30 PM"
  * - "Yesterday at 9:15 AM"
- * - "Monday at 11:45 PM"
- * - "Jan 15 at 3:20 PM"
+ * - "Saturday at 11:45 PM"  (2-6 days ago)
+ * - "Jan 15 at 3:20 PM"     (7+ days ago)
  */
 function formatRelativeTimestampWithTime(timestamp: string): string {
   const date = new Date(timestamp);
@@ -49,7 +50,8 @@ function formatRelativeTimestampWithTime(timestamp: string): string {
   if (isYesterday(date)) {
     return `Yesterday at ${timeString}`;
   }
-  if (isThisWeek(date)) {
+  // Cap at 6 days ago so the weekday name never collides with today's weekday.
+  if (date >= getStartOfDayNDaysAgo(6)) {
     return `${date.toLocaleDateString(undefined, { weekday: 'long' })} at ${timeString}`;
   }
   return `${date.toLocaleDateString(undefined, {

--- a/app/features/transactions/transaction-list.tsx
+++ b/app/features/transactions/transaction-list.tsx
@@ -12,7 +12,7 @@ import { SparkIcon } from '~/components/spark-icon';
 import { Card } from '~/components/ui/card';
 import { useTransactionAckStatusStore } from '~/features/transactions/transaction-ack-status-store';
 import { useIsVisible } from '~/hooks/use-is-visible';
-import { getStartOfWeek, isToday } from '~/lib/date';
+import { getStartOfDayNDaysAgo, isToday, isYesterday } from '~/lib/date';
 import {
   LinkWithViewTransition,
   VIEW_TRANSITION_DURATION_MS,
@@ -247,13 +247,16 @@ function TransactionSection({
   );
 }
 
-/** Filter transactions by status and time range using calendar day boundaries */
+/** Partition transactions into pending, today, yesterday, last 7 days, last 30 days, and older buckets using rolling time windows. */
 function usePartitionTransactions(transactions: Transaction[]) {
-  const startOfWeek = getStartOfWeek(new Date());
+  const last7DaysStart = getStartOfDayNDaysAgo(7);
+  const last30DaysStart = getStartOfDayNDaysAgo(30);
 
   const pendingTransactions: Transaction[] = [];
   const todayTransactions: Transaction[] = [];
-  const thisWeekTransactions: Transaction[] = [];
+  const yesterdayTransactions: Transaction[] = [];
+  const last7DaysTransactions: Transaction[] = [];
+  const last30DaysTransactions: Transaction[] = [];
   const olderTransactions: Transaction[] = [];
 
   // Transactions are already sorted correctly from the database
@@ -265,8 +268,12 @@ function usePartitionTransactions(transactions: Transaction[]) {
       const createdDate = new Date(transaction.createdAt);
       if (isToday(createdDate)) {
         todayTransactions.push(transaction);
-      } else if (createdDate >= startOfWeek) {
-        thisWeekTransactions.push(transaction);
+      } else if (isYesterday(createdDate)) {
+        yesterdayTransactions.push(transaction);
+      } else if (createdDate >= last7DaysStart) {
+        last7DaysTransactions.push(transaction);
+      } else if (createdDate >= last30DaysStart) {
+        last30DaysTransactions.push(transaction);
       } else {
         olderTransactions.push(transaction);
       }
@@ -276,7 +283,9 @@ function usePartitionTransactions(transactions: Transaction[]) {
   return {
     pendingTransactions,
     todayTransactions,
-    thisWeekTransactions,
+    yesterdayTransactions,
+    last7DaysTransactions,
+    last30DaysTransactions,
     olderTransactions,
   };
 }
@@ -310,7 +319,9 @@ export function TransactionList({
   const {
     pendingTransactions,
     todayTransactions,
-    thisWeekTransactions,
+    yesterdayTransactions,
+    last7DaysTransactions,
+    last30DaysTransactions,
     olderTransactions,
   } = usePartitionTransactions(allTransactions);
 
@@ -354,8 +365,16 @@ export function TransactionList({
         />
         <TransactionSection title="Today" transactions={todayTransactions} />
         <TransactionSection
-          title="This Week"
-          transactions={thisWeekTransactions}
+          title="Yesterday"
+          transactions={yesterdayTransactions}
+        />
+        <TransactionSection
+          title="Last Week"
+          transactions={last7DaysTransactions}
+        />
+        <TransactionSection
+          title="Last Month"
+          transactions={last30DaysTransactions}
         />
         <TransactionSection title="Older" transactions={olderTransactions} />
       </div>

--- a/app/lib/date.ts
+++ b/app/lib/date.ts
@@ -13,26 +13,12 @@ export function getStartOfDay(date: Date): Date {
 }
 
 /**
- * Returns the start of the week for a given date in local timezone.
- * Uses the browser's locale to determine the first day of the week.
- * Falls back to Sunday if locale info is unavailable.
+ * Returns midnight (start of day) for the day `n` days before today, in local timezone.
+ * `n = 0` is the start of today, `n = 1` is the start of yesterday, etc.
  */
-export function getStartOfWeek(date: Date): Date {
-  const locale = new Intl.Locale(navigator.language);
-  // getWeekInfo().firstDay: 1 = Monday, 7 = Sunday
-  const firstDayOfWeek = locale.getWeekInfo?.()?.firstDay ?? 7;
-
-  const result = getStartOfDay(date);
-
-  // getDay(): 0 = Sunday, 6 = Saturday
-  // Convert firstDayOfWeek from ISO (1-7) to JS (0-6)
-  const localeFirstDay = firstDayOfWeek === 7 ? 0 : firstDayOfWeek;
-  const currentDay = result.getDay();
-
-  // Calculate days to subtract to reach the start of week
-  const daysToSubtract = (currentDay - localeFirstDay + 7) % 7;
-  result.setDate(result.getDate() - daysToSubtract);
-
+export function getStartOfDayNDaysAgo(n: number): Date {
+  const result = getStartOfDay(new Date());
+  result.setDate(result.getDate() - n);
   return result;
 }
 
@@ -61,14 +47,4 @@ export function isYesterday(date: Date): boolean {
   const yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
   return isSameDay(date, yesterday);
-}
-
-/**
- * Checks if a date falls within the current calendar week (Sunday to Saturday) in local timezone.
- * Returns true for dates from the start of this week up to now.
- */
-export function isThisWeek(date: Date): boolean {
-  const now = new Date();
-  const startOfWeek = getStartOfWeek(now);
-  return date >= startOfWeek && date <= now;
 }


### PR DESCRIPTION
## Summary

- Transaction history was bucketed by calendar-week boundaries (locale-dependent via `Intl.Locale.getWeekInfo`). On a Monday morning a tx from yesterday could land in "Older" while one from a few hours earlier was "This Week" — meaningless to users.
- Replaces the calendar-week split with rolling day-based windows. Buckets are now **Pending / Today / Yesterday / Last Week / Last Month / Older**, and the detail screen shows a weekday name for any tx 2–6 days old (regardless of locale).

## Bucket boundaries

Reference point: `now` = the current time the page is open. Let `T = midnight at the start of today (local)`.

| Bucket | Cutoff range (`created_at`) | Calendar days included |
|---|---|---|
| **Pending** | any time, but `state = PENDING` | n/a — bypasses date check |
| **Today** | `created_at >= T` | today only (1 day) |
| **Yesterday** | `T-1d <= created_at < T` | yesterday only (1 day) |
| **Last Week** | `T-7d <= created_at < T-1d` | 2–7 days ago (6 days) |
| **Last Month** | `T-30d <= created_at < T-7d` | 8–30 days ago (23 days) |
| **Older** | `created_at < T-30d` | 31+ days ago |

`T-Nd` uses `setDate(getDate() - N)` — always midnight N calendar days back, never a 24h-rolling instant. Buckets are mutually exclusive and fully cover the timeline. Only `COMPLETED` and `REVERSED` feed the date-bucketed lanes; `DRAFT` / `FAILED` are filtered out.

## Detail screen

Same rolling logic for the timestamp label on the transaction detail page:

| Tx age | Label |
|---|---|
| Today | `Today at 2:30 PM` |
| Yesterday | `Yesterday at 9:15 AM` |
| 2–6 days old | `Saturday at 1:20 PM` (weekday name) |
| 7+ days old | `Apr 20 at 6:45 PM` |

The 6-day cap on the weekday label prevents a tx exactly 7 days old from rendering with the same weekday as today.

## Test plan

- [ ] Open `/transactions` on a Monday (or any day) — verify yesterday's transactions appear under **Yesterday**, not **Older**
- [ ] Verify each bucket renders only when it has at least one tx (empty sections are hidden)
- [ ] Open a transaction detail from 2–6 days ago — verify the timestamp shows the weekday name (e.g. "Saturday at 3:20 PM"), not a date
- [ ] Open a transaction detail from 7+ days ago — verify it shows "Mon DD at HH:MM"
- [ ] Spot-check a non-en-US locale (e.g. set browser locale to `de-DE`) to confirm the locale-dependent behavior is gone