### PR TITLE
fix(receive): guard getMintInfo with isOnline check (AGICASH-9S)

### DIFF
--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -105,6 +105,7 @@ export const canSendToLightning = (account: Account): boolean => {
   }
   if (account.isTestMint) return false;
   if (account.purpose !== 'transactional') return false;
+  if (!account.isOnline) return false;
   return !account.wallet.getMintInfo().isSupported(5).disabled;
 };
 
@@ -115,6 +116,7 @@ export const canSendToLightning = (account: Account): boolean => {
 export const canReceiveFromLightning = (account: Account): boolean => {
   if (account.type === 'spark') return true;
   if (account.isTestMint) return false;
+  if (!account.isOnline) return false;
   return !account.wallet.getMintInfo().isSupported(4).disabled;
 };
 

--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -44,34 +44,6 @@ export class ReceiveCashuTokenService {
       currency,
     });
 
-    const commonAccount = {
-      id: 'cashu-account-placeholder-id',
-      type: 'cashu' as const,
-      name: mintUrl.replace('https://', '').replace('http://', ''),
-      mintUrl,
-      createdAt: new Date().toISOString(),
-      currency,
-      version: 0,
-      keysetCounters: {},
-      proofs: [],
-      isDefault: false,
-      isSource: true,
-      isUnknown: true,
-      wallet,
-    };
-
-    if (!isOnline) {
-      return {
-        ...commonAccount,
-        purpose: 'transactional' as const,
-        state: 'active' as const,
-        expiresAt: null,
-        canReceive: false,
-        isOnline: false,
-        isTestMint: false,
-      };
-    }
-
     let expiresAt: string | null = null;
     if (wallet.purpose === 'offer') {
       const activeKeyset = findFirstActiveKeyset(
@@ -86,17 +58,29 @@ export class ReceiveCashuTokenService {
     const isExpired = expiresAt !== null && new Date(expiresAt) <= new Date();
 
     const baseAccount = {
-      ...commonAccount,
+      id: 'cashu-account-placeholder-id',
+      type: 'cashu' as const,
       purpose: wallet.purpose,
       state: isExpired ? ('expired' as const) : ('active' as const),
+      name: mintUrl.replace('https://', '').replace('http://', ''),
+      mintUrl,
+      createdAt: new Date().toISOString(),
+      currency,
+      version: 0,
+      keysetCounters: {},
       expiresAt,
+      proofs: [],
+      isDefault: false,
+      isSource: true,
+      isUnknown: true,
+      wallet,
     };
 
-    if (isExpired) {
+    if (!isOnline || isExpired) {
       return {
         ...baseAccount,
         canReceive: false,
-        cannotReceiveReason: 'This offer has expired',
+        cannotReceiveReason: isExpired ? 'This offer has expired' : undefined,
         isOnline,
         isTestMint: false,
       };

--- a/app/features/receive/receive-cashu-token-service.ts
+++ b/app/features/receive/receive-cashu-token-service.ts
@@ -44,6 +44,34 @@ export class ReceiveCashuTokenService {
       currency,
     });
 
+    const commonAccount = {
+      id: 'cashu-account-placeholder-id',
+      type: 'cashu' as const,
+      name: mintUrl.replace('https://', '').replace('http://', ''),
+      mintUrl,
+      createdAt: new Date().toISOString(),
+      currency,
+      version: 0,
+      keysetCounters: {},
+      proofs: [],
+      isDefault: false,
+      isSource: true,
+      isUnknown: true,
+      wallet,
+    };
+
+    if (!isOnline) {
+      return {
+        ...commonAccount,
+        purpose: 'transactional' as const,
+        state: 'active' as const,
+        expiresAt: null,
+        canReceive: false,
+        isOnline: false,
+        isTestMint: false,
+      };
+    }
+
     let expiresAt: string | null = null;
     if (wallet.purpose === 'offer') {
       const activeKeyset = findFirstActiveKeyset(
@@ -58,29 +86,17 @@ export class ReceiveCashuTokenService {
     const isExpired = expiresAt !== null && new Date(expiresAt) <= new Date();
 
     const baseAccount = {
-      id: 'cashu-account-placeholder-id',
-      type: 'cashu' as const,
+      ...commonAccount,
       purpose: wallet.purpose,
       state: isExpired ? ('expired' as const) : ('active' as const),
-      name: mintUrl.replace('https://', '').replace('http://', ''),
-      mintUrl,
-      createdAt: new Date().toISOString(),
-      currency,
-      version: 0,
-      keysetCounters: {},
       expiresAt,
-      proofs: [],
-      isDefault: false,
-      isSource: true,
-      isUnknown: true,
-      wallet,
     };
 
-    if (!isOnline || isExpired) {
+    if (isExpired) {
       return {
         ...baseAccount,
         canReceive: false,
-        cannotReceiveReason: isExpired ? 'This offer has expired' : undefined,
+        cannotReceiveReason: 'This offer has expired',
         isOnline,
         isTestMint: false,
       };


### PR DESCRIPTION
Guards `canReceiveFromLightning` / `canSendToLightning` with an `isOnline` check so an offline account in the selector no longer crashes cashu token input with `Mint info not initialized` (Sentry: AGICASH-9S).