### PR TITLE
fix: don't retry melt quote creation on MintOperationError

### DIFF
--- a/apps/web-wallet/app/features/receive/receive-cashu-token-quote-service.ts
+++ b/apps/web-wallet/app/features/receive/receive-cashu-token-quote-service.ts
@@ -1,4 +1,8 @@
-import type { MeltQuoteBolt11Response, Token } from '@cashu/cashu-ts';
+import {
+  type MeltQuoteBolt11Response,
+  MintOperationError,
+  type Token,
+} from '@cashu/cashu-ts';
 import { getCashuUnit } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 import type {
@@ -247,8 +251,16 @@ export class ReceiveCashuTokenQuoteService {
           description,
         });
 
-      const meltQuote =
-        await sourceAccount.wallet.createMeltQuoteBolt11(paymentRequest);
+      let meltQuote: MeltQuoteBolt11Response;
+      try {
+        meltQuote =
+          await sourceAccount.wallet.createMeltQuoteBolt11(paymentRequest);
+      } catch (error) {
+        if (error instanceof MintOperationError) {
+          throw new DomainError(error.message);
+        }
+        throw error;
+      }
 
       const amountRequired = new Money({
         amount: meltQuote.amount + meltQuote.fee_reserve,

--- a/apps/web-wallet/app/features/send/cashu-send-quote-service.ts
+++ b/apps/web-wallet/app/features/send/cashu-send-quote-service.ts
@@ -1,6 +1,7 @@
 import {
   type MeltQuoteBolt11Response,
   MeltQuoteState,
+  MintOperationError,
   OutputData,
 } from '@cashu/cashu-ts';
 import type { Big } from 'big.js';
@@ -147,7 +148,15 @@ export class CashuSendQuoteService {
     const cashuUnit = getCashuUnit(account.currency);
     const wallet = account.wallet;
 
-    const meltQuote = await wallet.createMeltQuoteBolt11(paymentRequest);
+    let meltQuote: MeltQuoteBolt11Response;
+    try {
+      meltQuote = await wallet.createMeltQuoteBolt11(paymentRequest);
+    } catch (error) {
+      if (error instanceof MintOperationError) {
+        throw new DomainError(error.message);
+      }
+      throw error;
+    }
 
     const amountWithLightningFee = meltQuote.amount + meltQuote.fee_reserve;
 


### PR DESCRIPTION
Closes #1089

Mint operation errors like `20739` (returned when paying a non-allowed invoice with a closed-loop gift card mint) are definitive mint responses and retrying won't help.

Updated `useCreateCashuLightningSendQuote` (`app/features/send/cashu-send-quote-hooks.ts`) and `useCreateCrossAccountReceiveQuotes` (`app/features/receive/receive-cashu-token-hooks.ts`) — the two mutations that call `createMeltQuoteBolt11` — to treat `MintOperationError` as non-retryable, matching the existing pattern in `useInitiateCashuSendQuote` and `useInitiateMelt`.
