### PR TITLE
fix(gift-cards): show mint name when card has no image

### DIFF
--- a/apps/web-wallet/app/features/gift-cards/gift-card-item.tsx
+++ b/apps/web-wallet/app/features/gift-cards/gift-card-item.tsx
@@ -31,6 +31,17 @@ export function GiftCardItem({
   const balance = getAccountBalance(account);
   const name = account.name;
 
+  if (!image && hideOverlayContent) {
+    return (
+      <WalletCard size={size} className={className}>
+        <WalletCardBlank />
+        <WalletCardOverlay className="flex items-center justify-center px-4">
+          <span className="truncate text-foreground text-lg">{name}</span>
+        </WalletCardOverlay>
+      </WalletCard>
+    );
+  }
+
   return (
     <WalletCard size={size} className={className}>
       {image ? (

--- a/apps/web-wallet/app/features/gift-cards/offer-item.tsx
+++ b/apps/web-wallet/app/features/gift-cards/offer-item.tsx
@@ -20,7 +20,7 @@ export function OfferItem({ account, image }: OfferItemProps) {
         <>
           <WalletCardBlank />
           <WalletCardOverlay className="flex items-center justify-center px-4">
-            <span className="truncate text-card-foreground text-lg">
+            <span className="truncate text-foreground text-lg">
               {account.name}
             </span>
           </WalletCardOverlay>

--- a/apps/web-wallet/app/features/gift-cards/offers-section.tsx
+++ b/apps/web-wallet/app/features/gift-cards/offers-section.tsx
@@ -50,7 +50,7 @@ function OfferCardButton({
           <>
             <WalletCardBlank />
             <WalletCardOverlay className="flex items-center justify-center px-4">
-              <span className="truncate text-card-foreground text-lg">
+              <span className="truncate text-foreground text-lg">
                 {account.name}
               </span>
             </WalletCardOverlay>


### PR DESCRIPTION
## What

Make the mint name visible when a gift-card-purpose mint has no image configured.

- `app/features/gift-cards/offer-item.tsx` — swap `text-card-foreground` → `text-foreground` (1 line). The imageless overlay was already there but rendered white-on-white in `:root`.
- `app/features/gift-cards/offers-section.tsx` — same swap on the inlined `OfferCardButton` overlay JSX (the duplicate of `OfferItem`'s imageless branch).
- `app/features/gift-cards/gift-card-item.tsx` — when `!image && hideOverlayContent` (the selected card on `/gift-cards/<id>` with no configured mint image), early-return a card with a centered name overlay and no balance. The existing stack-style overlay logic is unchanged for every other case.

## Why

In the default `:root`:
- `--card: hsl(0 0% 100%)`
- `--card-foreground: hsl(0 0% 98%)`

So `text-card-foreground` on `bg-card` rendered the offer card's name invisible. `--foreground: hsl(0 0% 3.9%)` gives contrast in `:root` and remains a sensible foreground in every defined theme.

For the gift-card details page, the selected card passes `hideOverlayContent=true` to suppress the stack-style overlay so an image can identify the card cleanly. With no image, the overlay being suppressed meant nothing identified the card. The early-return covers that one case with a name-only overlay — no balance (the balance is shown separately below on the details page), no gradient, just the name centered on the blank card. Every other call site (the stack list, non-selected cards in details) is unaffected.