### PR TITLE
chore(deps): bump @vercel/react-router 1.2.5 → 1.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -36,7 +36,7 @@
         "@tanstack/react-query": "5.90.20",
         "@tanstack/react-query-devtools": "5.91.3",
         "@vercel/analytics": "1.5.0",
-        "@vercel/react-router": "1.2.5",
+        "@vercel/react-router": "1.3.0",
         "big.js": "7.0.1",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
@@ -675,9 +675,9 @@
 
     "@vercel/analytics": ["@vercel/analytics@1.5.0", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g=="],
 
-    "@vercel/react-router": ["@vercel/react-router@1.2.5", "", { "dependencies": { "@vercel/static-config": "3.1.2", "ts-morph": "12.0.0" }, "peerDependencies": { "@react-router/dev": "7", "@react-router/node": "7", "isbot": "5", "react": ">=18", "react-dom": ">=18" } }, "sha512-y1GSzt+pZZkO53oUzpJzmeYkdQwgWF4nI9i5OtuM1h6ItgOppkYgtGze9SmRwon3B6m0gOQXiiRhcTB1kM7Hxg=="],
+    "@vercel/react-router": ["@vercel/react-router@1.3.0", "", { "dependencies": { "@vercel/static-config": "3.3.0", "ts-morph": "12.0.0" }, "peerDependencies": { "@react-router/dev": "7", "@react-router/node": "7", "isbot": "5", "react": ">=18", "react-dom": ">=18" } }, "sha512-z952pqHTGje/LSFRcbKyFSL7DDDFsIStsEmFbdF4cQDBYgTXQWepuQEfdRouNz3FTodib0/hXyWR1OVWd8hxtw=="],
 
-    "@vercel/static-config": ["@vercel/static-config@3.1.2", "", { "dependencies": { "ajv": "8.6.3", "json-schema-to-ts": "1.6.4", "ts-morph": "12.0.0" } }, "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ=="],
+    "@vercel/static-config": ["@vercel/static-config@3.3.0", "", { "dependencies": { "ajv": "8.6.3", "json-schema-to-ts": "1.6.4", "ts-morph": "12.0.0" } }, "sha512-GpS3tPwUeDJCkrKbMNtS2XLRFgfxTlN7YNUL+Bo23+fGolrDw6Oq79R3yvxTYgqRaJMGSEqC7iMw6mj6I5loxg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@tanstack/react-query": "5.90.20",
     "@tanstack/react-query-devtools": "5.91.3",
     "@vercel/analytics": "1.5.0",
-    "@vercel/react-router": "1.2.5",
+    "@vercel/react-router": "1.3.0",
     "big.js": "7.0.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",


### PR DESCRIPTION
## Summary
Production deploys on `next.agi.cash` are 500ing with `FUNCTION_INVOCATION_FAILED` after a silent Vercel-side change. Error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/node_modules/react-router/dist/development/index.mjs'
```

This PR bumps the Vercel adapter that produces the lambda bundle in case 1.3.0 fixes the packaging.

**Parallel attempt to #1083** (bun-patch react-router exports). Whichever fix gets a green Vercel preview deploy wins; the other gets closed.

### Changelog notes
`@vercel/react-router@1.3.0` upstream changelog only documents a TypeScript 5.9 upgrade and a bump of `@vercel/static-config` to `3.3.0`. No explicit "fix lambda packaging" entry — bumping anyway to see if the rebuilt package no longer hits the resolution.

## Test plan
- [ ] Vercel preview deploys cleanly
- [ ] preview URL returns 200 on `/`
- [ ] preview URL returns 200 on `/home`, `/terms`, `/qr`
- [ ] `bun run fix:all` clean
- [ ] no breaking-change peer-dep warnings on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)