### PR TITLE
fix(spark): handle missing WebAssembly with friendly error UI

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -38,7 +38,13 @@ configure({
 // Start Breez WASM fetch/compile as early as possible so it overlaps with
 // hydration, Sentry init, and the auth query — by the time the _protected
 // middleware awaits it, init is often already done.
-ensureBreezWasm();
+// Swallow the rejection here; the middleware re-awaits the same cached promise
+// and surfaces the error through the route ErrorBoundary, where we render a
+// friendly message. Without this `.catch`, the rejection also fires
+// `unhandledrejection` and is reported to Sentry as a duplicate.
+ensureBreezWasm().catch(() => {
+  // Surfaced via _protected middleware → route ErrorBoundary.
+});
 
 // Prefetch feature flags as early as possible.
 // Before login the DB client uses the anon key (no access token),

--- a/app/lib/spark/wasm.ts
+++ b/app/lib/spark/wasm.ts
@@ -3,12 +3,30 @@ import initBreezWasm from '@agicash/breez-sdk-spark';
 let wasmInitPromise: ReturnType<typeof initBreezWasm> | null = null;
 
 /**
+ * Thrown when `WebAssembly` is not available in the current browser session.
+ * Most commonly caused by iOS Lockdown Mode disabling WASM in WebKit; can also
+ * occur in restricted in-app WebViews on Android.
+ */
+export class WebAssemblyUnavailableError extends Error {
+  constructor() {
+    super('WebAssembly is not available in this browser session');
+    this.name = 'WebAssemblyUnavailableError';
+  }
+}
+
+/**
  * Initializes the Breez SDK WASM module exactly once, even across concurrent
  * callers. The SDK's own init only short-circuits after completion, so parallel
  * calls mid-init would each run a full fetch/compile/__wbindgen_start. Caching
  * the promise here makes the second caller await the same in-flight init.
+ *
+ * If `WebAssembly` is not exposed by the runtime, rejects with
+ * `WebAssemblyUnavailableError` before invoking any wasm-bindgen code.
  */
 export const ensureBreezWasm = () => {
+  if (typeof WebAssembly === 'undefined') {
+    return Promise.reject(new WebAssemblyUnavailableError());
+  }
   wasmInitPromise ??= initBreezWasm();
   return wasmInitPromise;
 };

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,6 +29,7 @@ import { ThemeProvider, useTheme } from '~/features/theme';
 import { getBgColorForTheme } from '~/features/theme/colors';
 import { getThemeCookies } from '~/features/theme/theme-cookies.server';
 import { getThemeScript } from '~/features/theme/theme-script';
+import { WebAssemblyUnavailableError } from '~/lib/spark';
 import { SupabaseRealtimeError } from '~/lib/supabase/supabase-realtime-hooks';
 import { transitionStyles, useViewTransitionEffect } from '~/lib/transitions';
 import stylesheet from '~/tailwind.css?url';
@@ -302,6 +303,36 @@ const useErrorDetails = (error: unknown) => {
         ),
       };
     }
+  }
+
+  if (error instanceof WebAssemblyUnavailableError) {
+    // All iOS browsers run on WebKit, so iOS Lockdown Mode disables WASM
+    // everywhere on iOS. On macOS, Lockdown Mode only restricts WebKit
+    // (Safari and embeds); Chrome/Firefox use their own engines and aren't
+    // affected. Detect at error time, not at boot — UA can lie, but it's
+    // only used to tailor the copy.
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    const isIOS = /iPhone|iPad|iPod/.test(ua);
+    const isMacSafari =
+      /Macintosh/.test(ua) &&
+      /Safari\//.test(ua) &&
+      !/Chrome\/|CriOS\/|FxiOS\/|Edg\//.test(ua);
+    const lockdownLikely = isIOS || isMacSafari;
+    return {
+      title: 'Browser not supported',
+      message: lockdownLikely
+        ? 'Agicash needs WebAssembly, which is disabled on this device. ' +
+          "If you've turned on Lockdown Mode, add agi.cash as an exception " +
+          'in Settings → Privacy & Security → Lockdown Mode, then reload.'
+        : "Agicash needs WebAssembly, but it isn't available in this browser. " +
+          'Try opening agi.cash in a recent version of Chrome, Safari, or ' +
+          'Firefox (not an in-app browser).',
+      footer: (
+        <Button variant="default" type="button" onClick={reload}>
+          Reload Page
+        </Button>
+      ),
+    };
   }
 
   if (error instanceof Error) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -328,7 +328,12 @@ const useErrorDetails = (error: unknown) => {
           'Try opening agi.cash in a recent version of Chrome, Safari, or ' +
           'Firefox (not an in-app browser).',
       footer: (
-        <Button variant="default" type="button" onClick={reload}>
+        <Button
+          className="mt-4"
+          variant="default"
+          type="button"
+          onClick={reload}
+        >
           Reload Page
         </Button>
       ),


### PR DESCRIPTION
## Summary

Resolves the Sentry issue [AGICASH-AY](https://make-prisms.sentry.io/issues/7468770917/) (`ReferenceError: Can't find variable: WebAssembly`).

When `WebAssembly` is unavailable in a browser session — most commonly iOS Lockdown Mode disabling WASM in WebKit, occasionally restricted in-app WebViews on Android — the Breez SDK crashed deep in wasm-bindgen with an unrecognizable `ReferenceError`. That landed in the generic "An unexpected error occurred" error card and reported to Sentry on every affected session.

Changes:

- **`app/lib/spark/wasm.ts`** — `ensureBreezWasm` now checks `typeof WebAssembly` upfront and rejects with a typed `WebAssemblyUnavailableError` before any wasm-bindgen code runs. Stable error identity instead of minified-bindings noise.
- **`app/entry.client.tsx`** — fire-and-forget `ensureBreezWasm()` is now `.catch()`-ed, so the rejection doesn't also surface as an `unhandledrejection` (which Sentry's global handler was reporting as a duplicate).
- **`app/root.tsx`** — `useErrorDetails` matches `WebAssemblyUnavailableError` and renders a platform-aware card:
  - iOS (any browser, all WebKit) or macOS Safari → "Lockdown Mode" copy with Settings path.
  - Anything else → generic "Try a different browser (not an in-app browser)" copy.
  - Both branches omit `shouldReport`, so Sentry stays quiet on this known/unsupported-environment failure.

The QR scanner (`zxing-wasm`) has the same Lockdown-Mode failure mode but isn't addressed here — it would surface inside the scanner routes and warrants a similar feature-local treatment in a follow-up.

## Test plan

- [ ] Open the app in iOS Safari with Lockdown Mode enabled (or simulate by overriding `WebAssembly` to `undefined` in DevTools before the middleware runs) and verify the "Lockdown Mode" error card renders instead of the generic one.
- [ ] Open the app with `WebAssembly` defined (normal browser) and verify no behavior change on the happy path.
- [ ] Spoof a non-iOS / non-macOS-Safari UA with `WebAssembly` undefined and verify the generic browser-unsupported copy renders.
- [ ] Confirm no `unhandledrejection` is reported in DevTools console when `WebAssembly` is undefined.
- [ ] After deploy, watch Sentry for `WebAssemblyUnavailableError` — should not appear; AGICASH-AY events should stop arriving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)