### PR TITLE
fix(deps): patch react-router exports to point at dist/production

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
   "patchedDependencies": {
     "@tanstack/query-core@5.90.20": "patches/@tanstack%2Fquery-core@5.90.20.patch",
     "@sentry/core@10.42.0": "patches/@sentry%2Fcore@10.42.0.patch",
+    "react-router@7.13.0": "patches/react-router@7.13.0.patch",
   },
   "packages": {
     "@agicash/bc-ur": ["@agicash/bc-ur@0.1.0", "", { "dependencies": { "@apocentre/alias-sampling": "^0.5.3", "@noble/hashes": "^1.3.3", "big.js": "^6.2.2", "buffer": "^6.0.3", "cbor-sync": "^1.0.4", "cborg": "^4.0.9", "jsbi": "3.1.5" } }, "sha512-B2Hh7dSqdeVZuMCwdNR0MXUr4fUU5n+gTWd0b0m9HpV6/mAXRMnAfuJbeax/krvHf8A3qMxFLAkTBKcSxUSPuw=="],

--- a/package.json
+++ b/package.json
@@ -118,10 +118,12 @@
   },
   "patchedDependencies": {
     "@tanstack/query-core@5.90.20": "patches/@tanstack%2Fquery-core@5.90.20.patch",
-    "@sentry/core@10.42.0": "patches/@sentry%2Fcore@10.42.0.patch"
+    "@sentry/core@10.42.0": "patches/@sentry%2Fcore@10.42.0.patch",
+    "react-router@7.13.0": "patches/react-router@7.13.0.patch"
   },
   "patchedDependencies:comments": {
     "@sentry/core@10.42.0": "This patch was added because we noticed that logs in Sentry dashboard started to show timstamps different than what our logs would record when the app would be in the background for a while and then brought back to the foreground. We suspected (not 100% sure but it seems like our patch has fixed it) that it is related to their logic which uses the Performance API to get the timestamp for greater precision (browser sometimes stops the performance api clock when the computer is asleep), so we opted out of that and are just using the Date API instead. Remove the patch once that has been solved.",
-    "@tanstack/query-core@5.90.20": "This patch is needed to add support for dynamic mutation scope. See https://github.com/TanStack/query/discussions/7126#discussioncomment-8815577 for more details. Remove the patch if tanstack query ever adds support for this natively."
+    "@tanstack/query-core@5.90.20": "This patch is needed to add support for dynamic mutation scope. See https://github.com/TanStack/query/discussions/7126#discussioncomment-8815577 for more details. Remove the patch if tanstack query ever adds support for this natively.",
+    "react-router@7.13.0": "Forces exports map to point at dist/production/ instead of dist/development/. The package ships both but its exports map only references development paths, so Vercel's lambda packager (which strips dev files from the bundle) produces a lambda that can't resolve react-router at runtime → ERR_MODULE_NOT_FOUND. Remove this patch when react-router upstream adds a production conditional to its exports map. Triggered 2026-05-18 by a silent change in Vercel's serverless lambda packaging."
   }
 }

