### PR TITLE
fix(auth): only redirect on document navigations to avoid trapping users without cookies

### DIFF
--- a/app/features/user/require-session-hint.server.ts
+++ b/app/features/user/require-session-hint.server.ts
@@ -11,6 +11,18 @@ import { sessionHintCookie } from './session-hint-cookie';
  * constraint](https://reactrouter.com/api/framework-conventions/route-module#splitting-route-modules).
  */
 export const requireSessionHintOrRedirect = (request: Request): void => {
+  // Only redirect on top-level document navigations (typed URL, refresh,
+  // link from an external page). Client-side navigations within the SPA
+  // come in as single-fetch data requests, and the existing
+  // clientMiddleware validates the JWT against localStorage on those — so
+  // letting them pass here is correct and also prevents trapping users
+  // whose cookies don't persist (e.g. cookies disabled, evicted from
+  // storage, manually cleared). Sec-Fetch-Mode is sent by all modern
+  // browsers; if it's absent we treat the request as non-navigation to
+  // avoid trapping older browsers in a redirect loop.
+  if (request.headers.get('Sec-Fetch-Mode') !== 'navigate') {
+    return;
+  }
   if (sessionHintCookie.isPresent(request.headers.get('Cookie'))) {
     return;
   }


### PR DESCRIPTION
## What this fixes

The server-side redirect from #1082 has a regression: any user whose `agi_session_hint` cookie isn't present gets bounced to `/home` on **every** in-app navigation, not just document loads. That traps users who are really logged in but have no cookie — e.g.:

- Cookies disabled in the browser
- Cookie cleared manually (DevTools, browser settings, privacy tools)
- Cookie evicted under storage pressure
- Users who were already logged in before #1082 shipped (no cookie yet)

Their JWT is sitting in localStorage. `clientMiddleware` would happily validate it and let them in — but they never get there, because every `<Link>` click runs the server loader first, which 302s them to `/home` before the client middleware can do its job. Clicking "Go to Wallet" appears to do nothing. They can't reach the wallet.

## How it's fixed

Gate the redirect on `Sec-Fetch-Mode === 'navigate'` so only top-level document navigations are intercepted:

```ts
if (request.headers.get('Sec-Fetch-Mode') !== 'navigate') {
  return;
}
```

`Sec-Fetch-Mode` is sent by all modern browsers (Chrome 76+, Firefox 90+, Safari 16.4+):

- **`navigate`** — typing a URL, refresh, opening a bookmark, clicking an external link
- **`cors` / `same-origin`** — `fetch()` calls, including React Router's single-fetch that powers SPA navigation

We only want to redirect the first kind. SPA navigations should fall through and let the existing `clientMiddleware` do its JWT check.

If the header is absent (ancient browser), we treat it as non-navigation — falling back to the pre-#1082 behavior (LoadingScreen flash, client redirects). Safer than trapping.

## Behavior matrix

| Scenario | Before this PR | After this PR |
|---|---|---|
| Fresh user types `/` | 302 to `/home`, no flicker | Same ✓ |
| Logged-in user types `/` (cookie present) | Wallet renders | Same ✓ |
| Logged-in user with no cookie types `/` | 302 to `/home`, then `authQueryOptions` restores cookie, click "Go to Wallet" → wallet | Same ✓ |
| **Logged-in user with no cookie clicks `<Link to="/send">` from `/home`** | **302 loops, never reaches `/send`** | **Single-fetch passes through, client middleware lets them in ✓** |
| **Signed up with cookies disabled** | **Silently bounced back to `/home`, app appears broken** | **SPA nav after signup works, wallet renders ✓** |

## Why we still want the cookie at all

The cookie isn't authoritative — it's a hint that lets the server make a fast 302 on the common unauthenticated path (someone clicks the marketing site and lands on `/`) without ever rendering the SSR loading shell. That's the original optimization, and it still works:

- No cookie + document navigation → 302 to `/home`, no flicker
- Cookie present + document navigation → render shell, client takes over

The Sec-Fetch-Mode gate just adds: *and don't redirect SPA navigations, because those have a client there to make the real decision.*

## Test plan

- [ ] Fresh visit to `/` while logged out → 302 to `/home`, no LoadingScreen flash
- [ ] Fresh visit to `/send` while logged out → 302 to `/home?redirectTo=/send`
- [ ] Logged-in user, reload `/` → wallet renders, no flicker
- [ ] Logged-in user, delete `agi_session_hint` cookie in DevTools, navigate to `/` → bounces through `/home` once, cookie is restored, subsequent visits work
- [ ] Disable cookies in browser settings, sign up → after signup, SPA navigates to `/`, wallet renders
- [ ] Disable cookies in browser settings, refresh `/` → bounces to `/home` (acceptable), click any link → SPA works
- [ ] No regression in OAuth callback `#access_token=...` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)