### PR TITLE
chore(receive): resolve TODO on claim error reporting

### DIFF
--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -72,7 +72,6 @@ export class ClaimCashuTokenService {
       }
 
       const message = 'Unexpected error while claiming the token';
-      // TODO: do we need to send this error to Sentry or Sentry can make alert from error log?
       console.error(message, { cause: error, time: new Date().toISOString() });
       return {
         success: false,


### PR DESCRIPTION
## Summary

Removes the TODO at `app/features/receive/claim-cashu-token-service.ts:75`:

```
// TODO: do we need to send this error to Sentry or Sentry can make alert from error log?
```

The existing `console.error(message, { cause, time })` already matches the codebase convention for non-`DomainError` paths in feature services. No code change beyond removing the comment.

## Convention found

Across feature services and hooks, the established pattern for unknown errors caught in domain code is:

```ts
if (error instanceof DomainError) {
  // surface the message to the user
} else {
  console.error('<context>', { cause: error, ... });
}
```

Examples:
- `app/features/send/send-confirmation.tsx:143` (`Failed to initiate cashu send`)
- `app/features/send/send-confirmation.tsx:171` (`Failed to initiate spark send`)
- `app/features/transfer/transfer-confirmation.tsx:48` (`Failed to initiate transfer`)
- `app/features/send/cashu-send-quote-hooks.ts:349` (`Initiate send error`)
- Many more in `app/features/receive`, `app/features/send`.

These errors reach Sentry via `Sentry.consoleLoggingIntegration()`, configured in both `app/entry.client.tsx` and `app/instrument.server.ts`. Sentry can alert on logs.

Explicit `Sentry.captureException` is reserved for narrower cases where the console pipeline isn't appropriate or where extra context must be attached:
- `app/root.tsx:339` - ErrorBoundary fallback after `Sentry.isEnabled()` check
- `app/routes/api.logs.ts:68` - the Sentry tunnel route itself
- `app/components/qr-scanner/qr-scanner.tsx:133` - wraps the raw error in a labeled `new Error()` for grouping
- `app/features/email/welcome-email-service.ts:26,63` - server-side flow with explicit `extra` attributes (`code`, `userId`)
- `app/features/shared/feature-flags.ts:39` - last-resort capture after exhausted retries

The claim path doesn't fit any of those categories — it's the standard "unknown error from a service call" shape — so the existing `console.error` is correct and the TODO can simply be deleted.

This also aligns with the `CLAUDE.md` Error Handling section: "Unknown errors -> `variant: 'destructive'` with generic message + `console.error`".

## Test plan

- [x] `bun run check:all` passes (typecheck, biome lint, biome format)
- [ ] No behavior change — diff is a single removed comment line