### PR TITLE
Prevent view-transition state leak via scroll restoration

### DIFF
--- a/app/features/gift-cards/use-restore-scroll-position.ts
+++ b/app/features/gift-cards/use-restore-scroll-position.ts
@@ -4,9 +4,9 @@ import { z } from 'zod';
 
 /**
  * Persists and restores the horizontal scroll position of a container across
- * navigations, keyed by `stateKey` in `location.state`. Pass `getScrollState()`
- * as the `state` argument to `navigate(...)` when leaving the page so the
- * position gets restored on back navigation.
+ * navigations. Positions are stored in `location.state` under `state.scrollPositions[stateKey]`.
+ * Pass `getScrollState()` as the `state` argument to `navigate(...)` when
+ * leaving the page so the position gets restored on back navigation.
  */
 export function useRestoreScrollPosition<K extends string>(stateKey: K) {
   const location = useLocation();
@@ -15,11 +15,11 @@ export function useRestoreScrollPosition<K extends string>(stateKey: K) {
 
   useEffect(() => {
     const result = z
-      .object({ [stateKey]: z.number() })
+      .object({ scrollPositions: z.object({ [stateKey]: z.number() }) })
       .safeParse(location.state);
 
     if (result.success && scrollRef.current) {
-      scrollRef.current.scrollLeft = result.data[stateKey];
+      scrollRef.current.scrollLeft = result.data.scrollPositions[stateKey];
     }
   }, [location.state, stateKey]);
 
@@ -29,12 +29,17 @@ export function useRestoreScrollPosition<K extends string>(stateKey: K) {
     }
   };
 
-  const getScrollState = () => ({
-    ...(typeof location.state === 'object' && location.state !== null
-      ? location.state
-      : {}),
-    [stateKey]: scrollPositionRef.current,
-  });
+  const getScrollState = () => {
+    const existing = z
+      .object({ scrollPositions: z.record(z.string(), z.number()) })
+      .safeParse(location.state);
+    return {
+      scrollPositions: {
+        ...(existing.success ? existing.data.scrollPositions : {}),
+        [stateKey]: scrollPositionRef.current,
+      },
+    };
+  };
 
   return { scrollRef, handleScroll, getScrollState };
 }


### PR DESCRIPTION
## What

`getScrollState` in `use-restore-scroll-position.ts` was merging every field of the current `location.state` into the next navigation. That includes the `{ transition, applyTo }` fields that `LinkWithViewTransition` stores in `history.state` to communicate slide direction to `useViewTransitionEffect`.

Once `/gift-cards` is reached via a slide (e.g. home → /gift-cards uses `slideRight applyTo='newView'`), those fields stay in `history.state` at that entry. Any subsequent raw `navigate` from `/gift-cards` that calls `getScrollState()` (offer click, etc.) inherits them and applies the same slide direction to a navigation that wasn't supposed to slide.

## Repro

1. Hard reset on `/gift-cards` (after having arrived from home — state is preserved across reload)
2. Click an offer card
3. Offer detail page slides in from the left, instead of just morphing the offer card

## Fix

Strip `transition` and `applyTo` from the merge. Only caller-owned state (e.g. sibling scroll positions) gets forwarded.

This is a surgical fix to unblock the offer/discover transition bugs. A follow-up could move scroll positions out of `history.state` entirely (`Map<location.key, ...>`) so the merge isn't needed at all and the two concerns stay fully decoupled — discussed on Discord; deferring until this lands and we confirm it fixes the symptom.