### PR TITLE
perf(auth): server-redirect logged-out visits via session hint cookie

### DIFF
--- a/app/features/homepage/components/marketing-nav.tsx
+++ b/app/features/homepage/components/marketing-nav.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import logoUrl from '~/assets/full_logo.png';
 import { authQueryOptions } from '~/features/user/auth';
 
@@ -13,6 +13,7 @@ const signupBtn =
   'border-[color:var(--mk-brand)] bg-[color:var(--mk-brand)] text-[#04080f] hover:bg-transparent hover:text-[color:var(--mk-brand)]';
 
 export function MarketingNav() {
+  const location = useLocation();
   const { data: authState } = useQuery(authQueryOptions());
   const isLoggedIn = authState?.isLoggedIn ?? false;
 
@@ -43,10 +44,16 @@ export function MarketingNav() {
             </Link>
           ) : (
             <>
-              <Link to="/login" className={`${navBtnBase} ${loginBtn}`}>
+              <Link
+                to={{ ...location, pathname: '/login' }}
+                className={`${navBtnBase} ${loginBtn}`}
+              >
                 Log in
               </Link>
-              <Link to="/signup" className={`${navBtnBase} ${signupBtn}`}>
+              <Link
+                to={{ ...location, pathname: '/signup' }}
+                className={`${navBtnBase} ${signupBtn}`}
+              >
                 Sign up
               </Link>
             </>

--- a/app/features/user/auth.ts
+++ b/app/features/user/auth.ts
@@ -28,6 +28,7 @@ import { generateRandomPassword } from '~/lib/password-generator';
 import { computeSHA256 } from '~/lib/sha256';
 import { guestAccountStorage } from './guest-account-storage';
 import { oauthLoginSessionStorage } from './oauth-login-session-storage';
+import { sessionHintCookie } from './session-hint-cookie';
 
 export type AuthUser = UserResponse['user'];
 
@@ -50,6 +51,7 @@ export const authQueryOptions = () =>
       const access_token = window.localStorage.getItem('access_token');
       const refresh_token = window.localStorage.getItem('refresh_token');
       if (!access_token || !refresh_token) {
+        sessionHintCookie.clear();
         return { isLoggedIn: false } as const;
       }
 
@@ -63,10 +65,18 @@ export const authQueryOptions = () =>
         // Set Sentry user again to include the isGuest flag
         Sentry.setUser({ id: response.user.id, isGuest: !response.user.email });
 
+        // Mirror auth state into a hint cookie so the server can short-circuit
+        // SSR for unauthenticated visits. Lifetime matches the refresh token
+        // so we don't leave a stale "logged in" hint after the session
+        // genuinely expires.
+        const { exp } = jwtDecode<OpenSecretJwt>(refresh_token);
+        sessionHintCookie.set(exp - Math.floor(Date.now() / 1000));
+
         return { isLoggedIn: true, user: response.user } as const;
       } catch (error) {
         console.error('Failed to fetch user', { cause: error });
         Sentry.setUser(null);
+        sessionHintCookie.clear();
         return { isLoggedIn: false } as const;
       }
     },
