### PR TITLE
chore: temporarily disable email signup

### DIFF
--- a/app/features/signup/signup-options.tsx
+++ b/app/features/signup/signup-options.tsx
@@ -72,9 +72,10 @@ export function SignupOptions({ onSelect }: Props) {
       </CardHeader>
       <CardContent>
         <div className="grid gap-4">
-          <Button onClick={() => selectOption('email')}>
+          {/* TEMPORARILY DISABLED: email signup (revert to re-enable) */}
+          {/* <Button onClick={() => selectOption('email')}>
             Create wallet with Email
-          </Button>
+          </Button> */}
           <Button onClick={() => selectOption('google')}>
             Create wallet with Google
           </Button>


### PR DESCRIPTION
Temporary, revertable comment-out of the "Create wallet with Email" button in the signup options so new users cannot create an account via email.

- The email-signup button is commented out (not deleted) in `app/features/signup/signup-options.tsx` — the only entry point into the email-signup form. Google signup and guest signup are unchanged.
- Email **login** for existing users is unaffected (separate flow: `app/features/login/`, `_auth.login.tsx`, `signIn`/`osSignIn`).
- All signup form/handler code is left intact and dormant.

Revert this PR to re-enable email signup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)