### PR TITLE
refactor(sentry): converge captureException calls on single pattern

### DIFF
--- a/app/features/email/welcome-email-service.ts
+++ b/app/features/email/welcome-email-service.ts
@@ -25,7 +25,6 @@ export async function sendWelcomeEmail(data: {
   if (!resendApiKey || !resendWelcomeTemplateId) {
     Sentry.captureException(
       new Error('Missing RESEND_API_KEY or RESEND_WELCOME_TEMPLATE_ID'),
-      { extra: { code: 'server_misconfigured', userId } },
     );
     return;
   }
@@ -60,8 +59,8 @@ export async function sendWelcomeEmail(data: {
       userId,
     });
   } catch (error) {
-    Sentry.captureException(error, {
-      extra: { code: 'email_send_failed', userId },
-    });
+    Sentry.captureException(
+      new Error('Failed to send welcome email', { cause: error }),
+    );
   }
 }

--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -1,5 +1,6 @@
 import type { Payment } from '@agicash/breez-sdk-spark';
 import type { Token } from '@cashu/cashu-ts';
+import * as Sentry from '@sentry/react-router';
 import type { QueryClient } from '@tanstack/react-query';
 import { getExchangeRate } from '~/hooks/use-exchange-rate';
 import type { Account, CashuAccount, SparkAccount } from '../accounts/account';
@@ -72,8 +73,7 @@ export class ClaimCashuTokenService {
       }
 
       const message = 'Unexpected error while claiming the token';
-      // TODO: do we need to send this error to Sentry or Sentry can make alert from error log?
-      console.error(message, { cause: error, time: new Date().toISOString() });
+      Sentry.captureException(new Error(message, { cause: error }));
       return {
         success: false,
         message,


### PR DESCRIPTION
Resolves TODO at `claim-cashu-token-service.ts:75` ("do we need to send this error to Sentry?") — yes, unexpected claim errors should be alertable Issues, not just logs.

Drops the `extra: { code, ... }` payload that only welcome-email-service used. All five `captureException` call sites now match qr-scanner's shape:

```ts
Sentry.captureException(new Error('descriptive message', { cause: error }));
```

Convention finding: `consoleLoggingIntegration` ships console.error to Sentry as **logs**, not **Issues** — explicit `captureException` needed for alerting. Replaces closed PR #1100 (wrong fix).