@@ -362,6 +372,7 @@ const getJwt = (key: string): OpenSecretJwt | null => {
 const removeKeys = () => {
   localStorage.removeItem(accessTokenKey);
   localStorage.removeItem(refreshTokenKey);
+  sessionHintCookie.clear();
 };
 
 const getRefreshToken = () => getJwt(refreshTokenKey);

--- a/app/features/user/require-session-hint.server.ts
+++ b/app/features/user/require-session-hint.server.ts
@@ -1,0 +1,25 @@
+import { redirect } from 'react-router';
+import { sessionHintCookie } from './session-hint-cookie';
+
+/**
+ * Server loader helper: short-circuit to /home when the session hint cookie
+ * is absent, preserving the current pathname as `redirectTo` so the user
+ * lands back on the original page after login.
+ *
+ * Lives in a separate module so it doesn't share the `redirect` import with
+ * the route file's clientMiddleware — see [react-router's split-route-modules
+ * constraint](https://reactrouter.com/api/framework-conventions/route-module#splitting-route-modules).
+ */
+export const requireSessionHintOrRedirect = (request: Request): void => {
+  if (sessionHintCookie.isPresent(request.headers.get('Cookie'))) {
+    return;
+  }
+
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  if (url.pathname !== '/') {
+    params.set('redirectTo', url.pathname);
+  }
+  const search = params.toString();
+  throw redirect(`/home${search ? `?${search}` : ''}`);
+};

--- a/app/features/user/session-hint-cookie.ts
+++ b/app/features/user/session-hint-cookie.ts
@@ -1,0 +1,41 @@
+/**
+ * Non-authoritative hint cookie that mirrors the client-side auth state so the
+ * server can short-circuit SSR for unauthenticated users. The real auth check
+ * still runs on the client against the Open Secret JWT stored in localStorage;
+ * the cookie only saves the loading flicker on the unauthenticated path.
+ *
+ * Forging this cookie does not bypass auth — protected routes still validate
+ * the JWT on the client. The worst case is a forged cookie causing the loading
+ * screen to render briefly before the client redirects.
+ */
+
+const cookieName = 'agi_session_hint';
+
+const hasSessionHint = (cookieHeader: string | null): boolean => {
+  if (!cookieHeader) {
+    return false;
+  }
+  return cookieHeader.split(';').some((entry) => {
+    const [name, value] = entry.trim().split('=');
+    return name === cookieName && value === '1';
+  });
+};
+
+const setSessionHint = (maxAgeSeconds: number): void => {
+  const safeMaxAge = Math.max(0, Math.floor(maxAgeSeconds));
+  const secure = location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${cookieName}=1; Path=/; SameSite=Lax; Max-Age=${safeMaxAge}${secure}`;
+};
+
+const clearSessionHint = (): void => {
+  document.cookie = `${cookieName}=; Path=/; SameSite=Lax; Max-Age=0`;
+};
+
+export const sessionHintCookie = {
+  /** Server: parse the Cookie header to check whether the hint is set. */
+  isPresent: hasSessionHint,
+  /** Client: set the hint with the given lifetime in seconds. */
+  set: setSessionHint,
+  /** Client: remove the hint. */
+  clear: clearSessionHint,
+};

--- a/app/routes/_protected.tsx
+++ b/app/routes/_protected.tsx
@@ -30,7 +30,7 @@ import {
   pendingGiftCardMintTermsStorage,
   pendingWalletTermsStorage,
 } from '~/features/user/pending-terms-storage';
-import { sessionHintCookie } from '~/features/user/session-hint-cookie';
+import { requireSessionHintOrRedirect } from '~/features/user/require-session-hint.server';
 import { type User, shouldAcceptTerms } from '~/features/user/user';
 import {
   defaultAccounts,
@@ -237,18 +237,8 @@ export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
 // unauthenticated path — 302 before any HTML is sent, so no flicker on the
 // way to /home.
 export async function loader({ request }: Route.LoaderArgs) {
-  const cookieHeader = request.headers.get('Cookie');
-  if (sessionHintCookie.isPresent(cookieHeader)) {
-    return null;
-  }
-
-  const url = new URL(request.url);
-  const params = new URLSearchParams(url.search);
-  if (url.pathname !== '/') {
-    params.set('redirectTo', url.pathname);
-  }
-  const search = params.toString();
-  throw redirect(`/home${search ? `?${search}` : ''}`);
+  requireSessionHintOrRedirect(request);
+  return null;
 }
 
 export async function clientLoader() {

--- a/app/routes/_protected.tsx
+++ b/app/routes/_protected.tsx
@@ -30,6 +30,7 @@ import {
   pendingGiftCardMintTermsStorage,
   pendingWalletTermsStorage,
 } from '~/features/user/pending-terms-storage';
+import { sessionHintCookie } from '~/features/user/session-hint-cookie';
 import { type User, shouldAcceptTerms } from '~/features/user/user';
 import {
   defaultAccounts,
@@ -230,6 +231,25 @@ const routeGuardMiddleware: Route.ClientMiddlewareFunction = async (
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [
   routeGuardMiddleware,
 ];
+
+// Cookie is a hint, not auth: clientMiddleware above still validates the JWT,
+// so a forged cookie just buys a brief loading screen. The win is the common
+// unauthenticated path — 302 before any HTML is sent, so no flicker on the
+// way to /home.
+export async function loader({ request }: Route.LoaderArgs) {
+  const cookieHeader = request.headers.get('Cookie');
+  if (sessionHintCookie.isPresent(cookieHeader)) {
+    return null;
+  }
+
+  const url = new URL(request.url);
+  const params = new URLSearchParams(url.search);
+  if (url.pathname !== '/') {
+    params.set('redirectTo', url.pathname);
+  }
+  const search = params.toString();
+  throw redirect(`/home${search ? `?${search}` : ''}`);
+}
 
 export async function clientLoader() {
   // We are keeping this clientLoader to force client rendering for all protected routes.


### PR DESCRIPTION
## Summary

Eliminates the loading-screen flicker that unauthenticated visitors see when hitting `/`.

Today `_protected.tsx` is fully client-rendered (`clientLoader.hydrate = true` + `HydrateFallback`), so the server has no idea whether to redirect. It SSRs the loading screen, the client hydrates, the client middleware runs the auth check, and only then does it redirect to `/home`.

This change adds a server `loader` to `_protected.tsx` that reads a non-authoritative hint cookie and short-circuits with a 302 before any HTML is sent.

## How it works

- **`app/features/user/session-hint-cookie.ts`** — small helper: server reads `Cookie` header, client sets/clears via `document.cookie`.
- **`app/features/user/auth.ts`** — `authQueryOptions` queryFn now mirrors auth state into the cookie. Set on successful user fetch (Max-Age = refresh token `exp`), cleared whenever the query resolves to `isLoggedIn: false`. Also cleared in `removeKeys()` so session-expiry reload reflects the right state.
- **`app/routes/_protected.tsx`** — new server `loader` reads the cookie and throws `redirect('/home')` when absent. The existing `clientMiddleware` is untouched and remains the source of truth for actual auth validation.

## Security note

The cookie is a **hint**, not auth. Anyone can forge `agi_session_hint=1` and reach the loading screen, but they can't get past the JWT check — same guarantee as today. The win is the unauthenticated path: cookie absent → server redirect → no flicker.

## Edge cases

- **Stale \"logged-in\" hint**: Max-Age matches refresh token expiry, so the cookie won't outlive the session.
- **Stale \"logged-out\" hint** (e.g., user clears cookies but keeps localStorage): they get redirected to `/home` once, then the next auth query refresh sets the cookie. One-time flicker, then back to normal.
- **Client navigation**: server loader still runs (via the data fetch), so even client-side navigation respects the redirect. The existing `clientMiddleware` redundantly enforces this anyway.
- **OAuth callback hash** (`#access_token=...`): browsers preserve URL fragments across redirects when the `Location` header has no fragment, so the hash survives the `/` → `/home` redirect at the browser level. The `clientMiddleware` already reads `window.location.hash` directly.

## Out of scope

`_auth.tsx` has the symmetric problem (logged-in user visits `/login` → flicker → redirect to `/`). Not addressed here since it's a less common path; happy to do as a follow-up if wanted.

## Test plan

- [ ] **Not browser-tested in this session** — local dev server failed to start due to a pre-existing stale `VITE_GIFT_CARDS` in `.env` (missing the `purpose` field added in 049f3459). Please verify locally:
- [ ] Logged-out: visit \`/\` → 302 to \`/home\`, no loading screen flash in DevTools Network tab
- [ ] Logged-out: visit \`/send\` → 302 to \`/home?redirectTo=/send\`
- [ ] Logged-in: visit \`/\` → wallet loads normally (cookie present)
- [ ] Log out → cookie cleared (DevTools → Application → Cookies)
- [ ] Sign up / sign in → cookie set with correct Max-Age
- [ ] \`bun run fix:all\` passes
- [ ] \`bunx tsc --noEmit\` passes (full \`bun run typecheck\` is blocked by the same \`.env\` issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)