### PR TITLE
fix(scan): float paste button over fullscreen scanner

### DIFF
--- a/app/components/qr-scanner/qr-scanner.tsx
+++ b/app/components/qr-scanner/qr-scanner.tsx
@@ -144,7 +144,7 @@ export const QRScanner = ({ onDecode }: QRScannerProps) => {
   }, [throttledDecode]);
 
   return (
-    <section className="fixed inset-0 h-screen w-screen sm:relative sm:aspect-square sm:h-[400px] sm:w-[400px] sm:overflow-hidden">
+    <section className="fixed inset-0 h-dvh w-dvw sm:relative sm:aspect-square sm:h-[400px] sm:w-[400px] sm:overflow-hidden">
       <div className="relative h-full w-full">
         {cameraError ? (
           <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black p-6 text-center">

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -3,7 +3,6 @@ import {
   ClosePageButton,
   Page,
   PageContent,
-  PageFooter,
   PageHeader,
   PageHeaderTitle,
 } from '~/components/page';
@@ -82,11 +81,13 @@ export default function ScanPage() {
       <PageContent className="relative flex items-center justify-center">
         <QRScanner onDecode={handleInput} />
       </PageContent>
-      <PageFooter className="pb-14">
-        <Button type="button" onClick={handlePaste}>
-          <Clipboard className="h-5 w-5" /> Paste
-        </Button>
-      </PageFooter>
+      <Button
+        type="button"
+        onClick={handlePaste}
+        className="-translate-x-1/2 fixed bottom-4 left-1/2 z-20"
+      >
+        <Clipboard className="h-5 w-5" /> Paste
+      </Button>
     </Page>
   );
 }

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -77,7 +77,7 @@ export default function ScanPage() {
 
   return (
     <Page>
-      <PageHeader className="z-10">
+      <PageHeader className="z-20">
         <ClosePageButton to="/" transition="slideDown" applyTo="oldView" />
         <PageHeaderTitle>Scan</PageHeaderTitle>
       </PageHeader>

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -81,11 +81,11 @@ export default function ScanPage() {
         <ClosePageButton to="/" transition="slideDown" applyTo="oldView" />
         <PageHeaderTitle>Scan</PageHeaderTitle>
       </PageHeader>
-      <PageContent className="relative z-10 mx-auto items-center pt-20 sm:justify-center sm:gap-32 sm:py-0">
+      <PageContent className="relative z-10 mx-auto items-center pt-20 sm:justify-center sm:py-0">
         <QRScanner onDecode={handleInput} />
         <div
           className={cn(
-            'mt-auto flex w-72 flex-col items-center gap-4',
+            'sm:-translate-x-1/2 mt-auto flex w-72 flex-col items-center gap-4 sm:absolute sm:bottom-14 sm:left-1/2 sm:mt-0',
             isPwa && 'pb-20',
           )}
         >

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -84,7 +84,10 @@ export default function ScanPage() {
       <PageContent className="relative z-10 mx-auto items-center pt-20 sm:justify-center sm:gap-32 sm:py-0">
         <QRScanner onDecode={handleInput} />
         <div
-          className={cn('mt-auto flex w-72 flex-col gap-4', isPwa && 'pb-20')}
+          className={cn(
+            'mt-auto flex w-72 flex-col items-center gap-4',
+            isPwa && 'pb-20',
+          )}
         >
           <Button type="button" onClick={handlePaste}>
             <Clipboard className="h-5 w-5" /> Paste

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -84,7 +84,7 @@ export default function ScanPage() {
       <Button
         type="button"
         onClick={handlePaste}
-        className="-translate-x-1/2 fixed bottom-4 left-1/2 z-20"
+        className="-translate-x-1/2 fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] left-1/2 z-20"
       >
         <Clipboard className="h-5 w-5" /> Paste
       </Button>

--- a/app/routes/_protected.scan.tsx
+++ b/app/routes/_protected.scan.tsx
@@ -10,13 +10,16 @@ import { QRScanner } from '~/components/qr-scanner';
 import { Button } from '~/components/ui/button';
 import { classifyInput } from '~/features/scan';
 import { validateBolt11 } from '~/features/send/validation';
+import useIsPwa from '~/hooks/use-is-pwa';
 import { useToast } from '~/hooks/use-toast';
 import { readClipboard } from '~/lib/read-clipboard';
 import { useNavigateWithViewTransition } from '~/lib/transitions';
+import { cn } from '~/lib/utils';
 
 export default function ScanPage() {
   const navigate = useNavigateWithViewTransition();
   const { toast } = useToast();
+  const isPwa = useIsPwa();
 
   const handleInput = (raw: string) => {
     const result = classifyInput(raw);
@@ -78,16 +81,16 @@ export default function ScanPage() {
         <ClosePageButton to="/" transition="slideDown" applyTo="oldView" />
         <PageHeaderTitle>Scan</PageHeaderTitle>
       </PageHeader>
-      <PageContent className="relative flex items-center justify-center">
+      <PageContent className="relative z-10 mx-auto items-center pt-20 sm:justify-center sm:gap-32 sm:py-0">
         <QRScanner onDecode={handleInput} />
+        <div
+          className={cn('mt-auto flex w-72 flex-col gap-4', isPwa && 'pb-20')}
+        >
+          <Button type="button" onClick={handlePaste}>
+            <Clipboard className="h-5 w-5" /> Paste
+          </Button>
+        </div>
       </PageContent>
-      <Button
-        type="button"
-        onClick={handlePaste}
-        className="-translate-x-1/2 fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] left-1/2 z-20"
-      >
-        <Clipboard className="h-5 w-5" /> Paste
-      </Button>
     </Page>
   );
 }


### PR DESCRIPTION
## Why

`/scan` rendered its paste button inside `PageFooter`, but `QRScanner`'s default `fixed inset-0 h-screen w-screen` covers the full viewport — the button ended up behind the camera, and on non-PWA mobile the library's scan-region outline visually slid into the paste area. We also weren't sizing or placing the button consistently with the rest of the app on desktop.

## What

- Render the paste button as an overlay inside `PageContent` (with `relative z-10` so it sits above the fullscreen camera, transparent bg so the camera shows through).
- **Mobile**: `mt-auto` pins it to the bottom of `PageContent`; `useIsPwa` + `pb-20` lifts it above the iOS home indicator in PWA — matches the home-page Send/Receive/Buy placement.
- **Desktop**: `sm:absolute sm:bottom-14 sm:left-1/2 sm:-translate-x-1/2 sm:mt-0` so the scanner becomes the only in-flow flex item and `sm:justify-center` centers it; paste sits 56px above the bottom, the canonical `PageFooter pb-14` distance other primary-action screens use.
- **Button is content-sized** (`items-center` on the wrapper, no `w-full`).
- **`PageHeader` to `z-20`** so the X close button stays clickable over the `z-10` `PageContent` stacking context.

## Test plan

- [ ] Mobile browser (Safari/Chrome, URL bar visible): outline centered, paste visible at the bottom, X tappable
- [ ] Installed iOS PWA: paste lifted ~80px above the home indicator (matches home buttons)
- [ ] Desktop: scanner vertically centered, paste 56px above the bottom of `PageContent`, content-width button
- [ ] `send.scan` / `receive.scan` / `transfer.scan` still fullscreen with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
