### PR TITLE
fix(og): use Vercel deployment URL for absolute metadata URLs

### DIFF
--- a/app/lib/canonical-origin.server.ts
+++ b/app/lib/canonical-origin.server.ts
@@ -1,0 +1,28 @@
+function getProductionDeploymentUrl(): string | undefined {
+  const host = process.env.VERCEL_PROJECT_PRODUCTION_URL;
+  return host ? `https://${host}` : undefined;
+}
+
+function getPreviewDeploymentUrl(): string | undefined {
+  const host = process.env.VERCEL_BRANCH_URL ?? process.env.VERCEL_URL;
+  return host ? `https://${host}` : undefined;
+}
+
+/**
+ * Origin for absolute URLs that external services must fetch (OG/Twitter
+ * images, `og:url`). Prefers Vercel's deployment URL over the request origin
+ * because at build-time prerender (`/home`, `/terms`) react-router uses
+ * `http://localhost`, which gets frozen into the static HTML and is
+ * unreachable by crawlers. Precedence mirrors Next.js's metadataBase fallback.
+ * @see https://github.com/vercel/next.js/pull/65089
+ * @param requestOrigin used outside Vercel (local dev / non-Vercel SSR).
+ */
+export function getCanonicalOrigin(requestOrigin: string): string {
+  if (process.env.VERCEL_ENV === 'preview') {
+    return getPreviewDeploymentUrl() ?? requestOrigin;
+  }
+  if (process.env.VERCEL_ENV === 'production') {
+    return getProductionDeploymentUrl() ?? requestOrigin;
+  }
+  return requestOrigin;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,6 +29,7 @@ import { ThemeProvider, useTheme } from '~/features/theme';
 import { getBgColorForTheme } from '~/features/theme/colors';
 import { getThemeCookies } from '~/features/theme/theme-cookies.server';
 import { getThemeScript } from '~/features/theme/theme-script';
+import { getCanonicalOrigin } from '~/lib/canonical-origin.server';
 import { WebAssemblyUnavailableError } from '~/lib/spark';
 import { SupabaseRealtimeError } from '~/lib/supabase/supabase-realtime-hooks';
 import { transitionStyles, useViewTransitionEffect } from '~/lib/transitions';
@@ -91,18 +92,17 @@ export async function loader({ request }: Route.LoaderArgs) {
     cookieSettings: cookieSettings || null,
     userAgentString: userAgentString || '',
     origin: url.origin,
+    canonicalOrigin: getCanonicalOrigin(url.origin),
     domain: url.host,
   };
 }
 
 export const meta = ({ loaderData }: Route.MetaArgs) => {
-  const { origin } = loaderData || {};
+  const canonicalOrigin = loaderData?.canonicalOrigin ?? 'https://agi.cash';
 
   const title = 'Agicash';
   const description = 'The easiest way to send and receive cash.';
-  const image = origin
-    ? `${origin}/og/agicash-card.webp`
-    : '/og/agicash-card.webp';
+  const image = `${canonicalOrigin}/og/agicash-card.webp`;
   const imageWidth = '900';
   const imageHeight = '473';
   const imageType = 'image/webp';
@@ -137,7 +137,7 @@ export const meta = ({ loaderData }: Route.MetaArgs) => {
       content: imageType,
     },
     { property: 'og:type', content: 'website' },
-    { property: 'og:url', content: origin },
+    { property: 'og:url', content: canonicalOrigin },
     { property: 'og:site_name', content: ogSiteName },
 
     // Twitter Card meta tags

--- a/app/routes/_public.receive-cashu-token.tsx
+++ b/app/routes/_public.receive-cashu-token.tsx
@@ -46,9 +46,10 @@ export function meta({ location, matches }: Route.MetaArgs): MetaDescriptor[] {
   const preview = mintUrl ? resolveSharePreview(mintUrl) : undefined;
   if (!preview) return rootMatch?.meta ?? [];
 
-  const origin =
-    (rootMatch?.data as { origin?: string } | undefined)?.origin ?? '';
-  const imageUrl = `${origin}${preview.ogImage}`;
+  const canonicalOrigin =
+    (rootMatch?.data as { canonicalOrigin?: string } | undefined)
+      ?.canonicalOrigin ?? 'https://agi.cash';
+  const imageUrl = `${canonicalOrigin}${preview.ogImage}`;
   const { title, description } = preview;
 
   return [


### PR DESCRIPTION
## Summary

Link previews (Discord/Twitter) for `https://agi.cash/` broke recently: the title and description rendered but the image showed "Image failed to load."

**Root cause:** `https://agi.cash/` 302-redirects to `/home`, which is **prerendered**. At build-time prerender, react-router constructs requests with origin `http://localhost`, so the `meta` function baked `og:image` / `twitter:image` / `og:url` as `http://localhost/...` into the static HTML — unreachable by crawlers. The image file itself was always served fine (`200 image/webp`).

This surfaced around May 21: Vercel previously had a bug (react-router#14281) where prerendered routes fell through to runtime SSR — at runtime `url.origin` is the real `https://agi.cash`, masking the issue. Once Vercel started serving the prerendered HTML as true static files (and #1091 removed the related workaround), the baked `http://localhost` is what crawlers receive.

## Changes

- **`app/lib/canonical-origin.server.ts`** (new): `getCanonicalOrigin(requestOrigin)` resolves a reachable origin from Vercel's system env vars, mirroring Next.js's `metadataBase` precedence ([vercel/next.js#65089](https://github.com/vercel/next.js/pull/65089)):
  - production → `VERCEL_PROJECT_PRODUCTION_URL`
  - preview → `VERCEL_BRANCH_URL ?? VERCEL_URL`
  - else (local dev / non-Vercel) → the request origin
- **`app/root.tsx`**: loader returns `canonicalOrigin`; `meta` uses it for `og:image`, `twitter:image`, `og:url`. Falls back to `https://agi.cash` if loader data is absent (error-boundary render) so the URL is always absolute.
- **`app/routes/_public.receive-cashu-token.tsx`**: per-gift-card/offer OG image uses `canonicalOrigin` too.

The request `origin`/`domain` from the root loader are intentionally left as-is — in-app share links and Lightning Address generation must reflect the **actual serving host**, not the production canonical, for preview/local self-consistency.

## Test plan

- [x] `bun run typecheck` and `biome` pass
- [ ] After deploy, confirm **"Enable access to System Environment Variables"** is checked in the Vercel project
- [ ] Verify the deployed `/home` HTML `og:image` resolves to the real domain (not `http://localhost`)
- [ ] Validate via the [X](https://cards-dev.twitter.com/validator) / [Facebook](https://developers.facebook.com/tools/debug/) link preview tools

> [!NOTE]
> No unit tests — per convention OG meta is verified via the social link-preview validators.