### PR TITLE
Solid page header on /gift-cards

### DIFF
--- a/app/features/gift-cards/gift-cards.tsx
+++ b/app/features/gift-cards/gift-cards.tsx
@@ -46,12 +46,12 @@ export function GiftCards() {
 
   return (
     <Page className="px-0 pb-0">
-      <PageHeader className="absolute inset-x-0 top-0 z-20 mb-0 px-4 pt-4 pb-4">
+      <PageHeader className="px-4">
         <ClosePageButton to="/" transition="slideLeft" applyTo="oldView" />
         <PageHeaderTitle>Gift Cards</PageHeaderTitle>
       </PageHeader>
 
-      <PageContent className="scrollbar-none relative min-h-0 overflow-y-auto px-0 pt-16 pb-0">
+      <PageContent className="scrollbar-none relative min-h-0 overflow-y-auto px-0 pb-0">
         <div className="flex w-full flex-col items-center gap-4">
           {giftCardsToDiscover.length > 0 && (
             <DiscoverGiftCards giftCards={giftCardsToDiscover} />


### PR DESCRIPTION
Match the rest of the app's page-header pattern (e.g. transactions list) — header sits in normal flow with a solid background, content disappears at the header boundary instead of scrolling under a transparent floating header.

Single change in `app/features/gift-cards/gift-cards.tsx`:
- `PageHeader` no longer `absolute inset-x-0 top-0 z-20` — sits in flex flow above `PageContent`
- `PageContent` no longer needs `pt-16` clearance for the floating header