### PR TITLE
fix(receive): render addCardDisclaimer for offers, not just gift cards

### DIFF
--- a/app/features/receive/receive-cashu-token.tsx
+++ b/app/features/receive/receive-cashu-token.tsx
@@ -286,22 +286,22 @@ export default function ReceiveToken({
           {claimableToken && receiveAccount ? (
             <div className="w-full max-w-sm px-4">
               {giftCard ? (
-                giftCard.purpose === 'gift-card' ? (
-                  <div className="flex flex-col items-center gap-3">
+                <div className="flex flex-col items-center gap-3">
+                  {giftCard.purpose === 'gift-card' ? (
                     <GiftCardItem
                       account={sourceAccount}
                       image={giftCard.image}
                       hideOverlayContent
                     />
-                    {giftCard.addCardDisclaimer && (
-                      <p className="text-center text-muted-foreground text-sm">
-                        {giftCard.addCardDisclaimer}
-                      </p>
-                    )}
-                  </div>
-                ) : (
-                  <OfferItem account={sourceAccount} image={giftCard.image} />
-                )
+                  ) : (
+                    <OfferItem account={sourceAccount} image={giftCard.image} />
+                  )}
+                  {giftCard.addCardDisclaimer && (
+                    <p className="text-center text-muted-foreground text-sm">
+                      {giftCard.addCardDisclaimer}
+                    </p>
+                  )}
+                </div>
               ) : (
                 <AccountSelector
                   accounts={selectableAccounts}
@@ -459,22 +459,22 @@ export function PublicReceiveCashuToken({ token }: { token: Token }) {
           {claimableToken && sourceAccount.canReceive ? (
             <div className="w-full max-w-sm px-4">
               {giftCard ? (
-                giftCard.purpose === 'gift-card' ? (
-                  <div className="flex flex-col items-center gap-3">
+                <div className="flex flex-col items-center gap-3">
+                  {giftCard.purpose === 'gift-card' ? (
                     <GiftCardItem
                       account={sourceAccount}
                       image={giftCard.image}
                       hideOverlayContent
                     />
-                    {giftCard.addCardDisclaimer && (
-                      <p className="text-center text-muted-foreground text-sm">
-                        {giftCard.addCardDisclaimer}
-                      </p>
-                    )}
-                  </div>
-                ) : (
-                  <OfferItem account={sourceAccount} image={giftCard.image} />
-                )
+                  ) : (
+                    <OfferItem account={sourceAccount} image={giftCard.image} />
+                  )}
+                  {giftCard.addCardDisclaimer && (
+                    <p className="text-center text-muted-foreground text-sm">
+                      {giftCard.addCardDisclaimer}
+                    </p>
+                  )}
+                </div>
               ) : (
                 <AccountSelector
                   accounts={selectableAccounts}


### PR DESCRIPTION
## Summary
`addCardDisclaimer` was previously only rendered inside the `purpose === 'gift-card'` branch in `receive-cashu-token.tsx`. Offers (`purpose: 'offer'`) never displayed their disclaimer text.

This PR lifts the disclaimer rendering above the purpose branch so it works the same way for both gift cards and offers. Both duplicate blocks in `receive-cashu-token.tsx` (~lines 289 and 462) are updated.

## Test plan
- [ ] receive a gift-card token from a `purpose: 'gift-card'` mint that has `addCardDisclaimer` set — verify text still renders below the card
- [ ] receive an offer token from a `purpose: 'offer'` mint that has `addCardDisclaimer` set — verify text now renders below the OfferItem
- [ ] `bun run fix:all` clean

## Triggered by
bob's `agicashlaunch` offer launch (#1075) — wants disclaimer "Valid at any Square merchant" to render for an offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)