### PR TITLE
refactor: migrate Zod → Zod Mini for smaller bundle

### DIFF
--- a/app/features/accounts/account-repository.ts
+++ b/app/features/accounts/account-repository.ts
@@ -1,6 +1,6 @@
 import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { normalizeMintUrl } from '~/lib/cashu';
 import { ProofSchema } from '~/lib/cashu/types';
 import type { Currency } from '~/lib/money';

--- a/app/features/accounts/account.ts
+++ b/app/features/accounts/account.ts
@@ -1,6 +1,6 @@
 import type { BreezSdk } from '@agicash/breez-sdk-spark';
 import type { DistributedOmit } from 'type-fest';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { type ExtendedCashuWallet, getCashuUnit, sumProofs } from '~/lib/cashu';
 import { type Currency, Money } from '~/lib/money';
 import type { SparkNetwork } from '../agicash-db/json-models/spark-account-details-db-data';

--- a/app/features/accounts/cashu-account.ts
+++ b/app/features/accounts/cashu-account.ts
@@ -1,5 +1,5 @@
 import type { Proof } from '@cashu/cashu-ts';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu/types';
 
 export const CashuProofSchema = z.object({
@@ -16,8 +16,8 @@ export const CashuProofSchema = z.object({
   state: z.enum(['UNSPENT', 'RESERVED', 'SPENT']),
   version: z.number(),
   createdAt: z.string(),
-  reservedAt: z.string().nullable().optional(),
-  spentAt: z.string().nullable().optional(),
+  reservedAt: z.optional(z.nullable(z.string())),
+  spentAt: z.optional(z.nullable(z.string())),
 });
 
 export type CashuProof = z.infer<typeof CashuProofSchema>;

--- a/app/features/agicash-db/json-models/account-details-db-data.ts
+++ b/app/features/agicash-db/json-models/account-details-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { CashuAccountDetailsDbDataSchema } from './cashu-account-details-db-data';
 import { SparkAccountDetailsDbDataSchema } from './spark-account-details-db-data';
 

--- a/app/features/agicash-db/json-models/cashu-account-details-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-account-details-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 export const CashuAccountDetailsDbDataSchema = z.object({
   /**

--- a/app/features/agicash-db/json-models/cashu-lightning-receive-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-lightning-receive-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuTokenMeltDbDataSchema } from './cashu-token-melt-db-data';
 
@@ -22,23 +22,23 @@ export const CashuLightningReceiveDbDataSchema = z.object({
   /**
    * The description of the transaction.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * Optional fee charged by the mint to deposit money into the account.
    * The payer of the lightning invoice pays this fee.
    */
-  mintingFee: z.instanceof(Money).optional(),
+  mintingFee: z.optional(z.instanceof(Money)),
   /**
    * Amounts for each blinded message created for this receive.
    * Will be set only when the receive quote gets paid.
    */
-  outputAmounts: z.array(z.number()).optional(),
+  outputAmounts: z.optional(z.array(z.number())),
   /**
    * The data of the cashu token melted for the receive.
    * This will be set only for cashu token receives when the destination account is not the mint that issued the token (the token was melted to
    * pay the lightning invoice of the mint quote from the destination mint).
    */
-  cashuTokenMeltData: CashuTokenMeltDbDataSchema.optional(),
+  cashuTokenMeltData: z.optional(CashuTokenMeltDbDataSchema),
   /**
    * The total fee for the transaction.
    * For lightning receives this will equal to `mintingFee` or zero if the mint has no minting fee.

--- a/app/features/agicash-db/json-models/cashu-lightning-send-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-lightning-send-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { DestinationDetailsSchema } from '~/features/send/cashu-send-quote';
 import { Money } from '~/lib/money';
 
@@ -52,32 +52,32 @@ export const CashuLightningSendDbDataSchema = z.object({
    * Destination details of the send.
    * This will be undefined if the send is directly paying a bolt11.
    */
-  destinationDetails: DestinationDetailsSchema.optional(),
+  destinationDetails: z.optional(DestinationDetailsSchema),
   /**
    * Preimage of the lightning payment.
    * Will be set only when the send is completed.
    * If the lightning payment is settled internally in the mint, this will be an empty string or '0x0000000000000000000000000000000000000000000000000000000000000000'.
    */
-  paymentPreimage: z.string().optional(),
+  paymentPreimage: z.optional(z.string()),
   /**
    * Amount spent on the send.
    * This is the sum of `amountReceived` and `totalFee`.
    * Available only when the send is completed.
    */
-  amountSpent: z.instanceof(Money).optional(),
+  amountSpent: z.optional(z.instanceof(Money)),
   /**
    * The actual Lightning Network fee that was charged after the transaction completed.
    * This may be less than the `lightningFeeReserve` if the payment was cheaper than expected.
    * The difference between `lightningFeeReserve` and `lightningFee`, along with any overpaid inputs, is returned as change to the user.
    * Available only when the send is completed.
    */
-  lightningFee: z.instanceof(Money).optional(),
+  lightningFee: z.optional(z.instanceof(Money)),
   /**
    * The actual fee for the transaction.
    * This is the sum of `lightningFee` and `cashuSendFee`.
    * Available only when the send is completed.
    */
-  totalFee: z.instanceof(Money).optional(),
+  totalFee: z.optional(z.instanceof(Money)),
 });
 
 /**

--- a/app/features/agicash-db/json-models/cashu-swap-receive-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-swap-receive-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 
@@ -22,7 +22,7 @@ export const CashuSwapReceiveDbDataSchema = z.object({
   /**
    * The description (memo) of the token being swapped.
    */
-  tokenDescription: z.string().optional(),
+  tokenDescription: z.optional(z.string()),
   /**
    * The amount credited to the account.
    */

--- a/app/features/agicash-db/json-models/cashu-swap-send-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-swap-send-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 
 /**
@@ -51,8 +51,8 @@ export const CashuSwapSendDbDataSchema = z.object({
    * The swap output amounts used for the send and change.
    * Will be defined only when the swap is needed (`inputAmount` is greater than the `amountToSend`).
    */
-  outputAmounts: z
-    .object({
+  outputAmounts: z.optional(
+    z.object({
       /**
        * The swap output amounts used for the send.
        * Proofs with these amounts are then used to create a token which is shared with the receiver.
@@ -63,8 +63,8 @@ export const CashuSwapSendDbDataSchema = z.object({
        * Proofs with these amounts are then returned to the source account as change.
        */
       change: z.array(z.number()),
-    })
-    .optional(),
+    }),
+  ),
 });
 
 /**

--- a/app/features/agicash-db/json-models/cashu-token-melt-db-data.ts
+++ b/app/features/agicash-db/json-models/cashu-token-melt-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 

--- a/app/features/agicash-db/json-models/spark-account-details-db-data.ts
+++ b/app/features/agicash-db/json-models/spark-account-details-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 export const SparkAccountDetailsDbDataSchema = z.object({
   /**

--- a/app/features/agicash-db/json-models/spark-lightning-receive-db-data.ts
+++ b/app/features/agicash-db/json-models/spark-lightning-receive-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuTokenMeltDbDataSchema } from './cashu-token-melt-db-data';
 
@@ -18,17 +18,17 @@ export const SparkLightningReceiveDbDataSchema = z.object({
   /**
    * The description of the transaction.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * The payment preimage of the lightning payment.
    * Will be set only when the receive quote gets paid.
    */
