### PR TITLE
refactor(hooks): adopt useTrack naming for receive-quote trackers

### DIFF
--- a/app/features/buy/buy-checkout.tsx
+++ b/app/features/buy/buy-checkout.tsx
@@ -20,8 +20,8 @@ import {
   type SparkAccount,
   getAccountHomePath,
 } from '../accounts/account';
-import { useCashuReceiveQuote } from '../receive/cashu-receive-quote-hooks';
-import { useSparkReceiveQuote } from '../receive/spark-receive-quote-hooks';
+import { useTrackCashuReceiveQuote } from '../receive/cashu-receive-quote-hooks';
+import { useTrackSparkReceiveQuote } from '../receive/spark-receive-quote-hooks';
 import { getDefaultUnit } from '../shared/currencies';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import type { BuyQuote } from './buy-store';
@@ -225,7 +225,7 @@ export function BuyCheckoutCashu({
   const { redirectTo } = useRedirectTo(getAccountHomePath(account));
   const navigateToTransaction = useNavigateToTransaction(redirectTo);
 
-  const { status: quotePaymentStatus } = useCashuReceiveQuote({
+  const { status: quotePaymentStatus } = useTrackCashuReceiveQuote({
     quoteId: quote.id,
     onPaid: (cashuQuote) => {
       navigateToTransaction(cashuQuote.transactionId);
@@ -255,7 +255,7 @@ export function BuyCheckoutSpark({
   const { redirectTo } = useRedirectTo(getAccountHomePath(account));
   const navigateToTransaction = useNavigateToTransaction(redirectTo);
 
-  const { status: quotePaymentStatus } = useSparkReceiveQuote({
+  const { status: quotePaymentStatus } = useTrackSparkReceiveQuote({
     quoteId: quote.id,
     onPaid: (sparkQuote) => {
       navigateToTransaction(sparkQuote.transactionId);

--- a/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/app/features/receive/cashu-receive-quote-hooks.ts
@@ -196,13 +196,13 @@ export function useCashuReceiveQuoteCache() {
   return useMemo(() => new CashuReceiveQuoteCache(queryClient), [queryClient]);
 }
 
-type UseCashuReceiveQuoteProps = {
+type UseTrackCashuReceiveQuoteProps = {
   quoteId?: string;
   onPaid?: (quote: CashuReceiveQuote) => void;
   onExpired?: (quote: CashuReceiveQuote) => void;
 };
 
-type UseCashuReceiveQuoteResponse =
+type UseTrackCashuReceiveQuoteResponse =
   | {
       status: 'LOADING';
       quote?: undefined;
@@ -212,11 +212,11 @@ type UseCashuReceiveQuoteResponse =
       quote: CashuReceiveQuote;
     };
 
-export function useCashuReceiveQuote({
+export function useTrackCashuReceiveQuote({
   quoteId,
   onPaid,
   onExpired,
-}: UseCashuReceiveQuoteProps): UseCashuReceiveQuoteResponse {
+}: UseTrackCashuReceiveQuoteProps): UseTrackCashuReceiveQuoteResponse {
   const enabled = !!quoteId;
   const onPaidRef = useLatest(onPaid);
   const onExpiredRef = useLatest(onExpired);

--- a/app/features/receive/receive-cashu.tsx
+++ b/app/features/receive/receive-cashu.tsx
@@ -28,8 +28,8 @@ import { getDefaultUnit } from '../shared/currencies';
 import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 import {
-  useCashuReceiveQuote,
   useCreateCashuReceiveQuote,
+  useTrackCashuReceiveQuote,
 } from './cashu-receive-quote-hooks';
 
 type CreateQuoteProps = {
@@ -46,7 +46,7 @@ const useCreateQuote = ({ account, amount, onPaid }: CreateQuoteProps) => {
     error,
   } = useCreateCashuReceiveQuote();
 
-  const { quote, status: quotePaymentStatus } = useCashuReceiveQuote({
+  const { quote, status: quotePaymentStatus } = useTrackCashuReceiveQuote({
     quoteId: createdQuote?.id,
     onPaid: onPaid,
   });

--- a/app/features/receive/receive-spark.tsx
+++ b/app/features/receive/receive-spark.tsx
@@ -23,7 +23,7 @@ import { MoneyWithConvertedAmount } from '../shared/money-with-converted-amount'
 import type { SparkReceiveQuote } from './spark-receive-quote';
 import {
   useCreateSparkReceiveQuote,
-  useSparkReceiveQuote,
+  useTrackSparkReceiveQuote,
 } from './spark-receive-quote-hooks';
 
 type Props = {
@@ -47,7 +47,7 @@ const useCreateQuote = ({
     error,
   } = useCreateSparkReceiveQuote();
 
-  const { quote, status: quotePaymentStatus } = useSparkReceiveQuote({
+  const { quote, status: quotePaymentStatus } = useTrackSparkReceiveQuote({
     quoteId: createdQuote?.id,
     onPaid,
   });

--- a/app/features/receive/spark-receive-quote-hooks.ts
+++ b/app/features/receive/spark-receive-quote-hooks.ts
@@ -68,13 +68,13 @@ export function useSparkReceiveQuoteCache() {
   return useMemo(() => new SparkReceiveQuoteCache(queryClient), [queryClient]);
 }
 
-type UseSparkReceiveQuoteProps = {
+type UseTrackSparkReceiveQuoteProps = {
   quoteId?: string;
   onPaid?: (quote: SparkReceiveQuote) => void;
   onExpired?: (quote: SparkReceiveQuote) => void;
 };
 
-type UseSparkReceiveQuoteResponse =
+type UseTrackSparkReceiveQuoteResponse =
   | {
       status: 'LOADING';
       quote?: undefined;
@@ -84,11 +84,11 @@ type UseSparkReceiveQuoteResponse =
       quote: SparkReceiveQuote;
     };
 
-export function useSparkReceiveQuote({
+export function useTrackSparkReceiveQuote({
   quoteId,
   onPaid,
   onExpired,
-}: UseSparkReceiveQuoteProps): UseSparkReceiveQuoteResponse {
+}: UseTrackSparkReceiveQuoteProps): UseTrackSparkReceiveQuoteResponse {
   const enabled = !!quoteId;
   const onPaidRef = useLatest(onPaid);
   const onExpiredRef = useLatest(onExpired);


### PR DESCRIPTION
Closes #414

Renames 2 hooks that match the `useTrackCashuSendSwap` model — entity-tracker shape with `repository.get(id)` queryFn and lifecycle callbacks:

- `useCashuReceiveQuote` -> `useTrackCashuReceiveQuote` (`app/features/receive/cashu-receive-quote-hooks.ts`)
- `useSparkReceiveQuote` -> `useTrackSparkReceiveQuote` (`app/features/receive/spark-receive-quote-hooks.ts`)

Associated `Props` / `Response` types renamed to match (`UseTrackCashuReceiveQuoteProps`, `UseTrackCashuReceiveQuoteResponse`, and Spark equivalents).

Other `use*` hooks intentionally untouched (see issue comment for rationale).

## Test plan
- [x] `bun run check:all` passes (typecheck + lint + format)
- [ ] Verify lightning receive flow still tracks quote state (Cashu + Spark)
- [ ] Verify Cash App buy flow still tracks quote state (Cashu + Spark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)