### PR TITLE
feat(spark): support LUD-06 description_hash on LNURL-pay

### DIFF
--- a/app/features/receive/lightning-address-service.ts
+++ b/app/features/receive/lightning-address-service.ts
@@ -1,4 +1,5 @@
-import { hexToBytes } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha2';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { base64url } from '@scure/base';
 import type { QueryClient } from '@tanstack/react-query';
 import { z } from 'zod/mini';
@@ -118,11 +119,7 @@ export class LightningAddressService {
       }
 
       const callback = `${this.baseUrl}/api/lnurlp/callback/${user.id}`;
-      const address = `${user.username}@${new URL(this.baseUrl).host}`;
-      const metadata = JSON.stringify([
-        ['text/plain', `Pay to ${address}`],
-        ['text/identifier', address],
-      ]);
+      const metadata = this.buildLnurlpMetadata(user.username);
 
       return {
         callback,
@@ -192,6 +189,8 @@ export class LightningAddressService {
       }
 
       if (account.type === 'cashu') {
+        // cashu does not support setting the description_hash of an invoice.
+        // Read more here: https://github.com/cashubtc/nuts/issues/110#issuecomment-2062898765
         const lightningQuote = await getLightningQuote({
           wallet: account.wallet,
           amount: amountToReceive,
@@ -227,10 +226,16 @@ export class LightningAddressService {
         new SparkReceiveQuoteRepositoryServer(this.db),
       );
 
+      const metadata = this.buildLnurlpMetadata(user.username);
+      const descriptionHash = bytesToHex(
+        sha256(new TextEncoder().encode(metadata)),
+      );
+
       const lightningQuote = await sparkReceiveQuoteService.getLightningQuote({
         wallet: account.wallet,
         amount: amountToReceive,
         receiverIdentityPubkey: user.sparkIdentityPublicKey,
+        descriptionHash,
       });
 
       await sparkReceiveQuoteService.createReceiveQuote({
@@ -344,6 +349,14 @@ export class LightningAddressService {
       preimage: receiveRequest.paymentPreimage ?? null,
       pr: receiveRequest.invoice,
     };
+  }
+
+  private buildLnurlpMetadata(username: string): string {
+    const address = `${username}@${new URL(this.baseUrl).host}`;
+    return JSON.stringify([
+      ['text/plain', `Pay to ${address}`],
+      ['text/identifier', address],
+    ]);
   }
 
   private encryptLnurlVerifyQuoteData(payload: LnurlVerifyQuoteData): string {

--- a/app/features/receive/spark-receive-quote-core.ts
+++ b/app/features/receive/spark-receive-quote-core.ts
@@ -50,9 +50,14 @@ export type GetLightningQuoteParams = {
    */
   receiverIdentityPubkey?: string;
   /**
-   * The description of the receive request.
+   * The description of the receive request (BOLT11 `d` tag).
    */
   description?: string;
+  /**
+   * Hex-encoded SHA-256 commitment to a description (BOLT11 `h` tag).
+   * When set, Breez SDK emits `h` only and drops `description`.
+   */
+  descriptionHash?: string;
 };
 
 export type CreateQuoteBaseParams = {
@@ -228,6 +233,7 @@ export async function getLightningQuote({
   amount,
   receiverIdentityPubkey,
   description,
+  descriptionHash,
 }: GetLightningQuoteParams): Promise<SparkReceiveLightningQuote> {
   const response = await measureOperation('BreezSdk.receivePayment', () =>
     wallet.receivePayment({
@@ -236,6 +242,7 @@ export async function getLightningQuote({
         description: description ?? '',
         amountSats: amount.toNumber('sat'),
         receiverIdentityPubkey,
+        descriptionHash,
       },
     }),
   );


### PR DESCRIPTION
Closes #989.

Sets the BOLT11 `h` tag on spark-account invoices created via LNURL-pay, so wallets that verify against the LUD-06 metadata hash accept them.

- Extracts `buildLnurlpMetadata(username)` in `LightningAddressService` so `handleLud16Request` (response) and `handleLnurlpCallback` (spark branch) hash identical bytes.
- Threads `descriptionHash?: string` through `GetLightningQuoteParams` to Breez SDK's `bolt11Invoice` receive method; sends empty description when the hash is set.
- Cashu branch intentionally untouched — that path is blocked on the upstream CDK change for `h`-tagged mint quotes.