-  paymentPreimage: z.string().optional(),
+  paymentPreimage: z.optional(z.string()),
   /**
    * The data of the cashu token melted for the receive.
    * This will be set only for cashu token receives to spark accounts.
    */
-  cashuTokenMeltData: CashuTokenMeltDbDataSchema.optional(),
+  cashuTokenMeltData: z.optional(CashuTokenMeltDbDataSchema),
   /**
    * The total fee for the transaction.
    * For lightning receives this will be zero.

--- a/app/features/agicash-db/json-models/spark-lightning-send-db-data.ts
+++ b/app/features/agicash-db/json-models/spark-lightning-send-db-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 
 /**
@@ -23,17 +23,17 @@ export const SparkLightningSendDbDataSchema = z.object({
    * This is the amount to send plus the actual fee paid to the lightning network.
    * Available only when the send is initiated.
    */
-  amountSpent: z.instanceof(Money).optional(),
+  amountSpent: z.optional(z.instanceof(Money)),
   /**
    * The actual Lightning Network fee that was charged for the transaction.
    * Will be set only when the send is initiated.
    */
-  lightningFee: z.instanceof(Money).optional(),
+  lightningFee: z.optional(z.instanceof(Money)),
   /**
    * Preimage of the lightning payment.
    * Will be set only when the send is completed.
    */
-  paymentPreimage: z.string().optional(),
+  paymentPreimage: z.optional(z.string()),
 });
 
 /**

--- a/app/features/contacts/contact.ts
+++ b/app/features/contacts/contact.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 const ContactSchema = z.object({
   id: z.string(),

--- a/app/features/gift-cards/gift-card-config.ts
+++ b/app/features/gift-cards/gift-card-config.ts
@@ -1,26 +1,29 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 export const GiftCardConfigSchema = z.array(
   z.object({
     url: z.url(),
-    name: z.string().min(1),
+    name: z.string().check(z.minLength(1)),
     currency: z.enum(['USD', 'BTC']),
     purpose: z.enum(['gift-card', 'offer']),
     isDiscoverable: z.boolean(),
-    addCardDisclaimer: z.string().optional(),
-    validPaymentDestinations: z
-      .object({
+    addCardDisclaimer: z.optional(z.string()),
+    validPaymentDestinations: z.optional(
+      z.object({
         descriptions: z.array(z.string()),
-        nodePubkeys: z.array(z.string().toLowerCase()),
-      })
-      .optional(),
+        nodePubkeys: z.array(z.string().check(z.toLowerCase())),
+      }),
+    ),
   }),
 );
 
-export const JsonGiftCardConfigSchema = z
-  .string()
-  .transform((str) => JSON.parse(str))
-  .pipe(GiftCardConfigSchema);
+export const JsonGiftCardConfigSchema = z.pipe(
+  z.pipe(
+    z.string(),
+    z.transform((str) => JSON.parse(str)),
+  ),
+  GiftCardConfigSchema,
+);
 
 export type GiftCardConfig = z.infer<typeof GiftCardConfigSchema>[number];
 

--- a/app/features/gift-cards/use-restore-scroll-position.ts
+++ b/app/features/gift-cards/use-restore-scroll-position.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 /**
  * Persists and restores the horizontal scroll position of a container across

--- a/app/features/receive/cashu-receive-quote-repository.server.ts
+++ b/app/features/receive/cashu-receive-quote-repository.server.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import type { Money } from '~/lib/money';
 import { computeSHA256 } from '~/lib/sha256';
 import type { AgicashDb } from '../agicash-db/database';

--- a/app/features/receive/cashu-receive-quote-repository.ts
+++ b/app/features/receive/cashu-receive-quote-repository.ts
@@ -1,5 +1,5 @@
 import type { Proof } from '@cashu/cashu-ts';
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import { proofToY } from '~/lib/cashu';
 import { computeSHA256 } from '~/lib/sha256';
 import type { AllUnionFieldsRequired } from '~/lib/type-utils';

--- a/app/features/receive/cashu-receive-quote.ts
+++ b/app/features/receive/cashu-receive-quote.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuTokenMeltDataSchema } from './cashu-token-melt-data';
 
@@ -28,7 +28,7 @@ const CashuReceiveQuoteBaseSchema = z.object({
   /**
    * Description of the receive.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * Date and time the receive quote was created in ISO 8601 format.
    */
