### PR TITLE
chore: add 3-day minimum release age for npm packages

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,6 @@
 [test]
 root = "./app"
+
+[install]
+# 3 days, in seconds — see https://bun.com/docs/runtime/bunfig#install-minimumreleaseage
+minimumReleaseAge = 259200


### PR DESCRIPTION
## Summary
- Adds `install.minimumReleaseAge = 259200` (3 days, in seconds) to `bunfig.toml`. Bun filters out npm package versions younger than the threshold during dependency resolution.
- Mitigates supply chain attacks where a malicious version is published and exploited in the short window before npm/maintainers catch it. The 3-day delay gives the ecosystem time to flag and unpublish compromised releases before they land in our installs.
- See https://bun.com/docs/runtime/bunfig#install-minimumreleaseage.

## Behavior notes
- Pinned dep bumped to a too-new version → `bun install` fails hard with `error: Version "<pkg>@<ver>" was published within minimum release age of 259200 seconds`. No silent skip.
- Semver-ranged deps (incl. transitives) → Bun picks the newest version in the range that is ≥3 days old.
- Existing lockfile installs are unaffected (verified locally with `bun install --frozen-lockfile`).
- No `minimumReleaseAgeExcludes` exemption list is configured — all packages, first-party and otherwise, are gated equally.

## Test plan
- [x] `bun install --frozen-lockfile` passes locally against the current lockfile (no forced downgrades)
- [ ] CI install passes on this branch
- [ ] (Optional sanity) try `bun add <some-package>@<version-released-in-the-last-hour>` and confirm the gate error is raised

🤖 Generated with [Claude Code](https://claude.com/claude-code)