### PR TITLE
feat(realtime): broadcast wallet.users updates to user's private channel

### DIFF
--- a/app/features/receive/claim-cashu-token-service.ts
+++ b/app/features/receive/claim-cashu-token-service.ts
@@ -9,7 +9,7 @@ import type { AccountRepository } from '../accounts/account-repository';
 import { AccountService } from '../accounts/account-service';
 import { DomainError } from '../shared/error';
 import type { User } from '../user/user';
-import { userQueryKey } from '../user/user-hooks';
+import { UserCache } from '../user/user-hooks';
 import type { UserService } from '../user/user-service';
 import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
 import type { CashuReceiveSwap } from './cashu-receive-swap';
@@ -135,7 +135,7 @@ export class ClaimCashuTokenService {
       // when home page loads might not show the correct currency.
       const result = await this.trySetDefaultAccount(user, receiveAccount);
       if (result.success) {
-        this.queryClient.setQueryData([userQueryKey], result.user);
+        this.queryClient.setQueryData([UserCache.Key], result.user);
       }
     }
 

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -5,12 +5,13 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { getQueryClient } from '~/features/shared/query-client';
 import { useAuthActions, useAuthState } from '~/features/user/auth';
 import type { Currency } from '~/lib/money';
 import { useLatest } from '~/lib/use-latest';
 import type { Account } from '../accounts/account';
