### PR TITLE
fix send-input spacing and move selected destination

### DIFF
--- a/app/features/send/resolve-destination.ts
+++ b/app/features/send/resolve-destination.ts
@@ -79,7 +79,7 @@ export async function resolveSendDestination(
       data: {
         sendType: 'BOLT11_INVOICE',
         destination: encoded,
-        destinationDisplay: `${encoded.slice(0, 12)}...${encoded.slice(-8)}`,
+        destinationDisplay: `${encoded.slice(0, 10)}...${encoded.slice(-6)}`,
         amount: validated.amount,
         decoded: bolt11.decoded,
       },

--- a/app/features/send/resolve-destination.ts
+++ b/app/features/send/resolve-destination.ts
@@ -79,7 +79,7 @@ export async function resolveSendDestination(
       data: {
         sendType: 'BOLT11_INVOICE',
         destination: encoded,
-        destinationDisplay: `${encoded.slice(0, 6)}...${encoded.slice(-4)}`,
+        destinationDisplay: `${encoded.slice(0, 12)}...${encoded.slice(-8)}`,
         amount: validated.amount,
         decoded: bolt11.decoded,
       },

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -236,7 +236,7 @@ export function SendInput() {
               </div>
             ) : (
               <>
-                <div className="flex items-center justify-start gap-4">
+                <div className="flex h-10 items-center justify-start gap-4">
                   <button type="button" onClick={handlePaste}>
                     <Clipboard />
                   </button>

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -186,7 +186,7 @@ export function SendInput() {
         <PageHeaderTitle>Send</PageHeaderTitle>
       </PageHeader>
 
-      <PageContent className="mx-auto flex flex-col items-center justify-between">
+      <PageContent className="flex flex-col items-center justify-between">
         <div className="flex h-[124px] flex-col items-center gap-2">
           <div className={shakeAnimationClass}>
             <MoneyInputDisplay

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -224,7 +224,7 @@ export function SendInput() {
           <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:max-w-none">
             {destinationDisplay ? (
               <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-lg border border-primary bg-background px-3 text-sm">
-                <span className="truncate">{destinationDisplay}</span>
+                <span className="min-w-0 truncate">{destinationDisplay}</span>
                 <button
                   type="button"
                   onClick={clearDestination}

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -223,7 +223,7 @@ export function SendInput() {
         <div className="flex w-full flex-col items-center gap-4 sm:items-start sm:justify-between">
           <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:max-w-none">
             {destinationDisplay ? (
-              <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-md border border-input px-3 text-sm">
+              <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-lg border border-primary bg-background px-3 text-sm">
                 <span className="truncate">{destinationDisplay}</span>
                 <button
                   type="button"

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -187,32 +187,28 @@ export function SendInput() {
       </PageHeader>
 
       <PageContent className="mx-auto flex flex-col items-center justify-between">
-        <div className="flex flex-col items-center justify-between gap-4">
-          <div className="flex h-[124px] flex-col items-center gap-2">
-            <div className={shakeAnimationClass}>
-              <MoneyInputDisplay
-                inputValue={rawInputValue}
-                currency={inputValue.currency}
-                unit={getDefaultUnit(inputValue.currency)}
-              />
+        <div className="flex h-[124px] flex-col items-center gap-2">
+          <div className={shakeAnimationClass}>
+            <MoneyInputDisplay
+              inputValue={rawInputValue}
+              currency={inputValue.currency}
+              unit={getDefaultUnit(inputValue.currency)}
+            />
+          </div>
+
+          {!exchangeRateError && (
+            <ConvertedMoneySwitcher
+              onSwitch={switchInputCurrency}
+              money={convertedValue}
+            />
+          )}
+
+          {destinationDisplay && (
+            <div className="flex items-center gap-2 text-sm">
+              <p>{destinationDisplay}</p>
+              <X onClick={clearDestination} className="h-4 w-4" />
             </div>
-
-            {!exchangeRateError && (
-              <ConvertedMoneySwitcher
-                onSwitch={switchInputCurrency}
-                money={convertedValue}
-              />
-            )}
-          </div>
-
-          <div className="flex h-[24px] items-center justify-center gap-4">
-            {destinationDisplay && (
-              <>
-                <p>{destinationDisplay}</p>
-                <X onClick={clearDestination} className="h-4 w-4" />
-              </>
-            )}
-          </div>
+          )}
         </div>
 
         <div className="w-full max-w-sm sm:max-w-none">

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -202,13 +202,6 @@ export function SendInput() {
               money={convertedValue}
             />
           )}
-
-          {destinationDisplay && (
-            <div className="-mt-2 flex items-center gap-2 text-sm">
-              <p>{destinationDisplay}</p>
-              <X onClick={clearDestination} className="h-4 w-4" />
-            </div>
-          )}
         </div>
 
         <div className="w-full max-w-sm sm:max-w-none">
@@ -229,28 +222,44 @@ export function SendInput() {
 
         <div className="flex w-full flex-col items-center gap-4 sm:items-start sm:justify-between">
           <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:max-w-none">
-            <div className="flex items-center justify-start gap-4">
-              <button type="button" onClick={handlePaste}>
-                <Clipboard />
-              </button>
+            {destinationDisplay ? (
+              <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-md border border-input px-3 text-sm">
+                <span className="truncate">{destinationDisplay}</span>
+                <button
+                  type="button"
+                  onClick={clearDestination}
+                  aria-label="Clear destination"
+                  className="shrink-0"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-start gap-4">
+                  <button type="button" onClick={handlePaste}>
+                    <Clipboard />
+                  </button>
 
-              <LinkWithViewTransition
-                to={buildLinkWithSearchParams('/send/scan')}
-                transition="slideUp"
-                applyTo="newView"
-              >
-                <Scan />
-              </LinkWithViewTransition>
+                  <LinkWithViewTransition
+                    to={buildLinkWithSearchParams('/send/scan')}
+                    transition="slideUp"
+                    applyTo="newView"
+                  >
+                    <Scan />
+                  </LinkWithViewTransition>
 
-              {sendAccount.purpose === 'transactional' && (
-                <SelectDestinationDrawer
-                  open={selectDestinationDrawerOpen}
-                  onOpenChange={setSelectDestinationDrawerOpen}
-                  onSelect={handleSelectDestination}
-                />
-              )}
-            </div>
-            <div /> {/* spacer */}
+                  {sendAccount.purpose === 'transactional' && (
+                    <SelectDestinationDrawer
+                      open={selectDestinationDrawerOpen}
+                      onOpenChange={setSelectDestinationDrawerOpen}
+                      onSelect={handleSelectDestination}
+                    />
+                  )}
+                </div>
+                <div /> {/* spacer */}
+              </>
+            )}
             <div className="flex items-center justify-end">
               <Button
                 onClick={() => handleContinue(inputValue, convertedValue)}
@@ -263,7 +272,7 @@ export function SendInput() {
           </div>
         </div>
       </PageContent>
-      <PageFooter className="pb-0 sm:pb-14">
+      <PageFooter className="sm:pb-14">
         <Numpad
           showDecimal={maxInputDecimals > 0}
           onButtonClick={(value) => {

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -220,55 +220,53 @@ export function SendInput() {
           />
         </div>
 
-        <div className="flex w-full flex-col items-center gap-4 sm:items-start sm:justify-between">
-          <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:max-w-none">
-            {destinationDisplay ? (
-              <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-lg border border-primary bg-background px-3 text-sm">
-                <span className="min-w-0 truncate">{destinationDisplay}</span>
-                <button
-                  type="button"
-                  onClick={clearDestination}
-                  aria-label="Clear destination"
-                  className="shrink-0"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-            ) : (
-              <>
-                <div className="flex h-10 items-center justify-start gap-4">
-                  <button type="button" onClick={handlePaste}>
-                    <Clipboard />
-                  </button>
-
-                  <LinkWithViewTransition
-                    to={buildLinkWithSearchParams('/send/scan')}
-                    transition="slideUp"
-                    applyTo="newView"
-                  >
-                    <Scan />
-                  </LinkWithViewTransition>
-
-                  {sendAccount.purpose === 'transactional' && (
-                    <SelectDestinationDrawer
-                      open={selectDestinationDrawerOpen}
-                      onOpenChange={setSelectDestinationDrawerOpen}
-                      onSelect={handleSelectDestination}
-                    />
-                  )}
-                </div>
-                <div /> {/* spacer */}
-              </>
-            )}
-            <div className="flex items-center justify-end">
-              <Button
-                onClick={() => handleContinue(inputValue, convertedValue)}
-                disabled={inputValue.isZero()}
-                loading={status === 'quoting' || isContinuing}
+        <div className="grid w-full max-w-sm grid-cols-3 gap-4 sm:max-w-none">
+          {destinationDisplay ? (
+            <div className="col-span-2 flex h-10 items-center justify-between gap-2 rounded-lg border border-primary bg-background px-3 text-sm">
+              <span className="min-w-0 truncate">{destinationDisplay}</span>
+              <button
+                type="button"
+                onClick={clearDestination}
+                aria-label="Clear destination"
+                className="shrink-0"
               >
-                Continue
-              </Button>
+                <X className="h-4 w-4" />
+              </button>
             </div>
+          ) : (
+            <>
+              <div className="flex h-10 items-center justify-start gap-4">
+                <button type="button" onClick={handlePaste}>
+                  <Clipboard />
+                </button>
+
+                <LinkWithViewTransition
+                  to={buildLinkWithSearchParams('/send/scan')}
+                  transition="slideUp"
+                  applyTo="newView"
+                >
+                  <Scan />
+                </LinkWithViewTransition>
+
+                {sendAccount.purpose === 'transactional' && (
+                  <SelectDestinationDrawer
+                    open={selectDestinationDrawerOpen}
+                    onOpenChange={setSelectDestinationDrawerOpen}
+                    onSelect={handleSelectDestination}
+                  />
+                )}
+              </div>
+              <div /> {/* spacer */}
+            </>
+          )}
+          <div className="flex items-center justify-end">
+            <Button
+              onClick={() => handleContinue(inputValue, convertedValue)}
+              disabled={inputValue.isZero()}
+              loading={status === 'quoting' || isContinuing}
+            >
+              Continue
+            </Button>
           </div>
         </div>
       </PageContent>

--- a/app/features/send/send-input.tsx
+++ b/app/features/send/send-input.tsx
@@ -204,7 +204,7 @@ export function SendInput() {
           )}
 
           {destinationDisplay && (
-            <div className="flex items-center gap-2 text-sm">
+            <div className="-mt-2 flex items-center gap-2 text-sm">
               <p>{destinationDisplay}</p>
               <X onClick={clearDestination} className="h-4 w-4" />
             </div>
@@ -263,7 +263,7 @@ export function SendInput() {
           </div>
         </div>
       </PageContent>
-      <PageFooter className="sm:pb-14">
+      <PageFooter className="pb-0 sm:pb-14">
         <Numpad
           showDecimal={maxInputDecimals > 0}
           onButtonClick={(value) => {


### PR DESCRIPTION
## Summary
The send input had an always-rendered 24px destination div + a 16px gap-4 wrapper, pushing 40px of dead space between the amount and the account selector. 

Move the selected destination to replace the action buttons (paste, scan,...)

<img width="760" height="554" alt="image" src="https://github.com/user-attachments/assets/bca3092c-e427-4e42-b4b0-dbafebb54558" />
