### PR TITLE
fix(cashu): stop transient outputs-pending (11004) from crashing swap tasks

### DIFF
--- a/apps/web-wallet/app/features/receive/cashu-receive-swap-hooks.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-swap-hooks.ts
@@ -12,6 +12,7 @@ import {
   useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import type { AgicashDbCashuReceiveSwap } from '../agicash-db/database';
+import { ConcurrencyError } from '../shared/error';
 import { useUser } from '../user/user-hooks';
 import type { CashuReceiveSwap } from './cashu-receive-swap';
 import { useCashuReceiveSwapRepository } from './cashu-receive-swap-repository';
@@ -163,8 +164,13 @@ export function useProcessCashuReceiveSwapTasks() {
       const account = getCashuAccount(swap.accountId);
       await receiveSwapService.completeSwap(account, swap);
     },
-    retry: 3,
-    throwOnError: true,
+    retry: (failureCount, error) => {
+      if (error instanceof ConcurrencyError) {
+        return true;
+      }
+      return failureCount < 3;
+    },
+    throwOnError: (error) => !(error instanceof ConcurrencyError),
     onError: (error, tokenHash) => {
       console.error('Error finalizing receive swap', {
         cause: error,

--- a/apps/web-wallet/app/features/receive/cashu-receive-swap-service.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-swap-service.ts
@@ -9,11 +9,13 @@ import {
   CashuErrorCodes,
   areMintUrlsEqual,
   getCashuUnit,
+  isTransientCashuSwapError,
   sumProofs,
 } from '~/lib/cashu';
 import { Money } from '~/lib/money';
 import type { CashuAccount } from '../accounts/account';
 import { tokenToMoney } from '../shared/cashu';
+import { ConcurrencyError } from '../shared/error';
 import type { CashuReceiveSwap } from './cashu-receive-swap';
 import {
   type CashuReceiveSwapRepository,
@@ -244,6 +246,11 @@ export class CashuReceiveSwapService {
         // TODO: make sure these proofs are not already in our balance and that they are not spent
         return proofs;
       }
+
+      if (isTransientCashuSwapError(error)) {
+        throw new ConcurrencyError(error.message);
+      }
+
       throw error;
     }
   }

--- a/apps/web-wallet/app/features/send/cashu-send-swap-hooks.ts
+++ b/apps/web-wallet/app/features/send/cashu-send-swap-hooks.ts
@@ -411,8 +411,13 @@ export function useProcessCashuSendSwapTasks() {
         account,
       });
     },
-    retry: 3,
-    throwOnError: true,
+    retry: (failureCount, error) => {
+      if (error instanceof ConcurrencyError) {
+        return true;
+      }
+      return failureCount < 3;
+    },
+    throwOnError: (error) => !(error instanceof ConcurrencyError),
     onError: (error, swapId) => {
       console.error('Error swapping for proofs to send', {
         cause: error,

--- a/apps/web-wallet/app/features/send/cashu-send-swap-service.ts
+++ b/apps/web-wallet/app/features/send/cashu-send-swap-service.ts
@@ -12,6 +12,7 @@ import {
   type ExtendedCashuWallet,
   getCashuProtocolUnit,
   getCashuUnit,
+  isTransientCashuSwapError,
   sumProofs,
 } from '~/lib/cashu';
 import { Money } from '~/lib/money';
@@ -21,7 +22,7 @@ import {
 } from '../receive/cashu-receive-swap-service';
 import { getTokenHash } from '../shared/cashu';
 import { getDefaultUnit } from '../shared/currencies';
-import { DomainError } from '../shared/error';
+import { ConcurrencyError, DomainError } from '../shared/error';
 import type { CashuSendSwap } from './cashu-send-swap';
 import {
   type CashuSendSwapRepository,
@@ -455,6 +456,10 @@ export class CashuSendSwapService {
             ),
           ),
         };
+      }
+
+      if (isTransientCashuSwapError(error)) {
+        throw new ConcurrencyError(error.message);
       }
 
       throw error;

--- a/apps/web-wallet/app/lib/cashu/error-codes.test.ts
+++ b/apps/web-wallet/app/lib/cashu/error-codes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { MintOperationError } from '@cashu/cashu-ts';
+import { CashuErrorCodes, isTransientCashuSwapError } from './error-codes';
+
+const mintError = (code: CashuErrorCodes) =>
+  new MintOperationError(code, `mint error ${code}`);
+
+describe('isTransientCashuSwapError', () => {
+  test('treats OUTPUTS_ARE_PENDING (11004) as transient', () => {
+    expect(
+      isTransientCashuSwapError(mintError(CashuErrorCodes.OUTPUTS_ARE_PENDING)),
+    ).toBe(true);
+  });
+
+  test('treats PROOFS_ARE_PENDING (11002) as transient', () => {
+    expect(
+      isTransientCashuSwapError(mintError(CashuErrorCodes.PROOFS_ARE_PENDING)),
+    ).toBe(true);
+  });
+
+  test('does not treat OUTPUT_ALREADY_SIGNED (11003) as transient', () => {
+    expect(
+      isTransientCashuSwapError(
+        mintError(CashuErrorCodes.OUTPUT_ALREADY_SIGNED),
+      ),
+    ).toBe(false);
+  });
+
+  test('does not treat TOKEN_ALREADY_SPENT (11001) as transient', () => {
+    expect(
+      isTransientCashuSwapError(mintError(CashuErrorCodes.TOKEN_ALREADY_SPENT)),
+    ).toBe(false);
+  });
+
+  test('does not treat other mint operation errors as transient', () => {
+    expect(
+      isTransientCashuSwapError(
+        mintError(CashuErrorCodes.TRANSACTION_NOT_BALANCED),
+      ),
+    ).toBe(false);
+    expect(
+      isTransientCashuSwapError(mintError(CashuErrorCodes.KEYSET_INACTIVE)),
+    ).toBe(false);
+  });
+
+  test('does not treat non-mint errors as transient', () => {
+    expect(isTransientCashuSwapError(new Error('boom'))).toBe(false);
+    expect(isTransientCashuSwapError('outputs are pending')).toBe(false);
+    expect(isTransientCashuSwapError(undefined)).toBe(false);
+  });
+});

--- a/apps/web-wallet/app/lib/cashu/error-codes.ts
+++ b/apps/web-wallet/app/lib/cashu/error-codes.ts
@@ -1,3 +1,5 @@
+import { MintOperationError } from '@cashu/cashu-ts';
+
 /**
  * Based on https://github.com/cashubtc/nuts/blob/main/error_codes.md
  */
@@ -216,3 +218,18 @@ export enum CashuErrorCodes {
    */
   BAT_MINT_RATE_LIMIT_EXCEEDED = 31004,
 }
+
+/**
+ * Whether the error is a transient swap error returned by the mint: the outputs or
+ * input proofs are still in flight in a parallel operation (codes 11002 and 11004).
+ * The mint settles them on its own, so the swap should be retried rather than failed.
+ * @see https://github.com/cashubtc/nuts/blob/main/error_codes.md
+ */
+export const isTransientCashuSwapError = (
+  error: unknown,
+): error is MintOperationError =>
+  error instanceof MintOperationError &&
+  [
+    CashuErrorCodes.PROOFS_ARE_PENDING,
+    CashuErrorCodes.OUTPUTS_ARE_PENDING,
+  ].includes(error.code);


### PR DESCRIPTION
## Problem

Sentry [7512228812](https://make-prisms.sentry.io/issues/7512228812) — `MintOperationError: outputs are pending` (cashu error code **11004 `OUTPUTS_ARE_PENDING`**), recurring in production. It crashes the task-processing **lead** client to the root error boundary ("Oops, something went wrong / Reload Page").

Chain: the background `TaskProcessor` (rendered only on the lead client) runs the cashu send-swap task → `swapProofs` (`cashu-send-swap-service.ts`). Its catch recovers only `OUTPUT_ALREADY_SIGNED` (11003) and `TOKEN_ALREADY_SPENT` (11001) via `wallet.restore()`; **11004 is not in the allowlist, so it re-throws**. The mutation runs `retry: 3` + `throwOnError: true`, so once retries exhaust the error is thrown during render → root boundary + `Sentry.captureException`. (These send/receive flows have no explicit capture, so the Sentry Issue is the boundary firing.)

## Fix

`OUTPUTS_ARE_PENDING` (11004) and `PROOFS_ARE_PENDING` (11002) are **transient** — the mint is still processing the outputs/inputs in a parallel operation and resolves them on its own. They need retry-until-resolved, **not** `wallet.restore()` (the outputs aren't signed yet — distinct from the 11003 path).

Two layers, both leaning on the existing `ConcurrencyError` ("always retry") convention — **not** a new operation-level classifier (that stays out of scope):

1. **Classify at the swap boundary.** New `isTransientCashuSwapError` predicate (`app/lib/cashu/error-codes.ts`). Both swap services' `swapProofs` catch now map it → `throw new ConcurrencyError(error.message)`, after (and distinct from) the existing 11003/11001 `wallet.restore()` recovery.
2. **Stop the boundary escalation.** The send `swapForProofsToSend` and receive `completeSwap` task mutations go from `retry: 3` / `throwOnError: true` to a type-aware `retry` (`ConcurrencyError` → retry, mirroring `useCreateCashuSendSwap` in the same file) plus `throwOnError: (e) => !(e instanceof ConcurrencyError)`. Transient errors retry until the mint settles and never reach the boundary; the swap row stays `DRAFT` and self-heals on the next trigger cycle. Unexpected errors keep their existing loud-fail behavior.

## Reviewer notes

- **Scope: send AND receive.** `cashu-receive-swap-service` has the identical 11003/11001-only allowlist and its `completeSwap` hook the identical `retry: 3` / `throwOnError: true` → the same latent 11004 crash. Both are fixed for consistency.
- **Observability tradeoff.** Retrying `ConcurrencyError` indefinitely (matching `useCreateCashuSendSwap`) means a persistently-stuck pending state retries **silently** — the mutation never settles, so `onError` never fires and nothing escalates, leaving no alert (the very signal that surfaced this bug). If preferred, a follow-up can bound the retry and log on give-up. Flagging for a decision.
- **Test is predicate-level.** `error-codes.test.ts` locks the classification (11004/11002 transient; 11003/11001/others not). A full service/hook render test isn't feasible here: importing `CashuSendSwapService` under `bun test` throws `window is not defined` (the Supabase client + realtime manager touch `window` at module top-level), which is why every existing repo test exercises pure modules only. The throw-conversion and retry config are covered by `tsc` + the conventions they mirror.

## Verification

- `bun run fix:all` — clean
- `bun run typecheck` — clean
- `bun test` — 139 pass / 0 fail (incl. the new 6-case predicate test)

Draft for review (gudnuf approved a draft fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
