### PR TITLE
 derive origin/domain from the deployment URL, not the request

### DIFF
--- a/app/lib/canonical-origin.server.ts
+++ b/app/lib/canonical-origin.server.ts
@@ -9,13 +9,16 @@ function getPreviewDeploymentUrl(): string | undefined {
 }
 
 /**
- * Origin for absolute URLs that external services must fetch (OG/Twitter
- * images, `og:url`). Prefers Vercel's deployment URL over the request origin
- * because at build-time prerender (`/home`, `/terms`) react-router uses
- * `http://localhost`, which gets frozen into the static HTML and is
- * unreachable by crawlers. Precedence mirrors Next.js's metadataBase fallback.
+ * The site's reachable origin, for absolute URLs that leave the app — OG/Twitter
+ * images, shared token links, profile URLs, `username@domain` Lightning
+ * Addresses. On Vercel it returns the production domain (or the branch/deploy
+ * URL on preview); elsewhere it falls back to the request origin. We avoid the
+ * request origin because at build-time prerender (`/home`, `/terms`) react-router
+ * uses `http://localhost`, which is frozen into the static HTML and — since the
+ * root loader never revalidates — served for the whole session. Precedence
+ * mirrors Next.js's metadataBase fallback.
  * @see https://github.com/vercel/next.js/pull/65089
- * @param requestOrigin used outside Vercel (local dev / non-Vercel SSR).
+ * @param requestOrigin fallback used off Vercel (local dev / non-Vercel SSR).
  */
 export function getCanonicalOrigin(requestOrigin: string): string {
   if (process.env.VERCEL_ENV === 'preview') {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -87,22 +87,22 @@ export async function loader({ request }: Route.LoaderArgs) {
   const cookieSettings = getThemeCookies(request);
   const userAgentString = request.headers.get('user-agent');
   const url = new URL(request.url);
+  const origin = getCanonicalOrigin(url.origin);
 
   return {
     cookieSettings: cookieSettings || null,
     userAgentString: userAgentString || '',
-    origin: url.origin,
-    canonicalOrigin: getCanonicalOrigin(url.origin),
-    domain: url.host,
+    origin,
+    domain: new URL(origin).host,
   };
 }
 
 export const meta = ({ loaderData }: Route.MetaArgs) => {
-  const canonicalOrigin = loaderData?.canonicalOrigin ?? 'https://agi.cash';
+  const origin = loaderData?.origin ?? 'https://agi.cash';
 
   const title = 'Agicash';
   const description = 'The easiest way to send and receive cash.';
-  const image = `${canonicalOrigin}/og/agicash-card.webp`;
+  const image = `${origin}/og/agicash-card.webp`;
   const imageWidth = '900';
   const imageHeight = '473';
   const imageType = 'image/webp';
@@ -137,7 +137,7 @@ export const meta = ({ loaderData }: Route.MetaArgs) => {
       content: imageType,
     },
     { property: 'og:type', content: 'website' },
-    { property: 'og:url', content: canonicalOrigin },
+    { property: 'og:url', content: origin },
     { property: 'og:site_name', content: ogSiteName },
 
     // Twitter Card meta tags

--- a/app/routes/_public.receive-cashu-token.tsx
+++ b/app/routes/_public.receive-cashu-token.tsx
@@ -46,10 +46,10 @@ export function meta({ location, matches }: Route.MetaArgs): MetaDescriptor[] {
   const preview = mintUrl ? resolveSharePreview(mintUrl) : undefined;
   if (!preview) return rootMatch?.meta ?? [];
 
-  const canonicalOrigin =
-    (rootMatch?.data as { canonicalOrigin?: string } | undefined)
-      ?.canonicalOrigin ?? 'https://agi.cash';
-  const imageUrl = `${canonicalOrigin}${preview.ogImage}`;
+  const origin =
+    (rootMatch?.data as { origin?: string } | undefined)?.origin ??
+    'https://agi.cash';
+  const imageUrl = `${origin}${preview.ogImage}`;
   const { title, description } = preview;
 
   return [


### PR DESCRIPTION
## Problem

Landing on a prerendered page first (`/` → `/home`) sets the root loader's `origin` to the build-time value `http://localhost`, and since the root loader never revalidates, that value sticks for the whole session — so shared token links, profile URLs, and `username@domain` Lightning Addresses all come out as `http://localhost/…`. Reloading straight onto a dynamic route fixes it, because then the loader runs at runtime with the real origin.

See in this video I started on /home and then the lightning address was `@localhost`, but then its fixed after refresh

https://github.com/user-attachments/assets/0d7a0319-4a31-4ef5-9526-3c196aafa6d9

## Fix

Resolve `origin` in the root loader through `getCanonicalOrigin` (Vercel's deployment URL, falling back to the request origin) and derive `domain` from it, so every consumer gets a reachable host regardless of entry path. This makes the separate `canonicalOrigin` field added in #1110 redundant, so the meta functions revert to reading `origin`.