+import type { AgicashDbUser } from '../agicash-db/database';
 import { guestAccountStorage } from './guest-account-storage';
 import type { User } from './user';
 import {
@@ -22,6 +23,43 @@ import {
 import { useUserService } from './user-service';
 
 export const userQueryKey = 'user';
+
+export class UserCache {
+  public static Key = userQueryKey;
+
+  constructor(private readonly queryClient: QueryClient) {}
+
+  set(user: User) {
+    this.queryClient.setQueryData([UserCache.Key], user);
+  }
+
+  get() {
+    return this.queryClient.getQueryData<User>([UserCache.Key]);
+  }
+
+  invalidate() {
+    return this.queryClient.invalidateQueries({ queryKey: [UserCache.Key] });
+  }
+}
+
+export function useUserCache() {
+  const queryClient = useQueryClient();
+  return useMemo(() => new UserCache(queryClient), [queryClient]);
+}
+
+export function useUserChangeHandlers() {
+  const userRepository = useReadUserRepository();
+  const userCache = useUserCache();
+
+  return [
+    {
+      event: 'USER_UPDATED',
+      handleEvent: async (payload: AgicashDbUser) => {
+        userCache.set(userRepository.toUser(payload));
+      },
+    },
+  ];
+}
 
 export const getUserFromCache = (
   queryClient: QueryClient = getQueryClient(),

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -22,10 +22,8 @@ import {
 } from './user-repository';
 import { useUserService } from './user-service';
 
-export const userQueryKey = 'user';
-
 export class UserCache {
-  public static Key = userQueryKey;
+  public static Key = 'user';
 
   constructor(private readonly queryClient: QueryClient) {}
 
@@ -64,7 +62,7 @@ export function useUserChangeHandlers() {
 export const getUserFromCache = (
   queryClient: QueryClient = getQueryClient(),
 ) => {
-  return queryClient.getQueryData<User>([userQueryKey]) ?? null;
+  return queryClient.getQueryData<User>([UserCache.Key]) ?? null;
 };
 
 export const getUserFromCacheOrThrow = () => {
@@ -84,7 +82,7 @@ const userQueryOptions = <TData = User>({
   userRepository: ReadUserRepository;
   select?: (data: User) => TData;
 }) => ({
-  queryKey: [userQueryKey],
+  queryKey: [UserCache.Key],
   queryFn: () => userRepository.get(userId),
   select,
 });
@@ -241,7 +239,7 @@ const useUpdateUser = () => {
   return useMutation({
     mutationFn: (updates: UpdateUser) => userRepository.update(userId, updates),
     onSuccess: (data) => {
-      queryClient.setQueryData([userQueryKey], data);
+      queryClient.setQueryData([UserCache.Key], data);
     },
   });
 };
@@ -264,7 +262,7 @@ export const useSetDefaultAccount = () => {
     mutationFn: (account: Account) =>
       userService.setDefaultAccount(user.current, account),
     onSuccess: (data) => {
-      queryClient.setQueryData([userQueryKey], data);
+      queryClient.setQueryData([UserCache.Key], data);
     },
   });
 

--- a/app/features/user/user-hooks.tsx
+++ b/app/features/user/user-hooks.tsx
@@ -15,7 +15,7 @@ import type { AgicashDbUser } from '../agicash-db/database';
 import { guestAccountStorage } from './guest-account-storage';
 import type { User } from './user';
 import {
-  type ReadUserRepository,
+  ReadUserRepository,
   type UpdateUser,
   useReadUserRepository,
   useWriteUserRepository,
@@ -46,14 +46,13 @@ export function useUserCache() {
 }
 
 export function useUserChangeHandlers() {
-  const userRepository = useReadUserRepository();
   const userCache = useUserCache();
 
   return [
     {
       event: 'USER_UPDATED',
       handleEvent: async (payload: AgicashDbUser) => {
-        userCache.set(userRepository.toUser(payload));
+        userCache.set(ReadUserRepository.toUser(payload));
       },
     },
   ];

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -387,6 +387,10 @@ export class ReadUserRepository {
 
     return data ? toUser(data) : null;
   }
+
+  toUser(dbUser: AgicashDbUser): User {
+    return toUser(dbUser);
+  }
 }
 
 export function useReadUserRepository() {

--- a/app/features/user/user-repository.ts
+++ b/app/features/user/user-repository.ts
@@ -55,35 +55,6 @@ type AccountInput = {
   | 'state'
 >;
 
-/**
- * Maps a database user row to a user object.
- * @param dbUser - The database user row.
- * @returns The user object.
- */
-function toUser(dbUser: AgicashDbUser): User {
-  const commonData = {
-    id: dbUser.id,
-    username: dbUser.username,
-    emailVerified: dbUser.email_verified,
-    createdAt: dbUser.created_at,
-    updatedAt: dbUser.updated_at,
-    cashuLockingXpub: dbUser.cashu_locking_xpub,
-    encryptionPublicKey: dbUser.encryption_public_key,
-    sparkIdentityPublicKey: dbUser.spark_identity_public_key,
-    defaultBtcAccountId: dbUser.default_btc_account_id ?? '',
-    defaultUsdAccountId: dbUser.default_usd_account_id,
-    defaultCurrency: dbUser.default_currency,
-    termsAcceptedAt: dbUser.terms_accepted_at,
-    giftCardMintTermsAcceptedAt: dbUser.gift_card_mint_terms_accepted_at,
-  };
-
-  if (dbUser.email) {
-    return { ...commonData, email: dbUser.email, isGuest: false };
-  }
-
-  return { ...commonData, isGuest: true };
-}
-
 export class WriteUserRepository {
   constructor(
     private readonly db: AgicashDb,
@@ -127,7 +98,7 @@ export class WriteUserRepository {
       throw new Error('Failed to update user', { cause: error });
     }
 
-    return toUser(updatedUser);
+    return ReadUserRepository.toUser(updatedUser);
   }
 
   /**
@@ -224,7 +195,7 @@ export class WriteUserRepository {
 
     const { accounts, user: upsertedUser } = data;
     return {
-      user: toUser(upsertedUser),
+      user: ReadUserRepository.toUser(upsertedUser),
       accounts: await Promise.all(
         accounts.map((account) => this.accountRepository.toAccount(account)),
       ),
@@ -366,7 +337,7 @@ export class ReadUserRepository {
       throw new Error('Failed to get user', { cause: error });
     }
 
-    return toUser(data);
+    return ReadUserRepository.toUser(data);
   }
 
   async getByUsername(
@@ -385,11 +356,31 @@ export class ReadUserRepository {
       throw new Error('Failed to get user by username', { cause: error });
     }
 
-    return data ? toUser(data) : null;
+    return data ? ReadUserRepository.toUser(data) : null;
   }
 
-  toUser(dbUser: AgicashDbUser): User {
-    return toUser(dbUser);
+  static toUser(dbUser: AgicashDbUser): User {
+    const commonData = {
+      id: dbUser.id,
+      username: dbUser.username,
+      emailVerified: dbUser.email_verified,
+      createdAt: dbUser.created_at,
+      updatedAt: dbUser.updated_at,
+      cashuLockingXpub: dbUser.cashu_locking_xpub,
+      encryptionPublicKey: dbUser.encryption_public_key,
+      sparkIdentityPublicKey: dbUser.spark_identity_public_key,
+      defaultBtcAccountId: dbUser.default_btc_account_id ?? '',
+      defaultUsdAccountId: dbUser.default_usd_account_id,
+      defaultCurrency: dbUser.default_currency,
+      termsAcceptedAt: dbUser.terms_accepted_at,
+      giftCardMintTermsAcceptedAt: dbUser.gift_card_mint_terms_accepted_at,
+    };
+
+    if (dbUser.email) {
+      return { ...commonData, email: dbUser.email, isGuest: false };
+    }
+
+    return { ...commonData, isGuest: true };
   }
 }
 

--- a/app/features/wallet/use-track-wallet-changes.ts
+++ b/app/features/wallet/use-track-wallet-changes.ts
@@ -40,7 +40,11 @@ import {
   useTransactionChangeHandlers,
   useTransactionsCache,
 } from '../transactions/transaction-hooks';
-import { useUser } from '../user/user-hooks';
+import {
+  useUser,
+  useUserCache,
+  useUserChangeHandlers,
+} from '../user/user-hooks';
 
 type DatabaseChangeHandler = {
   event: string;
@@ -95,6 +99,7 @@ export const useTrackWalletChanges = () => {
   const contactChangeHandlers = useContactChangeHandlers();
   const sparkReceiveQuoteChangeHandlers = useSparkReceiveQuoteChangeHandlers();
   const sparkSendQuoteChangeHandlers = useSparkSendQuoteChangeHandlers();
+  const userChangeHandlers = useUserChangeHandlers();
 
   const accountsCache = useAccountsCache();
   const transactionsCache = useTransactionsCache();
@@ -108,6 +113,7 @@ export const useTrackWalletChanges = () => {
   const sparkReceiveQuoteCache = useSparkReceiveQuoteCache();
   const pendingSparkReceiveQuotesCache = usePendingSparkReceiveQuotesCache();
   const unresolvedSparkSendQuotesCache = useUnresolvedSparkSendQuotesCache();
+  const userCache = useUserCache();
 
   useTrackDatabaseChanges({
     handlers: [
@@ -120,6 +126,7 @@ export const useTrackWalletChanges = () => {
       ...contactChangeHandlers,
       ...sparkReceiveQuoteChangeHandlers,
       ...sparkSendQuoteChangeHandlers,
+      ...userChangeHandlers,
     ],
     onConnected: () => {
       // Makes sure that data is refetched to get the latest updates from the database.
@@ -137,6 +144,7 @@ export const useTrackWalletChanges = () => {
       sparkReceiveQuoteCache.invalidate();
       pendingSparkReceiveQuotesCache.invalidate();
       unresolvedSparkSendQuotesCache.invalidate();
+      userCache.invalidate();
     },
   });
 };

--- a/app/routes/_protected.tsx
+++ b/app/routes/_protected.tsx
@@ -33,9 +33,9 @@ import {
 import { requireSessionHintOrRedirect } from '~/features/user/require-session-hint.server';
 import { type User, shouldAcceptTerms } from '~/features/user/user';
 import {
+  UserCache,
   defaultAccounts,
   getUserFromCache,
-  userQueryKey,
 } from '~/features/user/user-hooks';
 import { WriteUserRepository } from '~/features/user/user-repository';
 import { Wallet } from '~/features/wallet/wallet';
@@ -144,7 +144,7 @@ const ensureUserData = async (
       },
     });
     user = upsertedUser;
-    queryClient.setQueryData([userQueryKey], user);
+    queryClient.setQueryData([UserCache.Key], user);
     queryClient.setQueryData([AccountsCache.Key], accounts);
   }
 

--- a/supabase/migrations/20260522185431_add_users_broadcast_trigger.sql
+++ b/supabase/migrations/20260522185431_add_users_broadcast_trigger.sql
@@ -1,0 +1,23 @@
+-- broadcast wallet.users updates through the user's private realtime channel
+--
+-- topic uses new.id because wallet.users has no user_id column —
+-- the user is the row itself. existing side-table broadcasts use
+-- 'wallet:' || new.user_id::text, which would be wrong here.
+create or replace function "wallet"."broadcast_users_changes"()
+returns "trigger"
+language plpgsql
+security invoker
+set search_path = ''
+as $function$
+begin
+  perform realtime.send(
+    to_jsonb(new),
+    'USER_UPDATED',
+    'wallet:' || new.id::text,
+    true
+  );
+  return null;
+end;
+$function$;
+
+create constraint trigger "broadcast_users_changes_trigger" after update on "wallet"."users" deferrable initially deferred for each row execute function "wallet"."broadcast_users_changes"();


### PR DESCRIPTION
Closes #391.

## What

Enable Supabase realtime updates for the logged-in user's row. After this change, edits to `wallet.users` (default account, default currency, username, ToS flags) propagate to all open tabs / devices without a manual reload.

## How

1. **Migration** — new `wallet.broadcast_users_changes` function + `after update` constraint trigger on `wallet.users`. Emits `USER_UPDATED` with `to_jsonb(new)` on topic `wallet:${userId}`. Mirrors `broadcast_accounts_changes` (init migration L3575–3606); UPDATE-only because user INSERT happens once at signup and is followed by an SSR reload — there is no listener to broadcast to.
2. **`UserCache` + `useUserChangeHandlers`** — parity with `AccountsCache` / `useAccountChangeHandlers`, adapted for single-object semantics (one row, not a list). `ReadUserRepository.toUser` is promoted to a public method so the handler can convert payload → `User` the same way `AccountRepository.toAccount` does.
3. **Wire-in** — `useTrackWalletChanges` imports the new hooks, spreads the handlers, and invalidates `userCache` on `onConnected` alongside the other caches.

Topic uses `new.id` (not `new.user_id` like the side-table triggers) because `wallet.users` has no `user_id` column — the user *is* the row. The 4-line migration header calls this out so it doesn't read as a typo.

Full row payload (including `cashu_locking_xpub`, `encryption_public_key`, `spark_identity_public_key`) — these never change at runtime and the client already has them, but filtering would diverge from every other broadcast trigger.

## Test Plan (manual)

1. Apply the migration locally (Supabase dashboard or `bun supabase migration up`).
2. `bun run db:generate-types` to refresh types.
3. `bun run dev`, log in as the same user in two browser tabs (or two devices).
4. In tab A: change default currency / username / default account via the settings UI.
5. In tab B: confirm the UI reflects the update without manual reload.
6. Inspect the realtime debug log to confirm event is `USER_UPDATED` on topic `wallet:${userId}`, full row in payload, `is_private: true`.

## Notes

- No automated tests — no broadcast trigger in the repo has unit tests today; verification is the manual flow above.
- No RLS changes needed: the existing `realtime.messages` policies on `wallet:${userId}` topics (init migration L3555–3573) already cover this.