@@ -61,7 +61,7 @@ const CashuReceiveQuoteBaseSchema = z.object({
    * This amount is added to the payment request amount so the amount in the payment request is equal to `amount` plus `mintingFee`.
    * The sender pays the fee. The receiver will receive `amount` worth of ecash, while the mint keeps the `mintingFee`.
    */
-  mintingFee: z.instanceof(Money).optional(),
+  mintingFee: z.optional(z.instanceof(Money)),
   /**
    * The total fee for the transaction.
    * For receives of type LIGHTNING, this will be zero.

--- a/app/features/receive/cashu-receive-swap-repository.ts
+++ b/app/features/receive/cashu-receive-swap-repository.ts
@@ -1,5 +1,5 @@
 import type { Proof, Token } from '@cashu/cashu-ts';
-import type z from 'zod';
+import type { z } from 'zod/mini';
 import { proofToY } from '~/lib/cashu';
 import type { Money } from '~/lib/money';
 import type { AllUnionFieldsRequired } from '~/lib/type-utils';

--- a/app/features/receive/cashu-receive-swap.ts
+++ b/app/features/receive/cashu-receive-swap.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 
@@ -26,7 +26,7 @@ const CashuReceiveSwapBaseSchema = z.object({
   /**
    * Description (memo) of the token being received.
    */
-  tokenDescription: z.string().optional(),
+  tokenDescription: z.optional(z.string()),
   /**
    * UUID of the user receiving the token.
    */

--- a/app/features/receive/cashu-token-melt-data.ts
+++ b/app/features/receive/cashu-token-melt-data.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 
@@ -43,7 +43,7 @@ export const CashuTokenMeltDataSchema = z.object({
    * For cashu token receives over lightning, we are currently not returning the change to the user.
    * Available only when the melt is completed.
    */
-  lightningFee: z.instanceof(Money).optional(),
+  lightningFee: z.optional(z.instanceof(Money)),
 });
 
 export type CashuTokenMeltData = z.infer<typeof CashuTokenMeltDataSchema>;

--- a/app/features/receive/lightning-address-service.ts
+++ b/app/features/receive/lightning-address-service.ts
@@ -1,7 +1,7 @@
 import { hexToBytes } from '@noble/hashes/utils';
 import { base64url } from '@scure/base';
 import type { QueryClient } from '@tanstack/react-query';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { getCashuWallet } from '~/lib/cashu';
 import { ExchangeRateService } from '~/lib/exchange-rate/exchange-rate-service';
 import type {

--- a/app/features/receive/spark-receive-quote-repository.server.ts
+++ b/app/features/receive/spark-receive-quote-repository.server.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import type { Money } from '~/lib/money';
 import type { AgicashDb } from '../agicash-db/database';
 import { SparkLightningReceiveDbDataSchema } from '../agicash-db/json-models';

--- a/app/features/receive/spark-receive-quote-repository.ts
+++ b/app/features/receive/spark-receive-quote-repository.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import type { AllUnionFieldsRequired } from '~/lib/type-utils';
 import type {
   AgicashDb,

--- a/app/features/receive/spark-receive-quote.ts
+++ b/app/features/receive/spark-receive-quote.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuTokenMeltDataSchema } from './cashu-token-melt-data';
 
@@ -30,7 +30,7 @@ const SparkReceiveQuoteBaseSchema = z.object({
   /**
    * Description of the receive.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * Bolt 11 payment request.
    */
@@ -42,7 +42,7 @@ const SparkReceiveQuoteBaseSchema = z.object({
   /**
    * Optional public key of the wallet receiving the lightning invoice.
    */
-  receiverIdentityPubkey: z.string().optional(),
+  receiverIdentityPubkey: z.optional(z.string()),
   /**
    * UUID of the corresponding transaction.
    */

--- a/app/features/send/cashu-send-quote-repository.ts
+++ b/app/features/send/cashu-send-quote-repository.ts
@@ -1,5 +1,5 @@
 import type { Proof } from '@cashu/cashu-ts';
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import { proofToY } from '~/lib/cashu';
 import type { Money } from '~/lib/money';
 import { computeSHA256 } from '~/lib/sha256';

--- a/app/features/send/cashu-send-quote.ts
+++ b/app/features/send/cashu-send-quote.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuProofSchema } from '../accounts/cashu-account';
 
@@ -116,7 +116,7 @@ const CashuSendQuoteBaseSchema = z.object({
    * Destination details of the send.
    * This will be undefined if the send is directly paying a bolt11.
    */
-  destinationDetails: DestinationDetailsSchema.optional(),
+  destinationDetails: z.optional(DestinationDetailsSchema),
   /**
    * ID of the keyset used for the send.
    */

--- a/app/features/send/cashu-send-swap-repository.ts
+++ b/app/features/send/cashu-send-swap-repository.ts
@@ -1,5 +1,5 @@
 import type { Proof } from '@cashu/cashu-ts';
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import { proofToY } from '~/lib/cashu';
 import type { Money } from '~/lib/money';
 import type { AllUnionFieldsRequired } from '~/lib/type-utils';

--- a/app/features/send/cashu-send-swap.ts
+++ b/app/features/send/cashu-send-swap.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { CashuProofSchema } from '../accounts/cashu-account';
 
@@ -44,18 +44,18 @@ const CashuSendSwapBaseSchema = z.object({
    * The keyset id used to generate the output data at the time the swap was created.
    * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
    */
-  keysetId: z.string().optional(),
+  keysetId: z.optional(z.string()),
   /**
    * The keyset counter used to generate the output data at the time the swap was created.
    * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
    */
-  keysetCounter: z.number().optional(),
+  keysetCounter: z.optional(z.number()),
   /**
    * The output data used for deterministic outputs when we swap the inputProofs for proofsToSend.
    * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
    */
-  outputAmounts: z
-    .object({
+  outputAmounts: z.optional(
+    z.object({
       /**
        * The output amounts to use when constructing the send output data.
        */
@@ -64,8 +64,8 @@ const CashuSendSwapBaseSchema = z.object({
        * The output amounts to use when constructing the change output data.
        */
       change: z.array(z.number()),
-    })
-    .optional(),
+    }),
+  ),
   /**
    * The sum of the inputProofs.
    */
@@ -113,15 +113,18 @@ const CashuSendSwapBaseSchema = z.object({
   version: z.number(),
 });
 
-const CashuSendSwapDraftStateSchema = CashuSendSwapBaseSchema.pick({
-  keysetId: true,
-  keysetCounter: true,
-  outputAmounts: true,
-})
-  .required()
-  .extend({
+const CashuSendSwapDraftStateSchema = z.extend(
+  z.required(
+    z.pick(CashuSendSwapBaseSchema, {
+      keysetId: true,
+      keysetCounter: true,
+      outputAmounts: true,
+    }),
+  ),
+  {
     state: z.literal('DRAFT'),
-  });
+  },
+);
 
 const CashuSendSwapPendingCompletedStateSchema = z.object({
   state: z.enum(['PENDING', 'COMPLETED']),

--- a/app/features/send/spark-send-quote-repository.ts
+++ b/app/features/send/spark-send-quote-repository.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import type { Money } from '~/lib/money';
 import type { AllUnionFieldsRequired } from '~/lib/type-utils';
 import type {

--- a/app/features/send/spark-send-quote.ts
+++ b/app/features/send/spark-send-quote.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 
 /**
@@ -19,7 +19,7 @@ const SparkSendQuoteBaseSchema = z.object({
   /**
    * Date and time the send quote expires in ISO 8601 format.
    */
-  expiresAt: z.string().nullish(),
+  expiresAt: z.nullish(z.string()),
   /**
    * Amount being sent.
    */
@@ -108,15 +108,15 @@ const SparkSendQuoteFailedStateSchema = z.object({
   /**
    * ID of the send request in spark system.
    */
-  sparkId: z.string().optional(),
+  sparkId: z.optional(z.string()),
   /**
    * Spark transfer ID.
    */
-  sparkTransferId: z.string().optional(),
+  sparkTransferId: z.optional(z.string()),
   /**
    * Actual fee of the lightning payment.
    */
-  fee: z.instanceof(Money).optional(),
+  fee: z.optional(z.instanceof(Money)),
 });
 
 /**

--- a/app/features/send/utils.ts
+++ b/app/features/send/utils.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { ProofSchema } from '~/lib/cashu/types';
 import type { CashuProof } from '../accounts/cashu-account';
 import type { AgicashDbCashuProof } from '../agicash-db/database';

--- a/app/features/transactions/transaction-details/cashu-lightning-receive-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-lightning-receive-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { CashuLightningReceiveDbDataSchema } from '~/features/agicash-db/json-models';
 import { Money } from '~/lib/money';
 import { TransactionStateSchema } from '../transaction-enums';
@@ -20,12 +20,12 @@ export const CashuLightningReceiveTransactionDetailsSchema = z.object({
   /**
    * The description of the transaction.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * Optional fee charged by the mint to deposit money into the account.
    * The payer of the lightning invoice pays this fee.
    */
-  mintingFee: z.instanceof(Money).optional(),
+  mintingFee: z.optional(z.instanceof(Money)),
   /**
    * The amount credited to the account.
    */
@@ -38,25 +38,25 @@ export const CashuLightningReceiveTransactionDetailsSchema = z.object({
   /**
    * UUID linking paired send/receive transactions for internal transfers.
    */
-  transferId: z.string().optional(),
+  transferId: z.optional(z.string()),
 });
 
 export type CashuLightningReceiveTransactionDetails = z.infer<
   typeof CashuLightningReceiveTransactionDetailsSchema
 >;
 
-export const CashuLightningReceiveTransactionDetailsParser = z
-  .object({
+export const CashuLightningReceiveTransactionDetailsParser = z.pipe(
+  z.object({
     type: z.literal('CASHU_LIGHTNING'),
     direction: z.literal('RECEIVE'),
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
-      transferId: z.string().optional(),
+      transferId: z.optional(z.string()),
     }),
     decryptedTransactionDetails: CashuLightningReceiveDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({
       transactionDetails,
       decryptedTransactionDetails,
@@ -71,4 +71,5 @@ export const CashuLightningReceiveTransactionDetailsParser = z
         transferId: transactionDetails.transferId,
       };
     },
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/cashu-lightning-send-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-lightning-send-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { CashuLightningSendDbDataSchema } from '~/features/agicash-db/json-models';
 import { DestinationDetailsSchema } from '~/features/send/cashu-send-quote';
 import { Money } from '~/lib/money';
@@ -21,7 +21,7 @@ export const IncompleteCashuLightningSendTransactionDetailsSchema = z.object({
    * Additional details related to the transaction.
    * This will be undefined if the send is directly paying a bolt11.
    */
-  destinationDetails: DestinationDetailsSchema.optional(),
+  destinationDetails: z.optional(DestinationDetailsSchema),
   /**
    * The amount reserved for the send.
    * This is the sum of all proofs used as inputs to the cashu melt operation.
@@ -61,7 +61,7 @@ export const IncompleteCashuLightningSendTransactionDetailsSchema = z.object({
   /**
    * UUID linking paired send/receive transactions for internal transfers.
    */
-  transferId: z.string().optional(),
+  transferId: z.optional(z.string()),
 });
 
 export type IncompleteCashuLightningSendTransactionDetails = z.infer<
@@ -71,8 +71,9 @@ export type IncompleteCashuLightningSendTransactionDetails = z.infer<
 /**
  * Schema for completed cashu lightning send transaction.
  */
-export const CompletedCashuLightningSendTransactionDetailsSchema =
-  IncompleteCashuLightningSendTransactionDetailsSchema.extend({
+export const CompletedCashuLightningSendTransactionDetailsSchema = z.extend(
+  IncompleteCashuLightningSendTransactionDetailsSchema,
+  {
     /**
      * The preimage of the lightning payment.
      * If the lightning payment is settled internally in the mint, this will be an empty string or '0x0000000000000000000000000000000000000000000000000000000000000000'
@@ -89,7 +90,8 @@ export const CompletedCashuLightningSendTransactionDetailsSchema =
      * This is the sum of `lightningFee` and `cashuSendFee`.
      */
     totalFee: z.instanceof(Money),
-  });
+  },
+);
 
 export type CompletedCashuLightningSendTransactionDetails = z.infer<
   typeof CompletedCashuLightningSendTransactionDetailsSchema
@@ -104,18 +106,18 @@ export type CashuLightningSendTransactionDetails = z.infer<
   typeof CashuLightningSendTransactionDetailsSchema
 >;
 
-export const CashuLightningSendTransactionDetailsParser = z
-  .object({
+export const CashuLightningSendTransactionDetailsParser = z.pipe(
+  z.object({
     type: z.literal('CASHU_LIGHTNING'),
     direction: z.literal('SEND'),
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
-      transferId: z.string().optional(),
+      transferId: z.optional(z.string()),
     }),
     decryptedTransactionDetails: CashuLightningSendDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({
       state,
       transactionDetails,
@@ -155,4 +157,5 @@ export const CashuLightningSendTransactionDetailsParser = z
 
       return incompleteDetails;
     },
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/cashu-token-receive-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-token-receive-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import {
   CashuLightningReceiveDbDataSchema,
   CashuSwapReceiveDbDataSchema,
@@ -23,7 +23,7 @@ export const CashuTokenReceiveTransactionDetailsSchema = z.object({
   /**
    * The description of the transaction.
    */
-  description: z.string().optional(),
+  description: z.optional(z.string()),
   /**
    * Amount credited to the account.
    * This is the `tokenAmount` minus `totalFee`.
@@ -41,13 +41,13 @@ export const CashuTokenReceiveTransactionDetailsSchema = z.object({
    * but only if the destination mint has a minting fee.
    * In this case the receiving account creates a mint quote, and then the ln invoice of the mint quote is paid by melting the token proofs.
    */
-  mintingFee: z.instanceof(Money).optional(),
+  mintingFee: z.optional(z.instanceof(Money)),
   /**
    * The fee reserved for the lightning payment.
    * This is defined when receving the token to spark account or cashu account with mint different than the one that issued the token being
    * received.
    */
-  lightningFeeReserve: z.instanceof(Money).optional(),
+  lightningFeeReserve: z.optional(z.instanceof(Money)),
   /**
    * The total fee for the transaction.
    * This is the sum of `cashuReceiveFee`, `lightningFeeReserve`, and `mintingFee`.
@@ -74,14 +74,14 @@ export type CashuTokenReceiveTransactionDetails = z.infer<
  * Thus CashuTokenReceiveTransactionDetailsParser will be a union of three parsers, one for each of the three cases.
  */
 
-const CashuSwapReceiveParser = z
-  .object({
+const CashuSwapReceiveParser = z.pipe(
+  z.object({
     type: z.literal('CASHU_TOKEN'),
     direction: z.literal('RECEIVE'),
     state: TransactionStateSchema,
     decryptedTransactionDetails: CashuSwapReceiveDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({ decryptedTransactionDetails }): CashuTokenReceiveTransactionDetails => ({
       tokenAmount: decryptedTransactionDetails.tokenAmount,
       tokenMintUrl: decryptedTransactionDetails.tokenMintUrl,
@@ -90,18 +90,19 @@ const CashuSwapReceiveParser = z
       cashuReceiveFee: decryptedTransactionDetails.cashuReceiveFee,
       totalFee: decryptedTransactionDetails.cashuReceiveFee,
     }),
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;
 
-const CashuLightningReceiveParser: TransactionDetailsParserShape = z
-  .object({
+const CashuLightningReceiveParser: TransactionDetailsParserShape = z.pipe(
+  z.object({
     type: z.literal('CASHU_TOKEN'),
     direction: z.literal('RECEIVE'),
     state: TransactionStateSchema,
-    decryptedTransactionDetails: CashuLightningReceiveDbDataSchema.required({
+    decryptedTransactionDetails: z.required(CashuLightningReceiveDbDataSchema, {
       cashuTokenMeltData: true,
     }),
-  })
-  .transform(
+  }),
+  z.transform(
     ({ decryptedTransactionDetails }): CashuTokenReceiveTransactionDetails => ({
       tokenAmount: decryptedTransactionDetails.cashuTokenMeltData.tokenAmount,
       tokenMintUrl: decryptedTransactionDetails.cashuTokenMeltData.tokenMintUrl,
@@ -114,18 +115,19 @@ const CashuLightningReceiveParser: TransactionDetailsParserShape = z
         decryptedTransactionDetails.cashuTokenMeltData.lightningFeeReserve,
       totalFee: decryptedTransactionDetails.totalFee,
     }),
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;
 
-const SparkLightningReceiveParser = z
-  .object({
+const SparkLightningReceiveParser = z.pipe(
+  z.object({
     type: z.literal('CASHU_TOKEN'),
     direction: z.literal('RECEIVE'),
     state: TransactionStateSchema,
-    decryptedTransactionDetails: SparkLightningReceiveDbDataSchema.required({
+    decryptedTransactionDetails: z.required(SparkLightningReceiveDbDataSchema, {
       cashuTokenMeltData: true,
     }),
-  })
-  .transform(
+  }),
+  z.transform(
     ({ decryptedTransactionDetails }): CashuTokenReceiveTransactionDetails => ({
       tokenAmount: decryptedTransactionDetails.cashuTokenMeltData.tokenAmount,
       tokenMintUrl: decryptedTransactionDetails.cashuTokenMeltData.tokenMintUrl,
@@ -137,7 +139,8 @@ const SparkLightningReceiveParser = z
         decryptedTransactionDetails.cashuTokenMeltData.lightningFeeReserve,
       totalFee: decryptedTransactionDetails.totalFee,
     }),
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;
 
 export const CashuTokenReceiveTransactionDetailsParser = z.union([
   CashuSwapReceiveParser,

--- a/app/features/transactions/transaction-details/cashu-token-send-transaction-details.ts
+++ b/app/features/transactions/transaction-details/cashu-token-send-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { CashuSwapSendDbDataSchema } from '~/features/agicash-db/json-models';
 import { Money } from '~/lib/money';
 import { TransactionStateSchema } from '../transaction-enums';
@@ -58,14 +58,14 @@ export type CashuTokenSendTransactionDetails = z.infer<
   typeof CashuTokenSendTransactionDetailsSchema
 >;
 
-export const CashuTokenSendTransactionDetailsParser = z
-  .object({
+export const CashuTokenSendTransactionDetailsParser = z.pipe(
+  z.object({
     type: z.literal('CASHU_TOKEN'),
     direction: z.literal('SEND'),
     state: TransactionStateSchema,
     decryptedTransactionDetails: CashuSwapSendDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({
       state,
       decryptedTransactionDetails,
@@ -84,4 +84,5 @@ export const CashuTokenSendTransactionDetailsParser = z
         totalFee: decryptedTransactionDetails.totalFee,
       };
     },
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/spark-lightning-receive-transaction-details.ts
+++ b/app/features/transactions/transaction-details/spark-lightning-receive-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { SparkLightningReceiveDbDataSchema } from '~/features/agicash-db/json-models';
 import { Money } from '~/lib/money';
 import { TransactionStateSchema } from '../transaction-enums';
@@ -24,7 +24,7 @@ export const IncompleteSparkLightningReceiveTransactionDetailsSchema = z.object(
     /**
      * The description of the transaction.
      */
-    description: z.string().optional(),
+    description: z.optional(z.string()),
     /**
      * Amount credited to the account.
      * This is the amount of the bolt 11 payment request.
@@ -33,7 +33,7 @@ export const IncompleteSparkLightningReceiveTransactionDetailsSchema = z.object(
     /**
      * UUID linking paired send/receive transactions for internal transfers.
      */
-    transferId: z.string().optional(),
+    transferId: z.optional(z.string()),
   },
 );
 
@@ -44,8 +44,9 @@ export type IncompleteSparkLightningReceiveTransactionDetails = z.infer<
 /**
  * Schema for completed Spark lightning receive transaction.
  */
-export const CompletedSparkLightningReceiveTransactionDetailsSchema =
-  IncompleteSparkLightningReceiveTransactionDetailsSchema.extend({
+export const CompletedSparkLightningReceiveTransactionDetailsSchema = z.extend(
+  IncompleteSparkLightningReceiveTransactionDetailsSchema,
+  {
     /**
      * The payment preimage of the lightning payment.
      */
@@ -54,7 +55,8 @@ export const CompletedSparkLightningReceiveTransactionDetailsSchema =
      * The ID of the transfer in Spark system.
      */
     sparkTransferId: z.string(),
-  });
+  },
+);
 
 export type CompletedSparkLightningReceiveTransactionDetails = z.infer<
   typeof CompletedSparkLightningReceiveTransactionDetailsSchema
@@ -69,20 +71,20 @@ export type SparkLightningReceiveTransactionDetails = z.infer<
   typeof SparkLightningReceiveTransactionDetailsSchema
 >;
 
-export const SparkLightningReceiveTransactionDetailsParser = z
-  .object({
+export const SparkLightningReceiveTransactionDetailsParser = z.pipe(
+  z.object({
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('RECEIVE'),
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
       sparkId: z.string(),
-      sparkTransferId: z.string().optional(),
-      transferId: z.string().optional(),
+      sparkTransferId: z.optional(z.string()),
+      transferId: z.optional(z.string()),
     }),
     decryptedTransactionDetails: SparkLightningReceiveDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({
       state,
       transactionDetails,
@@ -114,4 +116,5 @@ export const SparkLightningReceiveTransactionDetailsParser = z
 
       return incompleteDetails;
     },
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/spark-lightning-send-transaction-details.ts
+++ b/app/features/transactions/transaction-details/spark-lightning-send-transaction-details.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { SparkLightningSendDbDataSchema } from '~/features/agicash-db/json-models';
 import { Money } from '~/lib/money';
 import { TransactionStateSchema } from '../transaction-enums';
@@ -44,16 +44,16 @@ export const IncompleteSparkLightningSendTransactionDetailsSchema = z.object({
    * The ID of the send request in Spark system.
    * Available after the payment is initiated.
    */
-  sparkId: z.string().optional(),
+  sparkId: z.optional(z.string()),
   /**
    * The ID of the transfer in Spark system.
    * Available after the payment is initiated.
    */
-  sparkTransferId: z.string().optional(),
+  sparkTransferId: z.optional(z.string()),
   /**
    * UUID linking paired send/receive transactions for internal transfers.
    */
-  transferId: z.string().optional(),
+  transferId: z.optional(z.string()),
 });
 
 export type IncompleteSparkLightningSendTransactionDetails = z.infer<
@@ -63,13 +63,15 @@ export type IncompleteSparkLightningSendTransactionDetails = z.infer<
 /**
  * Schema for a Spark lightning send transaction that is completed.
  */
-export const CompletedSparkLightningSendTransactionDetailsSchema =
-  IncompleteSparkLightningSendTransactionDetailsSchema.required().extend({
+export const CompletedSparkLightningSendTransactionDetailsSchema = z.extend(
+  z.required(IncompleteSparkLightningSendTransactionDetailsSchema),
+  {
     /** The preimage of the lightning payment. */
     paymentPreimage: z.string(),
     /** transferId remains optional — only present for TRANSFER transactions. */
-    transferId: z.string().optional(),
-  });
+    transferId: z.optional(z.string()),
+  },
+);
 
 export type CompletedSparkLightningSendTransactionDetails = z.infer<
   typeof CompletedSparkLightningSendTransactionDetailsSchema
@@ -84,20 +86,20 @@ export type SparkLightningSendTransactionDetails = z.infer<
   typeof SparkLightningSendTransactionDetailsSchema
 >;
 
-export const SparkLightningSendTransactionDetailsParser = z
-  .object({
+export const SparkLightningSendTransactionDetailsParser = z.pipe(
+  z.object({
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('SEND'),
     state: TransactionStateSchema,
     transactionDetails: z.object({
       paymentHash: z.string(),
-      sparkId: z.string().optional(),
-      sparkTransferId: z.string().optional(),
-      transferId: z.string().optional(),
+      sparkId: z.optional(z.string()),
+      sparkTransferId: z.optional(z.string()),
+      transferId: z.optional(z.string()),
     }),
     decryptedTransactionDetails: SparkLightningSendDbDataSchema,
-  })
-  .transform(
+  }),
+  z.transform(
     ({
       state,
       transactionDetails,
@@ -139,4 +141,5 @@ export const SparkLightningSendTransactionDetailsParser = z
 
       return incompleteDetails;
     },
-  ) satisfies TransactionDetailsParserShape;
+  ),
+) satisfies TransactionDetailsParserShape;

--- a/app/features/transactions/transaction-details/transaction-details-parser.ts
+++ b/app/features/transactions/transaction-details/transaction-details-parser.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { CashuLightningReceiveTransactionDetailsParser } from './cashu-lightning-receive-transaction-details';
 import { CashuLightningSendTransactionDetailsParser } from './cashu-lightning-send-transaction-details';
 import { CashuTokenReceiveTransactionDetailsParser } from './cashu-token-receive-transaction-details';

--- a/app/features/transactions/transaction-details/transaction-details-types.ts
+++ b/app/features/transactions/transaction-details/transaction-details-types.ts
@@ -1,5 +1,5 @@
 import type { Json } from 'supabase/database.types';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import {
   CashuLightningReceiveDbDataSchema,
   CashuLightningSendDbDataSchema,
@@ -50,7 +50,7 @@ export type TransactionDetailsParserInput = {
 
 type TransactionDetailsParserOutput = TransactionDetails;
 
-export type TransactionDetailsParserShape = z.ZodType<
+export type TransactionDetailsParserShape = z.ZodMiniType<
   TransactionDetailsParserOutput,
   TransactionDetailsParserInput
 >;

--- a/app/features/transactions/transaction-enums.ts
+++ b/app/features/transactions/transaction-enums.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 export const TransactionDirectionSchema = z.enum(['SEND', 'RECEIVE']);
 

--- a/app/features/transactions/transaction-repository.ts
+++ b/app/features/transactions/transaction-repository.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import type { AgicashDb, AgicashDbTransaction } from '../agicash-db/database';
 import { agicashDbClient } from '../agicash-db/database.client';
 import { useEncryption } from '../shared/encryption';

--- a/app/features/transactions/transaction.ts
+++ b/app/features/transactions/transaction.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { Money } from '~/lib/money';
 import { AccountPurposeSchema, AccountTypeSchema } from '../accounts/account';
 import { CashuLightningReceiveTransactionDetailsSchema } from './transaction-details/cashu-lightning-receive-transaction-details';
@@ -62,7 +62,7 @@ export const BaseTransactionSchema = z.object({
    * accountName/Type/Purpose fields still describe the account at the time
    * of the transaction.
    */
-  accountId: z.string().nullable(),
+  accountId: z.nullable(z.string()),
   /**
    * Name of the account at the time this transaction was created.
    */
@@ -86,7 +86,7 @@ export const BaseTransactionSchema = z.object({
   /**
    * UUID of the transaction that is reversed by this transaction.
    */
-  reversedTransactionId: z.string().nullish(),
+  reversedTransactionId: z.nullish(z.string()),
   /**
    * The purpose of this transaction (e.g. a Cash App buy or an internal transfer).
    * Defaults to 'PAYMENT' for organic send/receive transactions.
@@ -98,7 +98,7 @@ export const BaseTransactionSchema = z.object({
    * - `pending`: The transaction has entered a state where the user should acknowledge it.
    * - `acknowledged`: The transaction has been acknowledged by the user.
    */
-  acknowledgmentStatus: z.enum(['pending', 'acknowledged']).nullable(),
+  acknowledgmentStatus: z.nullable(z.enum(['pending', 'acknowledged'])),
   /**
    * Date and time the transaction was created in ISO 8601 format.
    */
@@ -106,19 +106,19 @@ export const BaseTransactionSchema = z.object({
   /**
    * Date and time the transaction was set to pending in ISO 8601 format.
    */
-  pendingAt: z.string().nullish(),
+  pendingAt: z.nullish(z.string()),
   /**
    * Date and time the transaction was completed in ISO 8601 format.
    */
-  completedAt: z.string().nullish(),
+  completedAt: z.nullish(z.string()),
   /**
    * Date and time the transaction failed in ISO 8601 format.
    */
-  failedAt: z.string().nullish(),
+  failedAt: z.nullish(z.string()),
   /**
    * Date and time the transaction was reversed in ISO 8601 format.
    */
-  reversedAt: z.string().nullish(),
+  reversedAt: z.nullish(z.string()),
   /**
    * Version of the transaction.
    * Incremented on every update.
@@ -126,71 +126,83 @@ export const BaseTransactionSchema = z.object({
   version: z.number(),
 });
 
-const CashuTokenSendTransactionSchema = BaseTransactionSchema.extend({
+const CashuTokenSendTransactionSchema = z.extend(BaseTransactionSchema, {
   type: z.literal('CASHU_TOKEN'),
   direction: z.literal('SEND'),
   details: CashuTokenSendTransactionDetailsSchema,
 });
 
-const CashuTokenReceiveTransactionSchema = BaseTransactionSchema.extend({
+const CashuTokenReceiveTransactionSchema = z.extend(BaseTransactionSchema, {
   type: z.literal('CASHU_TOKEN'),
   direction: z.literal('RECEIVE'),
   details: CashuTokenReceiveTransactionDetailsSchema,
 });
 
-const IncompleteCashuLightningSendTransactionSchema =
-  BaseTransactionSchema.extend({
+const IncompleteCashuLightningSendTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('CASHU_LIGHTNING'),
     direction: z.literal('SEND'),
     state: z.enum(['PENDING', 'FAILED']),
     details: IncompleteCashuLightningSendTransactionDetailsSchema,
-  });
+  },
+);
 
-const CompletedCashuLightningSendTransactionSchema =
-  BaseTransactionSchema.extend({
+const CompletedCashuLightningSendTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('CASHU_LIGHTNING'),
     direction: z.literal('SEND'),
     state: z.literal('COMPLETED'),
     details: CompletedCashuLightningSendTransactionDetailsSchema,
-  });
+  },
+);
 
-const CashuLightningReceiveTransactionSchema = BaseTransactionSchema.extend({
+const CashuLightningReceiveTransactionSchema = z.extend(BaseTransactionSchema, {
   type: z.literal('CASHU_LIGHTNING'),
   direction: z.literal('RECEIVE'),
   details: CashuLightningReceiveTransactionDetailsSchema,
 });
 
-const IncompleteSparkLightningReceiveTransactionSchema =
-  BaseTransactionSchema.extend({
+const IncompleteSparkLightningReceiveTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('RECEIVE'),
     state: z.enum(['DRAFT', 'PENDING', 'FAILED']),
     details: SparkLightningReceiveTransactionDetailsSchema,
-  });
+  },
+);
 
-const CompletedSparkLightningReceiveTransactionSchema =
-  BaseTransactionSchema.extend({
+const CompletedSparkLightningReceiveTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('RECEIVE'),
     state: z.literal('COMPLETED'),
     details: CompletedSparkLightningReceiveTransactionDetailsSchema,
-  });
+  },
+);
 
-const IncompleteSparkLightningSendTransactionSchema =
-  BaseTransactionSchema.extend({
+const IncompleteSparkLightningSendTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('SEND'),
     state: z.enum(['DRAFT', 'PENDING', 'FAILED']),
     details: IncompleteSparkLightningSendTransactionDetailsSchema,
-  });
+  },
+);
 
-const CompletedSparkLightningSendTransactionSchema =
-  BaseTransactionSchema.extend({
+const CompletedSparkLightningSendTransactionSchema = z.extend(
+  BaseTransactionSchema,
+  {
     type: z.literal('SPARK_LIGHTNING'),
     direction: z.literal('SEND'),
     state: z.literal('COMPLETED'),
     details: CompletedSparkLightningSendTransactionDetailsSchema,
-  });
+  },
+);
 
 /**
  * Union of all transaction type/direction/state variants.
@@ -211,13 +223,15 @@ const TransactionByTypeSchema = z.union([
  * Schema for all transaction types.
  */
 export const TransactionSchema = z.union([
-  TransactionByTypeSchema.and(
+  z.intersection(
+    TransactionByTypeSchema,
     z.object({
       purpose: z.literal('TRANSFER'),
       details: z.object({ transferId: z.string() }),
     }),
   ),
-  TransactionByTypeSchema.and(
+  z.intersection(
+    TransactionByTypeSchema,
     z.object({
       purpose: z.enum(['PAYMENT', 'BUY_CASHAPP']),
     }),

--- a/app/features/user/guest-account-storage.ts
+++ b/app/features/user/guest-account-storage.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { safeJsonParse } from '~/lib/json';
 
 const storageKey = 'guestAccount';

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
-import type { z } from 'zod';
+import type { z } from 'zod/mini';
 import { normalizeMintUrl } from '~/lib/cashu';
 import type { Currency } from '~/lib/money';
 import type { Account, RedactedAccount } from '../accounts/account';

--- a/app/lib/cashu/mint-validation.ts
+++ b/app/lib/cashu/mint-validation.ts
@@ -1,5 +1,5 @@
 import type { MintInfo, MintKeyset, WebSocketSupport } from '@cashu/cashu-ts';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import {
   CASHU_PROTOCOL_UNITS,
   type CashuProtocolUnit,
@@ -21,7 +21,7 @@ export const MintBlocklistSchema = z.array(
   z.object({
     mintUrl: z.url(),
     /** If null, the entire mint is blocked */
-    unit: z.enum(CASHU_PROTOCOL_UNITS).nullable(),
+    unit: z.nullable(z.enum(CASHU_PROTOCOL_UNITS)),
   }),
 );
 

--- a/app/lib/cashu/types.ts
+++ b/app/lib/cashu/types.ts
@@ -1,19 +1,19 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import { nullToUndefined } from '../zod';
 
 const SerializedDLEQSchema = z.object({
   s: z.string(),
   e: z.string(),
-  r: z.string().optional(),
+  r: z.optional(z.string()),
 });
 
 const P2PKWitnessSchema = z.object({
-  signatures: z.array(z.string()).optional(),
+  signatures: z.optional(z.array(z.string())),
 });
 
 const HTLCWitnessSchema = z.object({
   preimage: z.string(),
-  signatures: z.array(z.string()).optional(),
+  signatures: z.optional(z.array(z.string())),
 });
 
 const WitnessSchema = z.union([
@@ -36,9 +36,9 @@ export const ProofSchema = z.object({
   /** The unblinded signature for this secret, signed by the mints private key. */
   C: z.string(),
   /** DLEQ proof. */
-  dleq: nullToUndefined(SerializedDLEQSchema.optional()).optional(),
+  dleq: z.optional(nullToUndefined(z.optional(SerializedDLEQSchema))),
   /** Witness for P2PK or HTLC spending conditions. */
-  witness: nullToUndefined(WitnessSchema.optional()).optional(),
+  witness: z.optional(nullToUndefined(z.optional(WitnessSchema))),
 });
 
 /**

--- a/app/lib/zod.ts
+++ b/app/lib/zod.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/mini';
 
 /**
  * Converts null values to undefined before passing the value to schema.
@@ -8,8 +8,8 @@ import { z } from 'zod';
  * @param schema - The schema to do the preprocessing for.
  * @returns The schema with preprocessing null to undefined.
  */
-export const nullToUndefined = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess<z.infer<T> | undefined, T, z.infer<T> | null>(
-    (v) => (v === null ? undefined : v),
-    schema,
+export const nullToUndefined = <T extends z.ZodMiniType>(schema: T) =>
+  z.pipe(
+    z.transform((v: unknown): unknown => (v === null ? undefined : v)),
+    schema as z.ZodMiniType<z.infer<T>, unknown>,
   );

--- a/app/routes/_protected.tsx
+++ b/app/routes/_protected.tsx
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { Outlet, redirect } from 'react-router';
-import { ZodError } from 'zod';
+import { core } from 'zod/mini';
 import { AccountsCache } from '~/features/accounts/account-hooks';
 import { AccountRepository } from '~/features/accounts/account-repository';
 import { agicashDbClient } from '~/features/agicash-db/database.client';
@@ -137,7 +137,7 @@ const ensureUserData = async (
           giftCardMintTermsAcceptedAt,
         }),
       retry: (attemptIndex, error) => {
-        if (error instanceof ZodError) {
+        if (error instanceof core.$ZodError) {
           return false;
         }
         return attemptIndex < 2;

--- a/app/routes/api.events.ts
+++ b/app/routes/api.events.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { hmac } from '@noble/hashes/hmac';
 import { sha256 } from '@noble/hashes/sha2';
 import { bytesToHex } from '@noble/hashes/utils';
-import { z } from 'zod';
+import { z } from 'zod/mini';
 import type { AgicashDbUser } from '~/features/agicash-db/database';
 import { sendWelcomeEmail } from '~/features/email/welcome-email-service';
 import { safeJsonParse } from '~/lib/json';
@@ -13,9 +13,9 @@ const MAX_SIGNATURE_AGE_SECONDS = 300;
 // -- Schemas --
 
 const userDataSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().nullable(),
-}) satisfies z.ZodType<Pick<AgicashDbUser, 'id' | 'email'>>;
+  id: z.uuid(),
+  email: z.nullable(z.string()),
+}) satisfies z.ZodMiniType<Pick<AgicashDbUser, 'id' | 'email'>>;
 
 const eventSchema = z.intersection(
   z.object({
@@ -34,9 +34,11 @@ const eventSchema = z.intersection(
     // the whole parse rather than falling through here as `data: unknown`.
     z
       .object({ type: z.string(), data: z.unknown() })
-      .refine((v) => v.type !== 'user.email_verified', {
-        message: 'known event type with invalid data',
-      }),
+      .check(
+        z.refine((v) => v.type !== 'user.email_verified', {
+          message: 'known event type with invalid data',
+        }),
+      ),
   ]),
 );
 


### PR DESCRIPTION
Migrates all schema files from `zod` to the tree-shakable `zod/mini` API. Background and discussion in #733.

## Summary
- 51 files, +265/−229. No dependency change — `zod/mini` ships inside the `zod` package.
- Method chaining → standalone functions: `.optional()` → `z.optional()`, `.transform()` → `z.pipe(s, z.transform())`, `.refine()` → `.check(z.refine())`, `.extend()`/`.and()` → `z.extend()`/`z.intersection()`.

## Bundle impact (measured)

Built `master` vs this branch, client JS, gzipped per-file then summed:

| | master | zod/mini | delta |
|---|---|---|---|
| gzipped JS | 880.1 KiB | 865.2 KiB | **−14.9 KiB (−1.7%)** |
| raw JS | 2,709.5 KiB | 2,653.0 KiB | −56.5 KiB |

So: ~14.9 KiB gzipped off every page load.

## Worth merging?

@gudnuf @jbojcic1  — this is the concrete tradeoff for #733: 14.9 KiB gzipped saved for a one-time mechanical migration. The functional API is more verbose (`z.optional(z.array(z.string()))` vs `.array(z.string()).optional()`, `.transform()` needs a `z.pipe()` wrapper), but the diff isn't dramatic — mostly the transaction-details parsers. Merge it, or close #733 as not-worth-it?

## Test plan
- [x] `tsc` passes
- [x] biome passes
- [x] 133/133 unit tests pass