--- a/patches/react-router@7.13.0.patch
+++ b/patches/react-router@7.13.0.patch
@@ -1,0 +1,123 @@
+diff --git a/package.json b/package.json
+index c4ec835d848fe3e857238617c7a0b8bbe32012eb..6a8f186e55f4893b6bb6b1fe6af388c39444f107 100644
+--- a/package.json
++++ b/package.json
+@@ -24,81 +24,81 @@
+   "exports": {
+     ".": {
+       "react-server": {
+-        "module": "./dist/development/index-react-server.mjs",
+-        "default": "./dist/development/index-react-server.js"
++        "module": "./dist/production/index-react-server.mjs",
++        "default": "./dist/production/index-react-server.js"
+       },
+       "node": {
+-        "types": "./dist/development/index.d.ts",
+-        "module": "./dist/development/index.mjs",
+-        "module-sync": "./dist/development/index.mjs",
+-        "default": "./dist/development/index.js"
++        "types": "./dist/production/index.d.ts",
++        "module": "./dist/production/index.mjs",
++        "module-sync": "./dist/production/index.mjs",
++        "default": "./dist/production/index.js"
+       },
+       "module": {
+-        "types": "./dist/development/index.d.mts",
+-        "default": "./dist/development/index.mjs"
++        "types": "./dist/production/index.d.mts",
++        "default": "./dist/production/index.mjs"
+       },
+       "import": {
+-        "types": "./dist/development/index.d.mts",
+-        "default": "./dist/development/index.mjs"
++        "types": "./dist/production/index.d.mts",
++        "default": "./dist/production/index.mjs"
+       },
+       "default": {
+-        "types": "./dist/development/index.d.ts",
+-        "default": "./dist/development/index.js"
++        "types": "./dist/production/index.d.ts",
++        "default": "./dist/production/index.js"
+       }
+     },
+     "./dom": {
+       "node": {
+-        "types": "./dist/development/dom-export.d.ts",
+-        "module": "./dist/development/dom-export.mjs",
+-        "module-sync": "./dist/development/dom-export.mjs",
+-        "default": "./dist/development/dom-export.js"
++        "types": "./dist/production/dom-export.d.ts",
++        "module": "./dist/production/dom-export.mjs",
++        "module-sync": "./dist/production/dom-export.mjs",
++        "default": "./dist/production/dom-export.js"
+       },
+       "module": {
+-        "types": "./dist/development/dom-export.d.mts",
+-        "default": "./dist/development/dom-export.mjs"
++        "types": "./dist/production/dom-export.d.mts",
++        "default": "./dist/production/dom-export.mjs"
+       },
+       "import": {
+-        "types": "./dist/development/dom-export.d.mts",
+-        "default": "./dist/development/dom-export.mjs"
++        "types": "./dist/production/dom-export.d.mts",
++        "default": "./dist/production/dom-export.mjs"
+       },
+       "default": {
+-        "types": "./dist/development/dom-export.d.ts",
+-        "default": "./dist/development/dom-export.js"
++        "types": "./dist/production/dom-export.d.ts",
++        "default": "./dist/production/dom-export.js"
+       }
+     },
+     "./internal": {
+       "node": {
+-        "types": "./dist/development/lib/types/internal.d.ts"
++        "types": "./dist/production/lib/types/internal.d.ts"
+       },
+       "import": {
+-        "types": "./dist/development/lib/types/internal.d.mts"
++        "types": "./dist/production/lib/types/internal.d.mts"
+       },
+       "default": {
+-        "types": "./dist/development/lib/types/index.d.ts"
++        "types": "./dist/production/lib/types/index.d.ts"
+       }
+     },
+     "./internal/react-server-client": {
+       "react-server": {
+-        "module": "./dist/development/index-react-server-client.mjs",
+-        "default": "./dist/development/index-react-server-client.js"
++        "module": "./dist/production/index-react-server-client.mjs",
++        "default": "./dist/production/index-react-server-client.js"
+       },
+       "node": {
+-        "types": "./dist/development/index.d.ts",
+-        "module": "./dist/development/index.mjs",
+-        "module-sync": "./dist/development/index.mjs",
+-        "default": "./dist/development/index.js"
++        "types": "./dist/production/index.d.ts",
++        "module": "./dist/production/index.mjs",
++        "module-sync": "./dist/production/index.mjs",
++        "default": "./dist/production/index.js"
+       },
+       "module": {
+-        "types": "./dist/development/index.d.mts",
+-        "default": "./dist/development/index.mjs"
++        "types": "./dist/production/index.d.mts",
++        "default": "./dist/production/index.mjs"
+       },
+       "import": {
+-        "types": "./dist/development/index.d.mts",
+-        "default": "./dist/development/index.mjs"
++        "types": "./dist/production/index.d.mts",
++        "default": "./dist/production/index.mjs"
+       },
+       "default": {
+-        "types": "./dist/development/index.d.ts",
+-        "default": "./dist/development/index.js"
++        "types": "./dist/production/index.d.ts",
++        "default": "./dist/production/index.js"
+       }
+     },
+     "./package.json": "./package.json"


### PR DESCRIPTION
## Summary
Vercel started silently breaking our serverless deploys today (2026-05-18 ~20:50 UTC). `next.agi.cash` returns 500 `FUNCTION_INVOCATION_FAILED` with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/node_modules/react-router/dist/development/index.mjs'
imported from /var/task/build/server/nodejs_<hash>/server-index.mjs
```

Reproduced even on a 10-day-old commit (`82a37d63`) — confirmed Vercel-side. Local prod build under Node 24.15.0 doesn't reproduce because `bun build --target=node` inlines react-router; the Vercel adapter (`@vercel/react-router@1.2.5`) produces unbundled output that hits the runtime exports-map resolution.

## Root cause
`react-router@7.13.0`'s `exports."."` map points every condition at `./dist/development/...` — the package ships `dist/production/` too but never exposes it. Vercel's lambda packager strips dev files from the bundle, expecting production paths. Result: lambda can't resolve `react-router` at runtime.

## Fix
Bun-patch the package.json to swap `dist/development/` → `dist/production/` in the exports map.

## Test plan
- [ ] Vercel preview deploys cleanly on this branch
- [ ] preview URL responds 200 on `/`
- [ ] `bun run fix:all` clean
- [ ] confirm no other react-router consumers (e.g. `@react-router/node`, `@sentry/react-router`) break

## Out of scope
Upstream fix in react-router itself — file an issue at remix-run/react-router asking for a `production` conditional in their exports map. Remove this patch when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)