### PR TITLE
fix: friendly message for mint quota exceeded error

### DIFF
--- a/app/features/receive/cashu-receive-quote-core.ts
+++ b/app/features/receive/cashu-receive-quote-core.ts
@@ -1,11 +1,22 @@
-import type { MintQuoteBolt11Response, Proof } from '@cashu/cashu-ts';
+import {
+  MintOperationError,
+  type MintQuoteBolt11Response,
+  type Proof,
+} from '@cashu/cashu-ts';
 import { HARDENED_OFFSET } from '@scure/bip32';
 import { decodeBolt11 } from '~/lib/bolt11';
-import { type ExtendedCashuWallet, getCashuUnit } from '~/lib/cashu';
+import {
+  CashuErrorCodes,
+  type ExtendedCashuWallet,
+  type ExtendedMintQuoteBolt11Response,
+  formatCashuQuoteError,
+  getCashuUnit,
+} from '~/lib/cashu';
 import { Money } from '~/lib/money';
 import type { RedactedCashuAccount } from '../accounts/account';
 import { BASE_CASHU_LOCKING_DERIVATION_PATH } from '../shared/cashu';
 import { derivePublicKey } from '../shared/cryptography';
+import { DomainError } from '../shared/error';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 
@@ -265,11 +276,22 @@ export async function getLightningQuote(
   const { lockingPublicKey, fullLockingDerivationPath } =
     await deriveNut20LockingPublicKey(xPub);
 
-  const mintQuoteResponse = await wallet.createLockedMintQuote(
-    amount.toNumber(cashuUnit),
-    lockingPublicKey,
-    description,
-  );
+  let mintQuoteResponse: ExtendedMintQuoteBolt11Response;
+  try {
+    mintQuoteResponse = await wallet.createLockedMintQuote(
+      amount.toNumber(cashuUnit),
+      lockingPublicKey,
+      description,
+    );
+  } catch (error) {
+    if (
+      error instanceof MintOperationError &&
+      error.code === CashuErrorCodes.MINT_QUOTA_EXCEEDED
+    ) {
+      throw new DomainError(formatCashuQuoteError(error));
+    }
+    throw error;
+  }
 
   const expiresAt = new Date(mintQuoteResponse.expiry * 1000).toISOString();
 

--- a/app/features/send/cashu-send-quote-service.ts
+++ b/app/features/send/cashu-send-quote-service.ts
@@ -1,11 +1,17 @@
 import {
   type MeltQuoteBolt11Response,
   MeltQuoteState,
+  MintOperationError,
   OutputData,
 } from '@cashu/cashu-ts';
 import type { Big } from 'big.js';
 import { decodeBolt11, parseBolt11Invoice } from '~/lib/bolt11';
-import { getCashuUnit, sumProofs } from '~/lib/cashu';
+import {
+  CashuErrorCodes,
+  formatCashuQuoteError,
+  getCashuUnit,
+  sumProofs,
+} from '~/lib/cashu';
 import { matchBlindSignaturesToOutputData } from '~/lib/cashu/blind-signature-matching';
 import { type Currency, Money } from '~/lib/money';
 import type { CashuAccount } from '../accounts/account';
@@ -147,7 +153,18 @@ export class CashuSendQuoteService {
     const cashuUnit = getCashuUnit(account.currency);
     const wallet = account.wallet;
 
-    const meltQuote = await wallet.createMeltQuoteBolt11(paymentRequest);
+    let meltQuote: MeltQuoteBolt11Response;
+    try {
+      meltQuote = await wallet.createMeltQuoteBolt11(paymentRequest);
+    } catch (error) {
+      if (
+        error instanceof MintOperationError &&
+        error.code === CashuErrorCodes.MINT_QUOTA_EXCEEDED
+      ) {
+        throw new DomainError(formatCashuQuoteError(error));
+      }
+      throw error;
+    }
 
     const amountWithLightningFee = meltQuote.amount + meltQuote.fee_reserve;
 

--- a/app/lib/cashu/error-codes.ts
+++ b/app/lib/cashu/error-codes.ts
@@ -129,6 +129,12 @@ export enum CashuErrorCodes {
   PUBKEY_REQUIRED = 20009,
 
   /**
+   * Mint quota exceeded for the authenticated user
+   * Relevant nuts: @see [NUT-04](https://github.com/cashubtc/nuts/blob/main/04.md), [NUT-05](https://github.com/cashubtc/nuts/blob/main/05.md)
+   */
+  MINT_QUOTA_EXCEEDED = 33001,
+
+  /**
    * Endpoint requires clear auth
    * Relevant nuts: @see [NUT-21](https://github.com/cashubtc/nuts/blob/main/21.md)
    */

--- a/app/lib/cashu/index.ts
+++ b/app/lib/cashu/index.ts
@@ -1,9 +1,14 @@
 export * from './proof';
+export * from './quote-errors';
 export * from './secret';
 export * from './token';
 export * from './utils';
 export * from './error-codes';
-export { ExtendedMintInfo, type MintPurpose } from './protocol-extensions';
+export {
+  ExtendedMintInfo,
+  type ExtendedMintQuoteBolt11Response,
+  type MintPurpose,
+} from './protocol-extensions';
 export { ProofSchema } from './types';
 export * from './payment-request';
 export * from './melt-quote-subscription';

--- a/app/lib/cashu/quote-errors.test.ts
+++ b/app/lib/cashu/quote-errors.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { MintOperationError } from '@cashu/cashu-ts';
+import { CashuErrorCodes } from './error-codes';
+import { formatCashuQuoteError } from './quote-errors';
+
+const buildQuotaError = (detail: string, data: unknown): MintOperationError => {
+  const error = new MintOperationError(
+    CashuErrorCodes.MINT_QUOTA_EXCEEDED,
+    detail,
+  );
+  // The mint sends a structured `data` field that cashu-ts does not yet
+  // surface on the error type. Attach it directly so the formatter can
+  // exercise the friendly-message path.
+  (error as MintOperationError & { data?: unknown }).data = data;
+  return error;
+};
+
+describe('formatCashuQuoteError', () => {
+  test('returns friendly message for 33001 with full data and retry-after', () => {
+    const error = buildQuotaError('Mint quota exceeded: ₿600 of ₿1,000.', {
+      limit: 1000,
+      used: 600,
+      unit: 'sat',
+      window_secs: 86400,
+      retry_after: 3600,
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿400. Try again in 1h',
+    );
+  });
+
+  test('returns friendly message for 33001 with full data and no retry-after', () => {
+    const error = buildQuotaError('Mint quota exceeded.', {
+      limit: 5000,
+      used: 1234,
+      unit: 'sat',
+      window_secs: 86400,
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿3,766',
+    );
+  });
+
+  test('clamps remaining to zero when used exceeds limit', () => {
+    const error = buildQuotaError('Mint quota exceeded.', {
+      limit: 100,
+      used: 200,
+      unit: 'sat',
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿0',
+    );
+  });
+
+  test('falls back to detail when 33001 has no structured data', () => {
+    const detail = 'Mint quota exceeded: ₿600 of ₿1,000. Try again in 1h.';
+    const error = new MintOperationError(
+      CashuErrorCodes.MINT_QUOTA_EXCEEDED,
+      detail,
+    );
+
+    expect(formatCashuQuoteError(error)).toBe(detail);
+  });
+
+  test('falls back to detail when 33001 has malformed data', () => {
+    const detail = 'Mint quota exceeded.';
+    const error = buildQuotaError(detail, { limit: 'not-a-number' });
+
+    expect(formatCashuQuoteError(error)).toBe(detail);
+  });
+
+  test('falls back to detail when 33001 has unknown unit', () => {
+    const detail = 'Mint quota exceeded for eur unit.';
+    const error = buildQuotaError(detail, {
+      limit: 100,
+      used: 25,
+      unit: 'eur',
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(detail);
+  });
+
+  test('passes through non-quota MintOperationError unchanged', () => {
+    const error = new MintOperationError(
+      CashuErrorCodes.QUOTE_NOT_PAID,
+      'Quote not paid',
+    );
+
+    expect(formatCashuQuoteError(error)).toBe('Quote not paid');
+  });
+
+  test('returns message for generic Error instances', () => {
+    expect(formatCashuQuoteError(new Error('network failure'))).toBe(
+      'network failure',
+    );
+  });
+
+  test('returns string representation for non-Error inputs', () => {
+    expect(formatCashuQuoteError('unexpected')).toBe('unexpected');
+    expect(formatCashuQuoteError(null)).toBe('null');
+    expect(formatCashuQuoteError(undefined)).toBe('undefined');
+  });
+
+  test('humanizes retry-after under one minute', () => {
+    const error = buildQuotaError('quota', {
+      limit: 100,
+      used: 50,
+      unit: 'sat',
+      retry_after: 45,
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿50. Try again in 45s',
+    );
+  });
+
+  test('humanizes retry-after spanning hours and minutes', () => {
+    const error = buildQuotaError('quota', {
+      limit: 100,
+      used: 50,
+      unit: 'sat',
+      retry_after: 3 * 3600 + 30 * 60,
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿50. Try again in 3h 30m',
+    );
+  });
+
+  test('humanizes retry-after spanning days', () => {
+    const error = buildQuotaError('quota', {
+      limit: 100,
+      used: 50,
+      unit: 'sat',
+      retry_after: 2 * 86400 + 5 * 3600,
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of ₿50. Try again in 2d 5h',
+    );
+  });
+
+  test('formats usd unit as cents under the USD currency', () => {
+    const error = buildQuotaError('quota', {
+      limit: 10000,
+      used: 7500,
+      unit: 'usd',
+    });
+
+    expect(formatCashuQuoteError(error)).toBe(
+      'Amount exceeds remaining daily limit of 2,500¢',
+    );
+  });
+});

--- a/app/lib/cashu/quote-errors.ts
+++ b/app/lib/cashu/quote-errors.ts
@@ -1,0 +1,115 @@
+import { MintOperationError } from '@cashu/cashu-ts';
+import { Money } from '~/lib/money';
+import { CashuErrorCodes } from './error-codes';
+
+type MintQuotaExceededData = {
+  limit: number;
+  used: number;
+  unit: string;
+  window_secs?: number;
+  retry_after?: number;
+};
+
+const cashuProtocolUnitToMoneyInput: Record<
+  string,
+  { currency: 'BTC'; unit: 'sat' } | { currency: 'USD'; unit: 'cent' }
+> = {
+  sat: { currency: 'BTC', unit: 'sat' },
+  usd: { currency: 'USD', unit: 'cent' },
+};
+
+const isMintQuotaExceededData = (
+  value: unknown,
+): value is MintQuotaExceededData => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const data = value as Record<string, unknown>;
+  return (
+    typeof data.limit === 'number' &&
+    typeof data.used === 'number' &&
+    typeof data.unit === 'string'
+  );
+};
+
+const humanizeRetryAfter = (seconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  if (safeSeconds < 60) {
+    return `${safeSeconds}s`;
+  }
+  const minutes = Math.floor(safeSeconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainderMinutes === 0
+      ? `${hours}h`
+      : `${hours}h ${remainderMinutes}m`;
+  }
+  const days = Math.floor(hours / 24);
+  const remainderHours = hours % 24;
+  return remainderHours === 0 ? `${days}d` : `${days}d ${remainderHours}h`;
+};
+
+const formatRemaining = (data: MintQuotaExceededData): string | null => {
+  const moneyInput = cashuProtocolUnitToMoneyInput[data.unit];
+  if (!moneyInput) {
+    return null;
+  }
+  const remaining = Math.max(0, data.limit - data.used);
+  const money = new Money({
+    amount: remaining,
+    currency: moneyInput.currency,
+    unit: moneyInput.unit,
+  });
+  return money.toLocaleString({ unit: moneyInput.unit });
+};
+
+/**
+ * Converts an error thrown by a Cashu mint quote request into a message
+ * suitable for display to the user.
+ *
+ * When the mint returns a quota-exceeded error (NUT error code 33001) with
+ * structured `data`, returns a friendly message including the remaining limit
+ * and an optional retry-after hint. Falls back to the raw `detail` when the
+ * structured data is unavailable. For non-quota errors, returns the underlying
+ * error message.
+ */
+export const formatCashuQuoteError = (error: unknown): string => {
+  if (!(error instanceof MintOperationError)) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+
+  if (error.code !== CashuErrorCodes.MINT_QUOTA_EXCEEDED) {
+    return error.message;
+  }
+
+  const data = (error as MintOperationError & { data?: unknown }).data;
+  if (!isMintQuotaExceededData(data)) {
+    return getMintOperationErrorDetail(error);
+  }
+
+  const formattedRemaining = formatRemaining(data);
+  if (!formattedRemaining) {
+    return getMintOperationErrorDetail(error);
+  }
+
+  const baseMessage = `Amount exceeds remaining daily limit of ${formattedRemaining}`;
+  if (typeof data.retry_after === 'number') {
+    return `${baseMessage}. Try again in ${humanizeRetryAfter(data.retry_after)}`;
+  }
+  return baseMessage;
+};
+
+const getMintOperationErrorDetail = (error: MintOperationError): string => {
+  const detail = (error as MintOperationError & { detail?: unknown }).detail;
+  if (typeof detail === 'string' && detail.length > 0) {
+    return detail;
+  }
+  return error.message;
+};


### PR DESCRIPTION
## Summary

CDK PR #25 (https://github.com/MakePrisms/cdk/pull/25) introduced per-user rolling mint quotas with error code `33001`. When an authenticated user requests a mint quote that would push them over budget, the mint returns:

```json
{
  "code": 33001,
  "detail": "Mint quota exceeded: ₿600 of ₿1,000. Try again in 1h.",
  "data": { "limit": 1000, "used": 600, "unit": "sat", "window_secs": 86400, "retry_after": 3600 }
}
```

Today the wallet surfaces the raw `detail` string. Users find it confusing. This PR catches code `33001` at the service layer and substitutes a friendly message:

> **"Amount exceeds remaining daily limit of ₿400. Try again in 1h"**

`(limit - used) = 400`. The retry-after suffix is humanized (`45s`, `12m`, `3h 30m`, `2d 5h`, …) and only included when present.

## Touched surfaces

- **Receive (mint quote)** — `app/features/receive/cashu-receive-quote-core.ts`: wraps `wallet.createLockedMintQuote(...)` and re-throws as `DomainError` for `33001`. Feeds the add screen and any QR-scan-driven receive flow that lands on the create-quote step.
- **Send (melt quote)** — `app/features/send/cashu-send-quote-service.ts`: same shape around `wallet.createMeltQuoteBolt11(...)`. Surfaces as the existing toast.

Both surfaces use the existing `DomainError` path, so no new error-display infra is needed.

## What this is NOT

- It does not handle the **transfer-route** `"<name> cannot send Lightning payments"` error — root cause there is unrelated (mint advertises `agicash.purpose: "gift-card"`, source predicate rejects non-transactional). Separate PR.
- It does not address the adjacent `getMintAuthProvider(purpose)` returning `undefined` for transactional accounts (CLEAR_AUTH_REQUIRED bug). Separate PR.

## Design notes (open to review feedback)

Per maintainer guidance, we trust the CDK contract: when `code === 33001`, `data.limit`, `data.used`, and `data.unit` are guaranteed present. The helper still has type guards because TypeScript demands runtime narrowing, but the degenerate paths just preserve `error.message` (the raw `detail`) — they don't paper over CDK contract violations with clever logic. If CDK ever violates the contract, we surface the original mint message rather than swallowing or rebranding it.

Supported units: `sat` (BTC sats) and `usd` (USD cents). Unknown units fall through to the raw detail.

## Test plan

- [x] `bun test app/lib/cashu/quote-errors.test.ts` — 13/13 pass
- [x] `bun run check:all` — clean (only 2 pre-existing warnings in `vite-env.d.ts`, unrelated)
- [ ] Manual smoke against `https://limits2.agi.cash`: trigger a mint quote over budget, confirm friendly message renders on the receive screen
- [ ] Manual smoke for the send path: melt quote over the per-user quota → toast shows friendly message

The unit tests cover every branch (full data, retry-after presence/absence, used > limit clamp, missing data, malformed data, unknown unit, non-quota errors, non-Error inputs, retry-after humanization across s/m/h/d, USD unit). Manual smoke wasn't executed by the agent — the dev server hit a worktree-vite-cache contention issue. Reviewer should run the smoke before merge.

## CDK ↔ wallet contract reference

- Producer: `MakePrisms/cdk` PR #25 → error code `33001` (`Error::QuotaExceeded`) with `data: {used, limit, unit, window_secs, retry_after}`
- Consumer: this PR