### PR TITLE
wallet-sdk PR1: contract (types + interfaces)

### DIFF
--- a/packages/wallet-sdk/src/config.ts
+++ b/packages/wallet-sdk/src/config.ts
@@ -1,0 +1,25 @@
+/**
+ * SDK configuration — §1 of the contract.
+ *
+ * The SDK OWNS the Supabase client — the consumer never gets a handle, only
+ * provides these params (decision 1). `storage` is the pluggable adapter
+ * (web = browser, mcp = fs/sqlite). `clientId` is the leader-election instance id
+ * (auto-generated if omitted) — distinct from `openSecret.clientId`.
+ */
+import type { StorageAdapter } from './types/dependencies';
+
+export type SdkConfig = {
+  /** enclave/auth backend (VITE_OPEN_SECRET_API_URL + _CLIENT_ID) */
+  openSecret: { url: string; clientId: string };
+  /**
+   * db/realtime; schema pinned to 'wallet'; access token = the OpenSecret JWT
+   * (RLS-scoped). `serviceRoleKey` only if the SDK runs server-side.
+   */
+  supabase: { url: string; anonKey: string; serviceRoleKey?: string };
+  /** Spark/Breez SDK */
+  breezApiKey?: string;
+  /** @agicash/opensecret-sdk pluggable storage (web=browser, mcp=fs/sqlite) */
+  storage: StorageAdapter;
+  /** leader-election INSTANCE id (auto-generated if omitted) */
+  clientId?: string;
+};

--- a/packages/wallet-sdk/src/config.ts
+++ b/packages/wallet-sdk/src/config.ts
@@ -8,18 +8,39 @@
  */
 import type { StorageAdapter } from './types/dependencies';
 
+/**
+ * Configuration passed to {@link Sdk.create}. The consumer supplies connection
+ * params and a storage adapter; the SDK constructs and owns the underlying
+ * Supabase / OpenSecret / Breez clients (the consumer never gets a handle).
+ */
 export type SdkConfig = {
-  /** enclave/auth backend (VITE_OPEN_SECRET_API_URL + _CLIENT_ID) */
-  openSecret: { url: string; clientId: string };
+  /** OpenSecret enclave/auth backend (VITE_OPEN_SECRET_API_URL + _CLIENT_ID). */
+  openSecret: {
+    /** Base URL of the OpenSecret API. */
+    url: string;
+    /** OpenSecret client/app id. */
+    clientId: string;
+  };
   /**
-   * db/realtime; schema pinned to 'wallet'; access token = the OpenSecret JWT
-   * (RLS-scoped). `serviceRoleKey` only if the SDK runs server-side.
+   * Supabase DB + realtime connection. Schema is pinned to `wallet`; the access
+   * token used is the OpenSecret JWT (so reads/writes are RLS-scoped to the
+   * user). `serviceRoleKey` is only supplied when the SDK runs server-side.
    */
-  supabase: { url: string; anonKey: string; serviceRoleKey?: string };
-  /** Spark/Breez SDK */
+  supabase: {
+    /** Supabase project URL. */
+    url: string;
+    /** Supabase anon (public) key. */
+    anonKey: string;
+    /** Service-role key — server-side use only; omit in the browser. */
+    serviceRoleKey?: string;
+  };
+  /** API key for the Spark/Breez SDK (required for spark accounts). */
   breezApiKey?: string;
-  /** @agicash/opensecret-sdk pluggable storage (web=browser, mcp=fs/sqlite) */
+  /** Pluggable @agicash/opensecret-sdk storage (web = browser, mcp = fs/sqlite). */
   storage: StorageAdapter;
-  /** leader-election INSTANCE id (auto-generated if omitted) */
+  /**
+   * Leader-election INSTANCE id for background processing; auto-generated if
+   * omitted. Distinct from `openSecret.clientId`.
+   */
   clientId?: string;
 };

--- a/packages/wallet-sdk/src/domains.ts
+++ b/packages/wallet-sdk/src/domains.ts
@@ -26,35 +26,76 @@ import type { User } from './types/user';
 import type { BackgroundState } from './events';
 
 // --- §4 Auth + User --------------------------------------------------------
+
+/**
+ * Authentication and session management. The SDK holds the session/JWT
+ * internally and attaches it to Supabase/OpenSecret — no consumer reads the
+ * token. Sign-in/out also drive the `auth:*` events.
+ */
 export interface AuthDomain {
+  /** Sign in an existing user with email + password; resolves with the user. */
   signIn(params: { email: string; password: string }): Promise<User>;
+  /** Create a new full (email) account and sign it in. */
   signUp(params: { email: string; password: string }): Promise<User>;
+  /** Create and sign in an anonymous guest user. */
   signInGuest(): Promise<User>;
+  /** Sign out the current user and clear the session. */
   signOut(): Promise<void>;
+  /** Refresh the current session/access token (extends the session). */
   refresh(): Promise<void>;
+  /** Send a password-reset email to the given address. */
   resetPassword(email: string): Promise<void>;
+  /** Change the signed-in user's password (requires the current password). */
   changePassword(params: { current: string; new: string }): Promise<void>;
+  /** Upgrade the current guest user into a full email account, preserving funds/history. */
   upgradeGuest(params: { email: string; password: string }): Promise<User>;
-  // OAuth is a browser REDIRECT, not a synchronous session (web-only; MCP cannot Google-auth).
+  /**
+   * Begin Google OAuth. Returns the URL to redirect the browser to — OAuth is a
+   * REDIRECT flow, not a synchronous session. Web-only; the MCP daemon cannot do
+   * Google auth.
+   */
   beginGoogleSignIn(): Promise<{ authUrl: string }>;
+  /** Complete OAuth from the redirect callback params; resolves with the user. */
   completeOAuth(params: Record<string, unknown>): Promise<User>;
 }
 
+/** The current user and mutations on their profile. */
 export interface UserDomain {
+  /** The currently signed-in user, or null if none. */
   getCurrentUser(): Promise<User | null>;
-  /** throws DomainError if the username is taken */
+  /** Change the user's username. Throws `DomainError` if the username is taken. */
   updateUsername(username: string): Promise<User>;
 }
 
 // --- §2 Accounts -----------------------------------------------------------
+
+/**
+ * Wallet accounts. Per the two-mode API rule, `list`/`get` are fetches (by
+ * id/filter) and `add` creates, while `setDefault`/`getBalance` take the FULL
+ * account object the caller already holds (the SDK never re-reads it).
+ */
 export interface AccountsDomain {
-  list(): Promise<Account[]>; // fetch
-  get(id: string): Promise<Account | null>; // fetch
+  /** All of the user's accounts. */
+  list(): Promise<Account[]>;
+  /** The account with this id, or null if not found. */
+  get(id: string): Promise<Account | null>;
+  /** The default account, optionally for a specific currency (defaults are per-currency). */
   getDefault(params?: { currency?: Currency }): Promise<Account | null>;
-  add(config: AddAccountConfig): Promise<Account>; // create
-  setDefault(account: Account): Promise<void>; // FULL OBJECT; one default PER currency
-  getBalance(account: Account): Promise<Money>; // FULL OBJECT
-  /** PURE over passed-in accounts */
+  /** Create and persist a new account from the given config. */
+  add(config: AddAccountConfig): Promise<Account>;
+  /**
+   * Make `account` the default for its currency. Takes the full object. There is
+   * one default PER currency (BTC + USD), not a single global default.
+   */
+  setDefault(account: Account): Promise<void>;
+  /** Current balance of the given account (full object). */
+  getBalance(account: Account): Promise<Money>;
+  /**
+   * Recommend which of the passed-in `accounts` to use for `intent`. PURE over
+   * the accounts handed in (no DB read) — the web wallet feeds its cached
+   * accounts for an instant result. Cheap-first heuristic (gift-card-mint match
+   * + sufficient balance + default fallback); no cross-protocol cost comparison.
+   */
   suggestFor(
     intent: PaymentIntent,
     accounts: Account[],
@@ -62,81 +103,165 @@ export interface AccountsDomain {
 }
 
 // --- §3 Scan ---------------------------------------------------------------
+
+/** Destination parsing for scanned/pasted input. */
 export interface ScanDomain {
+  /**
+   * Classify a raw string into a {@link ParsedDestination} (bolt11 invoice,
+   * Lightning address, or cashu token). ln-address → invoice resolution is NOT
+   * done here — it happens inside `createLightningQuote`, where the amount is
+   * known. Account/gift-card matching is a separate `suggestFor` step.
+   */
   parse(input: string): Promise<ParsedDestination>;
 }
 
 // --- §5 Cashu --------------------------------------------------------------
+
+/** Cashu send operations: lightning sends, token sends, and reclaiming a pending token send. */
 export interface CashuSendOps {
-  // lightning-send -> CashuSendQuote. destination = bolt11 OR ln-address
-  // (an ln-address is resolved internally via LNURL-pay using the amount).
+  /**
+   * Create a LIGHTNING send quote. `destination` is a bolt11 invoice OR a
+   * Lightning address — an ln-address is resolved internally via LNURL-pay using
+   * the amount (no separate scan step). `amount` is required for amountless
+   * invoices / ln-addresses.
+   */
   createLightningQuote(params: {
     account: CashuAccount;
     destination: string;
     amount?: Money;
   }): Promise<CashuSendQuote>;
-  // token-send -> a SEPARATE CashuSendSwap
+  /**
+   * Create a TOKEN send — returns a separate {@link CashuSendSwap} (not a
+   * lightning quote). Spends/reserves proofs and prepares them to be encoded into
+   * a shareable token.
+   */
   createTokenQuote(params: {
     account: CashuAccount;
     amount: Money;
   }): Promise<CashuSendSwap>;
-  // executeQuote drives the LIGHTNING quote's state machine (FULL OBJECT);
-  // kicks off, resolves on transition; terminal arrives via event.
+  /**
+   * Execute a lightning send. This IS the orchestrator, not a thin kickoff: it
+   * contains the background state machine (task processing + mint melt-quote WS
+   * subscription) that drives UNPAID → PENDING → PAID, re-validating against the
+   * mint. Takes the full quote, resolves on KICK-OFF (returns the quote in its
+   * current state); the terminal state arrives via `send:completed`/`send:failed`
+   * or by polling `.get(quote.id)`.
+   */
   executeQuote(quote: CashuSendQuote): Promise<CashuSendQuote>;
+  /** Mark a send quote as failed with the given reason (full object). */
   failQuote(quote: CashuSendQuote, reason: string): Promise<void>;
-  // user-initiated reclaim of a PENDING token-send (decision 8); REVERSED lands DB-side.
-  reverse(swap: CashuSendSwap): Promise<CashuSendSwap>; // FULL OBJECT; gated PENDING
-  get(id: string): Promise<CashuSendQuote | CashuSendSwap | null>; // fetch
+  /**
+   * User-initiated reclaim of a PENDING token send: pulls `proofsToSend` back via
+   * a new cashu receive-swap tagged `reversedTransactionId`. Takes the full swap,
+   * gated to the PENDING state (there is no orchestrator auto-reverse); the swap
+   * lands REVERSED DB-side.
+   */
+  reverse(swap: CashuSendSwap): Promise<CashuSendSwap>;
+  /** Fetch a send quote or token-send swap by id, or null if not found. */
+  get(id: string): Promise<CashuSendQuote | CashuSendSwap | null>;
 }
 
+/** Cashu receive operations: claim a token, or create a lightning receive quote. */
 export interface CashuReceiveOps {
+  /**
+   * Claim a cashu token. By default it is received to the token's own mint; pass
+   * `destinationAccount` to receive cross-account — token → another cashu mint, or
+   * token → spark — which is done internally via melt-then-mint (hence the result
+   * may be a {@link SparkReceiveQuote}).
+   */
   receiveToken(params: {
     token: string;
-    // cross-account: token->cashu, or token->spark via melt-then-mint (internal)
     destinationAccount?: Account;
   }): Promise<CashuReceiveQuote | SparkReceiveQuote>;
+  /**
+   * Create a lightning receive quote (an invoice to be paid). `purpose` defaults
+   * to `'PAYMENT'`; `'BUY_CASHAPP'` is the buy-bitcoin / Cash App flow (pairs with
+   * the `cashAppDeepLink` helper).
+   */
   createLightningQuote(params: {
     account: CashuAccount;
     amount: Money;
     purpose?: 'PAYMENT' | 'BUY_CASHAPP';
   }): Promise<CashuReceiveQuote>;
+  /** Fetch a receive quote by id, or null if not found. */
   get(quoteId: string): Promise<CashuReceiveQuote | null>;
 }
 
+/**
+ * The cashu domain — ecash send/receive. Pending/unresolved enumeration is
+ * INTERNAL to the background processor (there is no public `listPending`);
+ * consumers observe in-flight state via `transactions` (PENDING) + events.
+ */
 export interface CashuDomain {
+  /** Send operations. */
   send: CashuSendOps;
+  /** Receive operations. */
   receive: CashuReceiveOps;
 }
 
 // --- §6 Spark --------------------------------------------------------------
+
+/** Spark (Breez) send operations. */
 export interface SparkSendOps {
+  /**
+   * Create a Spark lightning send quote. `destination` is a bolt11 invoice OR a
+   * Lightning address (resolved internally via LNURL-pay using the amount);
+   * `amount` is required for amountless invoices / ln-addresses.
+   */
   createLightningQuote(params: {
     account: SparkAccount;
     destination: string;
     amount?: Money;
   }): Promise<SparkSendQuote>;
-  executeQuote(quote: SparkSendQuote): Promise<SparkSendQuote>; // FULL OBJECT
+  /**
+   * Execute a Spark lightning send (full object). Calls Breez `sendPayment`,
+   * moving the quote UNPAID → PENDING; the terminal state arrives via the Breez
+   * callback (surfaced as `send:completed`/`send:failed`).
+   */
+  executeQuote(quote: SparkSendQuote): Promise<SparkSendQuote>;
+  /** Mark a send quote as failed with the given reason (full object). */
   failQuote(quote: SparkSendQuote, reason: string): Promise<void>;
+  /** Fetch a Spark send quote by id, or null if not found. */
   get(quoteId: string): Promise<SparkSendQuote | null>;
 }
 
+/** Spark (Breez) receive operations. */
 export interface SparkReceiveOps {
+  /**
+   * Create a Spark lightning receive quote (an invoice to be paid). `purpose`
+   * defaults to `'PAYMENT'`; `'BUY_CASHAPP'` is the buy-bitcoin / Cash App flow.
+   */
   createLightningQuote(params: {
     account: SparkAccount;
     amount: Money;
     description?: string;
     purpose?: 'PAYMENT' | 'BUY_CASHAPP';
   }): Promise<SparkReceiveQuote>;
+  /** Fetch a Spark receive quote by id, or null if not found. */
   get(quoteId: string): Promise<SparkReceiveQuote | null>;
 }
 
+/**
+ * The spark domain — Spark/Breez lightning send/receive. Spark balance is
+ * sourced from the Breez SDK's own event listener (not a DB trigger); this
+ * domain owns that source and emits `account:updated` with compare-before-emit.
+ */
 export interface SparkDomain {
+  /** Send operations. */
   send: SparkSendOps;
+  /** Receive operations. */
   receive: SparkReceiveOps;
 }
 
 // --- §7 Transactions -------------------------------------------------------
+
+/** Transaction history: cursor-paginated reads plus user acknowledgement. */
 export interface TransactionsDomain {
+  /**
+   * List transactions, newest-relevant first (state-sorted: PENDING first).
+   * Optionally filter by `accountId`, page with `cursor`, and size with
+   * `pageSize`. Returns the page plus a `nextCursor` (null when exhausted).
+   */
   list(params?: {
     accountId?: string;
     cursor?: TransactionCursor;
@@ -145,32 +270,65 @@ export interface TransactionsDomain {
     transactions: Transaction[];
     nextCursor: TransactionCursor | null;
   }>;
+  /** Fetch a single transaction by id, or null if not found. */
   get(id: string): Promise<Transaction | null>;
+  /** Count transactions whose `acknowledgmentStatus` is `pending` (e.g. for a badge). */
   countPendingAck(): Promise<number>;
-  acknowledge(transaction: Transaction): Promise<void>; // FULL OBJECT
+  /** Mark a transaction as acknowledged by the user (full object). */
+  acknowledge(transaction: Transaction): Promise<void>;
 }
 
 // --- §8 Contacts -----------------------------------------------------------
+
+/**
+ * Saved contacts. Contacts are CREATE/DELETE only (no `version` column), so the
+ * consumer dedupes/orders by op-type + refetch; `add`/`remove` drive the
+ * `contact:created`/`contact:deleted` events.
+ */
 export interface ContactsDomain {
+  /** All of the user's saved contacts. */
   list(): Promise<Contact[]>;
+  /** Fetch a saved contact by id, or null if not found. */
   get(id: string): Promise<Contact | null>;
+  /** Add a contact by username; resolves with the created {@link Contact}. */
   add(params: { username: string }): Promise<Contact>;
-  remove(contact: Contact): Promise<void>; // FULL OBJECT
-  /** min 3 chars, excludes existing */
+  /** Remove a saved contact (full object). */
+  remove(contact: Contact): Promise<void>;
+  /**
+   * Search addable user profiles by query (minimum 3 characters); excludes the
+   * user's existing contacts from the results.
+   */
   search(params: { query: string }): Promise<UserProfile[]>;
 }
 
 // --- §9 Transfers ----------------------------------------------------------
+
+/**
+ * Cross-account transfers (cashu↔spark via Lightning). A transfer is executed as
+ * a paired send + receive (TWO transactions linked by `transferId`); there are
+ * no aggregate `transfer:*` events — the consumer reconstructs status from each
+ * transaction's own events. Receive auto-fails if the send fails.
+ */
 export interface TransfersDomain {
+  /**
+   * Quote a cross-account transfer: returns an ephemeral {@link TransferQuote}
+   * (cost preview, not persisted). Naming mirrors cashu/spark.
+   */
   createQuote(params: {
     sourceAccount: Account;
     destinationAccount: Account;
     amount: Money;
   }): Promise<TransferQuote>;
-  executeQuote(quote: TransferQuote): Promise<TransferResult>; // FULL OBJECT
+  /**
+   * Execute a previously-created transfer quote (full object); resolves with the
+   * ids of the two resulting transactions and their shared `transferId`.
+   */
+  executeQuote(quote: TransferQuote): Promise<TransferResult>;
 }
 
 // --- ExchangeRate (multi-provider domain; §12 notes it is exported) --------
+
+/** Fiat/BTC exchange-rate conversion (multi-provider). */
 export interface ExchangeRateDomain {
   /**
    * Convert `amount` into `to` currency at the current rate.
@@ -181,8 +339,18 @@ export interface ExchangeRateDomain {
 }
 
 // --- §10 Background --------------------------------------------------------
+
+/**
+ * Background processing lifecycle. Leader election is an internal DB-row lock
+ * (`wallet.task_processing_locks` + `take_lead` RPC, 5s poll) shared across
+ * tabs/devices/processes; only the leader runs the orchestrators (which read the
+ * DB as needed). State transitions are surfaced via `background:state`.
+ */
 export interface BackgroundDomain {
+  /** Begin lead-polling and run the orchestrators while this instance is leader. */
   start(): Promise<void>;
+  /** Pause processing, letting in-flight operations finish (does not close connections). */
   stop(): Promise<void>;
+  /** The current background-processing lifecycle state (synchronous). */
   state(): BackgroundState;
 }

--- a/packages/wallet-sdk/src/domains.ts
+++ b/packages/wallet-sdk/src/domains.ts
@@ -1,0 +1,180 @@
+/**
+ * Domain interfaces — §2-§10 of the contract. DECLARATIONS ONLY (no impl).
+ *
+ * Two-mode API rule (Josip 6/01): user-invoked methods take FULL OBJECTS; the
+ * exceptions are `get(id)` / `list(filter)` (fetch) and `create*` / `add`
+ * (params + the full account). Reactivity is events-only; all methods return
+ * Promises.
+ */
+import type {
+  Account,
+  CashuAccount,
+  SparkAccount,
+} from './types/account';
+import type { AccountSuggestion, AddAccountConfig } from './types/account-config';
+import type {
+  CashuReceiveQuote,
+  CashuSendQuote,
+  CashuSendSwap,
+} from './types/cashu';
+import type { Contact, UserProfile } from './types/contact';
+import type { Currency, Money } from './types/money';
+import type { ParsedDestination, PaymentIntent } from './types/scan';
+import type { SparkReceiveQuote, SparkSendQuote } from './types/spark';
+import type { Transaction, TransactionCursor } from './types/transaction';
+import type { TransferQuote, TransferResult } from './types/transfer';
+import type { User } from './types/user';
+import type { BackgroundState } from './events';
+
+// --- §4 Auth + User --------------------------------------------------------
+export interface AuthDomain {
+  signIn(params: { email: string; password: string }): Promise<User>;
+  signUp(params: { email: string; password: string }): Promise<User>;
+  signInGuest(): Promise<User>;
+  signOut(): Promise<void>;
+  refresh(): Promise<void>;
+  resetPassword(email: string): Promise<void>;
+  changePassword(params: { current: string; new: string }): Promise<void>;
+  upgradeGuest(params: { email: string; password: string }): Promise<User>;
+  // OAuth is a browser REDIRECT, not a synchronous session (web-only; MCP cannot Google-auth).
+  beginGoogleSignIn(): Promise<{ authUrl: string }>;
+  completeOAuth(params: Record<string, unknown>): Promise<User>;
+}
+
+export interface UserDomain {
+  getCurrentUser(): Promise<User | null>;
+  /** throws DomainError if the username is taken */
+  updateUsername(username: string): Promise<User>;
+}
+
+// --- §2 Accounts -----------------------------------------------------------
+export interface AccountsDomain {
+  list(): Promise<Account[]>; // fetch
+  get(id: string): Promise<Account | null>; // fetch
+  getDefault(params?: { currency?: Currency }): Promise<Account | null>;
+  add(config: AddAccountConfig): Promise<Account>; // create
+  setDefault(account: Account): Promise<void>; // FULL OBJECT; one default PER currency
+  getBalance(account: Account): Promise<Money>; // FULL OBJECT
+  /** PURE over passed-in accounts */
+  suggestFor(intent: PaymentIntent, accounts: Account[]): Promise<AccountSuggestion>;
+}
+
+// --- §3 Scan ---------------------------------------------------------------
+export interface ScanDomain {
+  parse(input: string): Promise<ParsedDestination>;
+}
+
+// --- §5 Cashu --------------------------------------------------------------
+export interface CashuSendOps {
+  // lightning-send -> CashuSendQuote. destination = bolt11 OR ln-address
+  // (an ln-address is resolved internally via LNURL-pay using the amount).
+  createLightningQuote(params: {
+    account: CashuAccount;
+    destination: string;
+    amount?: Money;
+  }): Promise<CashuSendQuote>;
+  // token-send -> a SEPARATE CashuSendSwap
+  createTokenQuote(params: { account: CashuAccount; amount: Money }): Promise<CashuSendSwap>;
+  // executeQuote drives the LIGHTNING quote's state machine (FULL OBJECT);
+  // kicks off, resolves on transition; terminal arrives via event.
+  executeQuote(quote: CashuSendQuote): Promise<CashuSendQuote>;
+  failQuote(quote: CashuSendQuote, reason: string): Promise<void>;
+  // user-initiated reclaim of a PENDING token-send (decision 8); REVERSED lands DB-side.
+  reverse(swap: CashuSendSwap): Promise<CashuSendSwap>; // FULL OBJECT; gated PENDING
+  get(id: string): Promise<CashuSendQuote | CashuSendSwap | null>; // fetch
+}
+
+export interface CashuReceiveOps {
+  receiveToken(params: {
+    token: string;
+    // cross-account: token->cashu, or token->spark via melt-then-mint (internal)
+    destinationAccount?: Account;
+  }): Promise<CashuReceiveQuote | SparkReceiveQuote>;
+  createLightningQuote(params: {
+    account: CashuAccount;
+    amount: Money;
+    purpose?: 'PAYMENT' | 'BUY_CASHAPP';
+  }): Promise<CashuReceiveQuote>;
+  get(quoteId: string): Promise<CashuReceiveQuote | null>;
+}
+
+export interface CashuDomain {
+  send: CashuSendOps;
+  receive: CashuReceiveOps;
+}
+
+// --- §6 Spark --------------------------------------------------------------
+export interface SparkSendOps {
+  createLightningQuote(params: {
+    account: SparkAccount;
+    destination: string;
+    amount?: Money;
+  }): Promise<SparkSendQuote>;
+  executeQuote(quote: SparkSendQuote): Promise<SparkSendQuote>; // FULL OBJECT
+  failQuote(quote: SparkSendQuote, reason: string): Promise<void>;
+  get(quoteId: string): Promise<SparkSendQuote | null>;
+}
+
+export interface SparkReceiveOps {
+  createLightningQuote(params: {
+    account: SparkAccount;
+    amount: Money;
+    description?: string;
+    purpose?: 'PAYMENT' | 'BUY_CASHAPP';
+  }): Promise<SparkReceiveQuote>;
+  get(quoteId: string): Promise<SparkReceiveQuote | null>;
+}
+
+export interface SparkDomain {
+  send: SparkSendOps;
+  receive: SparkReceiveOps;
+}
+
+// --- §7 Transactions -------------------------------------------------------
+export interface TransactionsDomain {
+  list(params?: {
+    accountId?: string;
+    cursor?: TransactionCursor;
+    pageSize?: number;
+  }): Promise<{ transactions: Transaction[]; nextCursor: TransactionCursor | null }>;
+  get(id: string): Promise<Transaction | null>;
+  countPendingAck(): Promise<number>;
+  acknowledge(transaction: Transaction): Promise<void>; // FULL OBJECT
+}
+
+// --- §8 Contacts -----------------------------------------------------------
+export interface ContactsDomain {
+  list(): Promise<Contact[]>;
+  get(id: string): Promise<Contact | null>;
+  add(params: { username: string }): Promise<Contact>;
+  remove(contact: Contact): Promise<void>; // FULL OBJECT
+  /** min 3 chars, excludes existing */
+  search(params: { query: string }): Promise<UserProfile[]>;
+}
+
+// --- §9 Transfers ----------------------------------------------------------
+export interface TransfersDomain {
+  createQuote(params: {
+    sourceAccount: Account;
+    destinationAccount: Account;
+    amount: Money;
+  }): Promise<TransferQuote>;
+  executeQuote(quote: TransferQuote): Promise<TransferResult>; // FULL OBJECT
+}
+
+// --- ExchangeRate (multi-provider domain; §12 notes it is exported) --------
+export interface ExchangeRateDomain {
+  /**
+   * Convert `amount` into `to` currency at the current rate.
+   * TODO(post-PR1): ground the method surface against
+   * `app/lib/exchange-rate/**` when the domain is implemented.
+   */
+  convert(params: { amount: Money; to: Currency }): Promise<Money>;
+}
+
+// --- §10 Background --------------------------------------------------------
+export interface BackgroundDomain {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  state(): BackgroundState;
+}

--- a/packages/wallet-sdk/src/domains.ts
+++ b/packages/wallet-sdk/src/domains.ts
@@ -6,12 +6,11 @@
  * (params + the full account). Reactivity is events-only; all methods return
  * Promises.
  */
+import type { Account, CashuAccount, SparkAccount } from './types/account';
 import type {
-  Account,
-  CashuAccount,
-  SparkAccount,
-} from './types/account';
-import type { AccountSuggestion, AddAccountConfig } from './types/account-config';
+  AccountSuggestion,
+  AddAccountConfig,
+} from './types/account-config';
 import type {
   CashuReceiveQuote,
   CashuSendQuote,
@@ -56,7 +55,10 @@ export interface AccountsDomain {
   setDefault(account: Account): Promise<void>; // FULL OBJECT; one default PER currency
   getBalance(account: Account): Promise<Money>; // FULL OBJECT
   /** PURE over passed-in accounts */
-  suggestFor(intent: PaymentIntent, accounts: Account[]): Promise<AccountSuggestion>;
+  suggestFor(
+    intent: PaymentIntent,
+    accounts: Account[],
+  ): Promise<AccountSuggestion>;
 }
 
 // --- §3 Scan ---------------------------------------------------------------
@@ -74,7 +76,10 @@ export interface CashuSendOps {
     amount?: Money;
   }): Promise<CashuSendQuote>;
   // token-send -> a SEPARATE CashuSendSwap
-  createTokenQuote(params: { account: CashuAccount; amount: Money }): Promise<CashuSendSwap>;
+  createTokenQuote(params: {
+    account: CashuAccount;
+    amount: Money;
+  }): Promise<CashuSendSwap>;
   // executeQuote drives the LIGHTNING quote's state machine (FULL OBJECT);
   // kicks off, resolves on transition; terminal arrives via event.
   executeQuote(quote: CashuSendQuote): Promise<CashuSendQuote>;
@@ -136,7 +141,10 @@ export interface TransactionsDomain {
     accountId?: string;
     cursor?: TransactionCursor;
     pageSize?: number;
-  }): Promise<{ transactions: Transaction[]; nextCursor: TransactionCursor | null }>;
+  }): Promise<{
+    transactions: Transaction[];
+    nextCursor: TransactionCursor | null;
+  }>;
   get(id: string): Promise<Transaction | null>;
   countPendingAck(): Promise<number>;
   acknowledge(transaction: Transaction): Promise<void>; // FULL OBJECT

--- a/packages/wallet-sdk/src/errors.ts
+++ b/packages/wallet-sdk/src/errors.ts
@@ -1,0 +1,27 @@
+/**
+ * SDK error classes — §12 of the contract.
+ *
+ * `SdkError` (base + `readonly code`) is NET-NEW (master's errors have no shared
+ * base / no `code`). `ConcurrencyError` / `DomainError` / `NotFoundError` are
+ * re-parented onto `SdkError` (master forms live in `app/features/shared/error.ts`).
+ * PR1 ships the class SHAPES only — empty bodies, no logic.
+ */
+
+export class SdkError extends Error {
+  readonly code: string;
+
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = new.target.name;
+    this.code = code;
+  }
+}
+
+/** transient/stale; caller (or orchestrator) refetches + retries. */
+export class ConcurrencyError extends SdkError {}
+
+/** user-facing message; never retry. */
+export class DomainError extends SdkError {}
+
+/** entity not found. */
+export class NotFoundError extends SdkError {}

--- a/packages/wallet-sdk/src/errors.ts
+++ b/packages/wallet-sdk/src/errors.ts
@@ -7,7 +7,16 @@
  * PR1 ships the class SHAPES only — empty bodies, no logic.
  */
 
+/**
+ * Base class for every error the SDK throws. Net-new in the SDK (master's errors
+ * have no shared base / no `code`). Carries a machine-readable `code` alongside
+ * the human `message`, and sets `name` to the concrete subclass name so
+ * `instanceof` and logged names agree. Subclasses signal how the caller should
+ * react (retry vs surface vs treat-as-missing); the `executeQuote` orchestrator
+ * and web hooks both map a `classify()` verdict onto these subtypes.
+ */
 export class SdkError extends Error {
+  /** Stable, machine-readable error code (e.g. a cashu/protocol code). */
   readonly code: string;
 
   constructor(message: string, code: string) {
@@ -17,11 +26,11 @@ export class SdkError extends Error {
   }
 }
 
-/** transient/stale; caller (or orchestrator) refetches + retries. */
+/** Transient/stale state (e.g. an optimistic-lock conflict); the caller (or orchestrator) refetches + retries. */
 export class ConcurrencyError extends SdkError {}
 
-/** user-facing message; never retry. */
+/** A definitive, user-facing failure; the message is safe to show and the caller must never retry. */
 export class DomainError extends SdkError {}
 
-/** entity not found. */
+/** The requested entity does not exist. */
 export class NotFoundError extends SdkError {}

--- a/packages/wallet-sdk/src/events.ts
+++ b/packages/wallet-sdk/src/events.ts
@@ -12,6 +12,11 @@ import type { Transaction } from './types/transaction';
 import type { User } from './types/user';
 import type { SdkError } from './errors';
 
+/**
+ * Lifecycle state of the background processor (see {@link BackgroundDomain}).
+ * Reflects whether it is running and whether this instance currently holds the
+ * leader lock: `stopped` → `starting` → `follower`/`leader` → `stopping`.
+ */
 export type BackgroundState =
   | 'stopped'
   | 'starting'
@@ -19,30 +24,44 @@ export type BackgroundState =
   | 'leader'
   | 'stopping';
 
+/**
+ * The full set of events the SDK emits, keyed by event name, mapping to that
+ * event's payload type. This is the SDK's ONLY reactivity surface — consumers
+ * subscribe via {@link EventEmitter} (the web wallet feeds its own read-model
+ * from these) rather than polling. Naming is flat with the `protocol` carried in
+ * the payload; create vs update is encoded in the event NAME (not a payload
+ * flag), and payloads carry the entity `version` for ordering.
+ */
 export type SdkEventMap = {
+  /** A send moved to PENDING (initiated, awaiting settlement). */
   'send:pending': {
     quoteId: string;
     transactionId: string;
     protocol: 'cashu' | 'spark';
   };
+  /** A send settled successfully; `amount` is the amount sent. */
   'send:completed': {
     quoteId: string;
     transactionId: string;
     amount: Money;
     protocol: 'cashu' | 'spark';
   };
+  /** A send failed terminally; `error` carries the classified reason. */
   'send:failed': {
     quoteId: string;
     error: SdkError;
     protocol: 'cashu' | 'spark';
   };
+  /** A receive completed; funds are credited and `amount` is the amount received. */
   'receive:completed': {
     quoteId: string;
     transactionId: string;
     amount: Money;
     protocol: 'cashu' | 'spark';
   };
+  /** A receive quote expired before it was paid. */
   'receive:expired': { quoteId: string; protocol: 'cashu' | 'spark' };
+  /** A receive failed terminally; `error` carries the classified reason. */
   'receive:failed': {
     quoteId: string;
     error: SdkError;
@@ -50,18 +69,40 @@ export type SdkEventMap = {
   };
   // NO transfer:* events (decision 5): a transfer is TWO transactions (debit + credit),
   // reconstructed consumer-side from the two transaction:* events, linked by `transferId`.
+  /** An account was created or updated; `op` distinguishes which. */
   'account:updated': { account: Account; op: 'created' | 'updated' };
+  /** A new transaction appeared in history. */
   'transaction:created': { transaction: Transaction };
+  /** An existing transaction changed state (apply by `transaction.version`). */
   'transaction:updated': { transaction: Transaction };
+  /** A contact was added. */
   'contact:created': { contact: Contact };
+  /** A contact was removed; only its id is carried. */
   'contact:deleted': { contactId: string };
+  /** The user signed in (or a guest/full session became active). */
   'auth:signed-in': { user: User };
+  /** The user signed out. */
   'auth:signed-out': Record<string, never>;
+  /** The session expired and could not be refreshed; the consumer must re-auth. */
   'auth:session-expired': Record<string, never>;
+  /** The background processor changed lifecycle state. */
   'background:state': { state: BackgroundState };
 };
 
+/**
+ * A read-only, type-safe event subscription surface over an event map `M`.
+ * Handlers receive the payload typed to the subscribed event; both methods
+ * return an unsubscribe function. The SDK exposes one as `sdk.events`.
+ */
 export interface EventEmitter<M> {
+  /**
+   * Subscribe to `event`; `handler` is called on every emission.
+   * @returns an unsubscribe function.
+   */
   on<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
+  /**
+   * Subscribe to `event` for a single emission, then auto-unsubscribe.
+   * @returns an unsubscribe function (to cancel before it fires).
+   */
   once<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
 }

--- a/packages/wallet-sdk/src/events.ts
+++ b/packages/wallet-sdk/src/events.ts
@@ -20,14 +20,22 @@ export type BackgroundState =
   | 'stopping';
 
 export type SdkEventMap = {
-  'send:pending': { quoteId: string; transactionId: string; protocol: 'cashu' | 'spark' };
+  'send:pending': {
+    quoteId: string;
+    transactionId: string;
+    protocol: 'cashu' | 'spark';
+  };
   'send:completed': {
     quoteId: string;
     transactionId: string;
     amount: Money;
     protocol: 'cashu' | 'spark';
   };
-  'send:failed': { quoteId: string; error: SdkError; protocol: 'cashu' | 'spark' };
+  'send:failed': {
+    quoteId: string;
+    error: SdkError;
+    protocol: 'cashu' | 'spark';
+  };
   'receive:completed': {
     quoteId: string;
     transactionId: string;
@@ -35,7 +43,11 @@ export type SdkEventMap = {
     protocol: 'cashu' | 'spark';
   };
   'receive:expired': { quoteId: string; protocol: 'cashu' | 'spark' };
-  'receive:failed': { quoteId: string; error: SdkError; protocol: 'cashu' | 'spark' };
+  'receive:failed': {
+    quoteId: string;
+    error: SdkError;
+    protocol: 'cashu' | 'spark';
+  };
   // NO transfer:* events (decision 5): a transfer is TWO transactions (debit + credit),
   // reconstructed consumer-side from the two transaction:* events, linked by `transferId`.
   'account:updated': { account: Account; op: 'created' | 'updated' };

--- a/packages/wallet-sdk/src/events.ts
+++ b/packages/wallet-sdk/src/events.ts
@@ -1,0 +1,55 @@
+/**
+ * Event layer — §11 of the contract. FULLY NET-NEW (no master EventEmitter).
+ *
+ * PR1 ships the `SdkEventMap` keys + the `EventEmitter<M>` INTERFACE (declaration
+ * only — no implementation). `BackgroundState` is defined here (used by
+ * `background:state` and `BackgroundDomain.state()`).
+ */
+import type { Account } from './types/account';
+import type { Contact } from './types/contact';
+import type { Money } from './types/money';
+import type { Transaction } from './types/transaction';
+import type { User } from './types/user';
+import type { SdkError } from './errors';
+
+export type BackgroundState =
+  | 'stopped'
+  | 'starting'
+  | 'follower'
+  | 'leader'
+  | 'stopping';
+
+export type SdkEventMap = {
+  'send:pending': { quoteId: string; transactionId: string; protocol: 'cashu' | 'spark' };
+  'send:completed': {
+    quoteId: string;
+    transactionId: string;
+    amount: Money;
+    protocol: 'cashu' | 'spark';
+  };
+  'send:failed': { quoteId: string; error: SdkError; protocol: 'cashu' | 'spark' };
+  'receive:completed': {
+    quoteId: string;
+    transactionId: string;
+    amount: Money;
+    protocol: 'cashu' | 'spark';
+  };
+  'receive:expired': { quoteId: string; protocol: 'cashu' | 'spark' };
+  'receive:failed': { quoteId: string; error: SdkError; protocol: 'cashu' | 'spark' };
+  // NO transfer:* events (decision 5): a transfer is TWO transactions (debit + credit),
+  // reconstructed consumer-side from the two transaction:* events, linked by `transferId`.
+  'account:updated': { account: Account; op: 'created' | 'updated' };
+  'transaction:created': { transaction: Transaction };
+  'transaction:updated': { transaction: Transaction };
+  'contact:created': { contact: Contact };
+  'contact:deleted': { contactId: string };
+  'auth:signed-in': { user: User };
+  'auth:signed-out': Record<string, never>;
+  'auth:session-expired': Record<string, never>;
+  'background:state': { state: BackgroundState };
+};
+
+export interface EventEmitter<M> {
+  on<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
+  once<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
+}

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -1,1 +1,121 @@
-// @agicash/wallet-sdk
+/**
+ * @agicash/wallet-sdk — public contract (PR1: types + interfaces, no impl).
+ *
+ * This barrel is the package's single public entry (`exports["."]`). It re-exports
+ * the public domain TYPES + domain INTERFACES + the `Sdk` class shape + `SdkConfig`
+ * + the event layer + the error classes. No implementation lands in PR1.
+ */
+
+// --- entry point + config --------------------------------------------------
+export type { Sdk } from './sdk';
+export type { SdkConfig } from './config';
+
+// --- value types -----------------------------------------------------------
+// `Money` is a TYPE-ONLY export in PR1 (it is a placeholder `declare class` with
+// no runtime binding — see ./types/money). Slice 0 replaces it with a real
+// re-export of `app/lib/money`'s `Money`, at which point this becomes a value export.
+export type { Money } from './types/money';
+export type { Currency, CurrencyUnit, BtcUnit, UsdUnit } from './types/money';
+
+// --- domain interfaces -----------------------------------------------------
+export type {
+  AuthDomain,
+  UserDomain,
+  AccountsDomain,
+  ScanDomain,
+  CashuDomain,
+  CashuSendOps,
+  CashuReceiveOps,
+  SparkDomain,
+  SparkSendOps,
+  SparkReceiveOps,
+  TransactionsDomain,
+  ContactsDomain,
+  TransfersDomain,
+  ExchangeRateDomain,
+  BackgroundDomain,
+} from './domains';
+
+// --- events ----------------------------------------------------------------
+export type { EventEmitter, SdkEventMap, BackgroundState } from './events';
+
+// --- errors (real classes — values, not just types) ------------------------
+export { SdkError, ConcurrencyError, DomainError, NotFoundError } from './errors';
+
+// --- accounts (§2) ---------------------------------------------------------
+export type {
+  Account,
+  AccountType,
+  AccountState,
+  AccountPurpose,
+  CashuProof,
+  ExtendedAccount,
+  CashuAccount,
+  SparkAccount,
+  ExtendedCashuAccount,
+  ExtendedSparkAccount,
+  RedactedAccount,
+  RedactedCashuAccount,
+} from './types/account';
+export type { AddAccountConfig, AccountSuggestion } from './types/account-config';
+
+// --- scan (§3) -------------------------------------------------------------
+export type { ParsedDestination, PaymentIntent } from './types/scan';
+
+// --- user (§4) -------------------------------------------------------------
+export type { User, FullUser, GuestUser } from './types/user';
+
+// --- cashu (§5) ------------------------------------------------------------
+export type {
+  CashuSendQuote,
+  CashuSendSwap,
+  PendingCashuSendSwap,
+  CashuReceiveQuote,
+  CashuTokenMeltData,
+  DestinationDetails,
+} from './types/cashu';
+
+// --- spark (§6) ------------------------------------------------------------
+export type { SparkSendQuote, SparkReceiveQuote } from './types/spark';
+
+// --- transactions (§7) -----------------------------------------------------
+export type {
+  Transaction,
+  BaseTransaction,
+  TransactionCursor,
+  TransactionDirection,
+  TransactionType,
+  TransactionState,
+  TransactionPurpose,
+} from './types/transaction';
+export type {
+  TransactionDetails,
+  CashuTokenSendTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
+  CashuLightningSendTransactionDetails,
+  IncompleteCashuLightningSendTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  CashuLightningReceiveTransactionDetails,
+  SparkLightningSendTransactionDetails,
+  IncompleteSparkLightningSendTransactionDetails,
+  CompletedSparkLightningSendTransactionDetails,
+  SparkLightningReceiveTransactionDetails,
+  IncompleteSparkLightningReceiveTransactionDetails,
+  CompletedSparkLightningReceiveTransactionDetails,
+} from './types/transaction-details';
+
+// --- contacts (§8) ---------------------------------------------------------
+export type { Contact, UserProfile } from './types/contact';
+
+// --- transfers (§9) --------------------------------------------------------
+export type { TransferQuote, TransferLeg, TransferResult } from './types/transfer';
+
+// --- type-dependency placeholders (PR1) ------------------------------------
+// Re-exported so consumers/contract reviewers can see the deferred seams.
+// Each is wired to its real source in a later slice — see ./dependencies.
+export type {
+  StorageAdapter,
+  Bolt11Invoice,
+  ParsedToken,
+  SparkNetwork,
+} from './types/dependencies';

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -40,7 +40,12 @@ export type {
 export type { EventEmitter, SdkEventMap, BackgroundState } from './events';
 
 // --- errors (real classes — values, not just types) ------------------------
-export { SdkError, ConcurrencyError, DomainError, NotFoundError } from './errors';
+export {
+  SdkError,
+  ConcurrencyError,
+  DomainError,
+  NotFoundError,
+} from './errors';
 
 // --- accounts (§2) ---------------------------------------------------------
 export type {
@@ -57,7 +62,10 @@ export type {
   RedactedAccount,
   RedactedCashuAccount,
 } from './types/account';
-export type { AddAccountConfig, AccountSuggestion } from './types/account-config';
+export type {
+  AddAccountConfig,
+  AccountSuggestion,
+} from './types/account-config';
 
 // --- scan (§3) -------------------------------------------------------------
 export type { ParsedDestination, PaymentIntent } from './types/scan';
@@ -108,7 +116,11 @@ export type {
 export type { Contact, UserProfile } from './types/contact';
 
 // --- transfers (§9) --------------------------------------------------------
-export type { TransferQuote, TransferLeg, TransferResult } from './types/transfer';
+export type {
+  TransferQuote,
+  TransferLeg,
+  TransferResult,
+} from './types/transfer';
 
 // --- type-dependency placeholders (PR1) ------------------------------------
 // Re-exported so consumers/contract reviewers can see the deferred seams.

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -21,22 +21,50 @@ import type {
 } from './domains';
 import type { EventEmitter, SdkEventMap } from './events';
 
+/**
+ * The Agicash wallet SDK — the single entry point a consumer (the web wallet or
+ * the MCP wallet) interacts with. Construct it with {@link Sdk.create}, reach
+ * functionality through the domain accessors, subscribe to {@link Sdk.events}
+ * for reactivity, and call {@link Sdk.destroy} to tear it down.
+ *
+ * The SDK is framework-free and holds no general domain cache: methods return
+ * Promises, long-running operations return a quote whose discriminated `state`
+ * carries progress, and all change notifications flow through `events`.
+ */
 export declare class Sdk {
+  /**
+   * Asynchronously construct and connect an SDK instance: builds the
+   * Supabase/OpenSecret/Breez clients from `config` and wires the domains. The
+   * SDK owns those clients; the caller only supplies params via {@link SdkConfig}.
+   */
   static create(config: SdkConfig): Promise<Sdk>;
+  /** Authentication: sign in/up/out, password + guest flows, OAuth. */
   readonly auth: AuthDomain;
+  /** The current user and profile mutations (e.g. username). */
   readonly user: UserDomain;
+  /** Wallet accounts: list/get, defaults, add, balance, suggestions. */
   readonly accounts: AccountsDomain;
-  /** .send + .receive */
+  /** Cashu operations — `.send` + `.receive`. */
   readonly cashu: CashuDomain;
-  /** .send + .receive */
+  /** Spark operations — `.send` + `.receive`. */
   readonly spark: SparkDomain;
+  /** Transaction history: paginated list, get, acknowledgement. */
   readonly transactions: TransactionsDomain;
+  /** Saved contacts: list/get/add/remove + user search. */
   readonly contacts: ContactsDomain;
+  /** Cross-account transfers (cashu↔spark via Lightning). */
   readonly transfers: TransfersDomain;
+  /** Parse a scanned/pasted destination string. */
   readonly scan: ScanDomain;
+  /** Fiat/BTC exchange-rate conversion. */
   readonly exchangeRate: ExchangeRateDomain;
+  /** Background processing lifecycle (leader-elected orchestrators). */
   readonly background: BackgroundDomain;
+  /** Type-safe event subscription surface (the SDK's only reactivity channel). */
   readonly events: EventEmitter<SdkEventMap>;
-  /** close WS subs (mints + Supabase + Breez), halt orchestrators, clear timers */
+  /**
+   * Tear down the instance: close WS subscriptions (mints + Supabase realtime +
+   * Breez), halt orchestrators, and clear timers. Call when the consumer is done.
+   */
   destroy(): Promise<void>;
 }

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -1,0 +1,42 @@
+/**
+ * The `Sdk` class SHAPE — §1 of the contract. DECLARATION ONLY (no impl).
+ *
+ * PR1 ships the public shape via `declare class` (no method bodies / no wiring).
+ * The real `Sdk.create` shell + domain-accessor wiring + connection setup land in
+ * the core implementation PR (Slice 0 / PR2).
+ */
+import type { SdkConfig } from './config';
+import type {
+  AccountsDomain,
+  AuthDomain,
+  BackgroundDomain,
+  CashuDomain,
+  ContactsDomain,
+  ExchangeRateDomain,
+  ScanDomain,
+  SparkDomain,
+  TransactionsDomain,
+  TransfersDomain,
+  UserDomain,
+} from './domains';
+import type { EventEmitter, SdkEventMap } from './events';
+
+export declare class Sdk {
+  static create(config: SdkConfig): Promise<Sdk>;
+  readonly auth: AuthDomain;
+  readonly user: UserDomain;
+  readonly accounts: AccountsDomain;
+  /** .send + .receive */
+  readonly cashu: CashuDomain;
+  /** .send + .receive */
+  readonly spark: SparkDomain;
+  readonly transactions: TransactionsDomain;
+  readonly contacts: ContactsDomain;
+  readonly transfers: TransfersDomain;
+  readonly scan: ScanDomain;
+  readonly exchangeRate: ExchangeRateDomain;
+  readonly background: BackgroundDomain;
+  readonly events: EventEmitter<SdkEventMap>;
+  /** close WS subs (mints + Supabase + Breez), halt orchestrators, clear timers */
+  destroy(): Promise<void>;
+}

--- a/packages/wallet-sdk/src/types/account-config.ts
+++ b/packages/wallet-sdk/src/types/account-config.ts
@@ -9,15 +9,28 @@
 import type { Account } from './account';
 import type { Currency } from './money';
 
+/**
+ * Input to {@link AccountsDomain.add}. A cashu account is pinned to a mint URL;
+ * a spark account needs no URL (its keys are seed-derived internally). `name`
+ * defaults to a generated label when omitted.
+ */
 export type AddAccountConfig =
   | { type: 'cashu'; mintUrl: string; currency: Currency; name?: string }
   | { type: 'spark'; currency: Currency; name?: string }; // seed-derived internally
 
+/**
+ * The result of {@link AccountsDomain.suggestFor} — which of the passed-in
+ * accounts to use for a payment intent. Net-new logic (generalizes master's
+ * `findMatchingOfferOrGiftCardAccount` + online-filter + default fallback);
+ * computed purely over the accounts the caller hands in.
+ */
 export type AccountSuggestion = {
+  /** The best account to use for the intent. */
   recommended: Account;
-  /** sufficient balance, lower priority */
+  /** Other accounts with sufficient balance, ranked lower than `recommended`. */
   alternatives: Account[];
+  /** Accounts that match but lack sufficient balance for the intent. */
   insufficient: Account[];
-  /** e.g. "gift-card-mint match" | "default cashu" | ... */
+  /** Human-readable basis for the recommendation, e.g. "gift-card-mint match" | "default cashu". */
   reason: string;
 };

--- a/packages/wallet-sdk/src/types/account-config.ts
+++ b/packages/wallet-sdk/src/types/account-config.ts
@@ -1,0 +1,23 @@
+/**
+ * Account create-config + suggestion types — §2 of the contract.
+ *
+ * `AddAccountConfig` is the input to `accounts.add`. `AccountSuggestion` is the
+ * output of `accounts.suggestFor` — NET-NEW logic (generalizes master's
+ * `findMatchingOfferOrGiftCardAccount` + online-filter + default fallback);
+ * the SHAPES are defined by the contract, not lifted from a single master type.
+ */
+import type { Account } from './account';
+import type { Currency } from './money';
+
+export type AddAccountConfig =
+  | { type: 'cashu'; mintUrl: string; currency: Currency; name?: string }
+  | { type: 'spark'; currency: Currency; name?: string }; // seed-derived internally
+
+export type AccountSuggestion = {
+  recommended: Account;
+  /** sufficient balance, lower priority */
+  alternatives: Account[];
+  insufficient: Account[];
+  /** e.g. "gift-card-mint match" | "default cashu" | ... */
+  reason: string;
+};

--- a/packages/wallet-sdk/src/types/account.ts
+++ b/packages/wallet-sdk/src/types/account.ts
@@ -20,35 +20,72 @@ import type {
 } from './dependencies';
 import type { Currency, Money } from './money';
 
+/** Protocol backing an account: cashu ecash or a Spark (Breez) wallet. */
 export type AccountType = 'cashu' | 'spark';
 
+/** Whether the account is usable (`active`) or has expired (e.g. an expired offer keyset). */
 export type AccountState = 'active' | 'expired';
 
+/**
+ * What the account exists for. Only `transactional` accounts can send/receive
+ * over Lightning; `gift-card`/`offer` accounts are UI-only in v1 but the field
+ * is carried because `canSendToLightning`/`canReceiveFromLightning` gate on it.
+ */
 export type AccountPurpose = 'transactional' | 'gift-card' | 'offer';
 
 /**
- * `CashuProof` — `app/features/accounts/cashu-account.ts` (`z.infer<CashuProofSchema>`).
+ * A single cashu proof (a unit of ecash) held by a cashu `Account`.
+ *
+ * Lifted from `app/features/accounts/cashu-account.ts` (a `zod/mini` schema,
+ * here as its `z.infer` shape). The `state` tracks the proof through the
+ * stale-proof reservation lifecycle (`UNSPENT` → `RESERVED` during an in-flight
+ * send → `SPENT`); `version` supports optimistic locking on the row.
  */
 export type CashuProof = {
+  /** UUID of the proof row. */
   id: string;
+  /** UUID of the cashu account the proof belongs to. */
   accountId: string;
+  /** UUID of the owning user. */
   userId: string;
+  /** ID of the mint keyset this proof was issued under. */
   keysetId: string;
+  /** Denomination of the proof, in the mint's cashu unit (e.g. sats / cents). */
   amount: number;
+  /** The proof's blinded secret. */
   secret: string;
+  /** The mint's unblinded signature (cashu-ts `Proof.C`). */
   unblindedSignature: string;
+  /** The proof's public key Y value (used for proof-state lookups). */
   publicKeyY: string;
   /** `Proof['dleq']` from @cashu/cashu-ts (placeholder in PR1, see ./dependencies). */
   dleq: ProofDleq;
   /** `Proof['witness']` from @cashu/cashu-ts (placeholder in PR1, see ./dependencies). */
   witness: ProofWitness;
+  /** Reservation state: `RESERVED` while an in-flight send holds it; otherwise `UNSPENT`/`SPENT`. */
   state: 'UNSPENT' | 'RESERVED' | 'SPENT';
+  /** Row version; used for optimistic locking. */
   version: number;
+  /** Creation time, as an ISO 8601 timestamp. */
   createdAt: string;
+  /** When the proof was reserved by an in-flight send (null/absent otherwise). */
   reservedAt?: string | null;
+  /** When the proof was spent (null/absent otherwise). */
   spentAt?: string | null;
 };
 
+/**
+ * A wallet account — a per-currency balance backed by either a cashu mint or a
+ * Spark (Breez) wallet. The SDK OWNS this domain type and the web/MCP consumers
+ * import it (decision 7); it is lifted verbatim from
+ * `app/features/accounts/account.ts`.
+ *
+ * Shape = a common base intersected with a `type`-discriminated union (`type` is
+ * the discriminant, NOT `kind`). Methods take the NARROW variant (`CashuAccount`
+ * / `SparkAccount`) so TS rejects e.g. passing a cashu account to a spark op. The
+ * `wallet` field on each variant is a LIVE protocol handle — not serializable and
+ * never a DB read.
+ */
 export type Account = {
   id: string;
   name: string;
@@ -73,9 +110,14 @@ export type Account = {
       type: 'cashu';
       mintUrl: string;
       isTestMint: boolean;
-      /** Counter value per mint keyset (keysetId -> counter). NUT-13. */
+      /**
+       * Holds counter value for each mint keyset. Key is the keyset id, value is counter value.
+       */
       keysetCounters: Record<string, number>;
-      /** All cashu proofs for the account (denominated in cashu units). */
+      /**
+       * Holds all cashu proofs for the account.
+       * Amounts are denominated in the cashu units (e.g. sats for BTC accounts, cents for USD accounts).
+       */
       proofs: CashuProof[];
       /** LIVE handle — mint info/keysets/keys/seed (protocol-metadata memo). Not serializable. */
       wallet: ExtendedCashuWallet;
@@ -84,25 +126,38 @@ export type Account = {
       type: 'spark';
       balance: Money | null;
       network: SparkNetwork;
-      /** LIVE Breez SDK instance (a connection, NOT DB data); stub-that-throws when offline. */
+      /**
+       * The Spark wallet instance for the account.
+       * If the wallet is not online, this will be a stub that throws on any method call.
+       */
       wallet: BreezSdk;
     }
 );
 
 // derivations (master, verbatim):
+
+/** An `Account` of a given `type` augmented with whether it is the default for its currency. */
 export type ExtendedAccount<T extends AccountType = AccountType> = Extract<
   Account,
   { type: T }
 > & { isDefault: boolean };
 
+/** The cashu-only narrowing of `Account`. */
 export type CashuAccount = Extract<Account, { type: 'cashu' }>;
+/** The spark-only narrowing of `Account`. */
 export type SparkAccount = Extract<Account, { type: 'spark' }>;
+/** Cashu `ExtendedAccount` (carries `isDefault`). */
 export type ExtendedCashuAccount = ExtendedAccount<'cashu'>;
+/** Spark `ExtendedAccount` (carries `isDefault`). */
 export type ExtendedSparkAccount = ExtendedAccount<'spark'>;
 
 /**
- * Account type without sensitive data (proofs). Server-safe.
+ * Account type without sensitive data (e.g. proofs for cashu accounts).
+ * Useful for cases where you need to use non sensitive account data in contexts
+ * where sensitive data cannot be decrypted (on server).
+ *
  * (`DistributedOmit` is a PR1 placeholder — see ./dependencies.)
  */
 export type RedactedAccount = DistributedOmit<Account, 'proofs'>;
+/** The cashu-only narrowing of `RedactedAccount`. */
 export type RedactedCashuAccount = Extract<RedactedAccount, { type: 'cashu' }>;

--- a/packages/wallet-sdk/src/types/account.ts
+++ b/packages/wallet-sdk/src/types/account.ts
@@ -1,0 +1,108 @@
+/**
+ * Account domain types — §2 of the contract.
+ *
+ * Lifted verbatim from `app/features/accounts/account.ts` (hand-written TS:
+ * `type = base ∧ cashu|spark union`; discriminant `type`, NOT `kind`) and
+ * `app/features/accounts/cashu-account.ts` (`CashuProof` = `z.infer` of a
+ * zod/mini schema). The SDK OWNS these types; the wallet imports them (decision 7).
+ *
+ * `wallet` is a LIVE handle (`ExtendedCashuWallet` / `BreezSdk`) kept verbatim —
+ * no `AccountData` split (decision 7-i). Here those handles are placeholder types
+ * (see ./dependencies); they become real in later slices.
+ */
+import type {
+  BreezSdk,
+  DistributedOmit,
+  ExtendedCashuWallet,
+  ProofDleq,
+  ProofWitness,
+  SparkNetwork,
+} from './dependencies';
+import type { Currency, Money } from './money';
+
+export type AccountType = 'cashu' | 'spark';
+
+export type AccountState = 'active' | 'expired';
+
+export type AccountPurpose = 'transactional' | 'gift-card' | 'offer';
+
+/**
+ * `CashuProof` — `app/features/accounts/cashu-account.ts` (`z.infer<CashuProofSchema>`).
+ */
+export type CashuProof = {
+  id: string;
+  accountId: string;
+  userId: string;
+  keysetId: string;
+  amount: number;
+  secret: string;
+  unblindedSignature: string;
+  publicKeyY: string;
+  /** `Proof['dleq']` from @cashu/cashu-ts (placeholder in PR1, see ./dependencies). */
+  dleq: ProofDleq;
+  /** `Proof['witness']` from @cashu/cashu-ts (placeholder in PR1, see ./dependencies). */
+  witness: ProofWitness;
+  state: 'UNSPENT' | 'RESERVED' | 'SPENT';
+  version: number;
+  createdAt: string;
+  reservedAt?: string | null;
+  spentAt?: string | null;
+};
+
+export type Account = {
+  id: string;
+  name: string;
+  type: AccountType;
+  purpose: AccountPurpose;
+  state: AccountState;
+  /** gates canSendToLightning / canReceiveFromLightning */
+  isOnline: boolean;
+  currency: Currency;
+  /** ISO 8601 */
+  createdAt: string;
+  /** Row version; used for optimistic locking. */
+  version: number;
+  /**
+   * The account expiry time, as an ISO 8601 timestamp.
+   * For offer accounts, this is when the ecash expires (derived from keyset expiry).
+   * Null for accounts that don't expire.
+   */
+  expiresAt: string | null;
+} & (
+  | {
+      type: 'cashu';
+      mintUrl: string;
+      isTestMint: boolean;
+      /** Counter value per mint keyset (keysetId -> counter). NUT-13. */
+      keysetCounters: Record<string, number>;
+      /** All cashu proofs for the account (denominated in cashu units). */
+      proofs: CashuProof[];
+      /** LIVE handle — mint info/keysets/keys/seed (protocol-metadata memo). Not serializable. */
+      wallet: ExtendedCashuWallet;
+    }
+  | {
+      type: 'spark';
+      balance: Money | null;
+      network: SparkNetwork;
+      /** LIVE Breez SDK instance (a connection, NOT DB data); stub-that-throws when offline. */
+      wallet: BreezSdk;
+    }
+);
+
+// derivations (master, verbatim):
+export type ExtendedAccount<T extends AccountType = AccountType> = Extract<
+  Account,
+  { type: T }
+> & { isDefault: boolean };
+
+export type CashuAccount = Extract<Account, { type: 'cashu' }>;
+export type SparkAccount = Extract<Account, { type: 'spark' }>;
+export type ExtendedCashuAccount = ExtendedAccount<'cashu'>;
+export type ExtendedSparkAccount = ExtendedAccount<'spark'>;
+
+/**
+ * Account type without sensitive data (proofs). Server-safe.
+ * (`DistributedOmit` is a PR1 placeholder — see ./dependencies.)
+ */
+export type RedactedAccount = DistributedOmit<Account, 'proofs'>;
+export type RedactedCashuAccount = Extract<RedactedAccount, { type: 'cashu' }>;

--- a/packages/wallet-sdk/src/types/cashu.ts
+++ b/packages/wallet-sdk/src/types/cashu.ts
@@ -105,7 +105,11 @@ export type CashuSendSwap = CashuSendSwapBase &
         keysetCounter: number;
         outputAmounts: { send: number[]; change: number[] };
       }
-    | { state: 'PENDING' | 'COMPLETED'; tokenHash: string; proofsToSend: CashuProof[] }
+    | {
+        state: 'PENDING' | 'COMPLETED';
+        tokenHash: string;
+        proofsToSend: CashuProof[];
+      }
     | { state: 'FAILED'; failureReason: string }
     | { state: 'REVERSED' }
   );
@@ -163,7 +167,10 @@ type CashuReceiveQuoteBase = {
 };
 
 export type CashuReceiveQuote = CashuReceiveQuoteBase &
-  ({ type: 'LIGHTNING' } | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }) &
+  (
+    | { type: 'LIGHTNING' }
+    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+  ) &
   (
     | { state: 'UNPAID' | 'EXPIRED' }
     | {

--- a/packages/wallet-sdk/src/types/cashu.ts
+++ b/packages/wallet-sdk/src/types/cashu.ts
@@ -1,0 +1,176 @@
+/**
+ * Cashu quote / swap domain types — §5 of the contract.
+ *
+ * Lifted verbatim (as the zod/mini `z.infer` shapes) from:
+ *   - `app/features/send/cashu-send-quote.ts`   (CashuSendQuote + DestinationDetails)
+ *   - `app/features/send/cashu-send-swap.ts`     (CashuSendSwap — token send)
+ *   - `app/features/receive/cashu-receive-quote.ts` (CashuReceiveQuote)
+ *   - `app/features/receive/cashu-token-melt-data.ts` (CashuTokenMeltData)
+ *
+ * Token-send (`CashuSendSwap`) is structurally distinct from lightning-send
+ * (`CashuSendQuote`) per decision 7-ii. NOTE the `CashuSendSwap.createdAt: Date`
+ * quirk (master uses `z.date()` there, unlike every ISO-string `createdAt`).
+ */
+import type { CashuProtocolProof } from './dependencies';
+import type { Money } from './money';
+import type { CashuProof } from './account';
+
+// ---------------------------------------------------------------------------
+// DestinationDetails (discriminated on `sendType`)
+// ---------------------------------------------------------------------------
+
+export type DestinationDetails =
+  | { sendType: 'AGICASH_CONTACT'; contactId: string }
+  | { sendType: 'LN_ADDRESS'; lnAddress: string };
+
+// ---------------------------------------------------------------------------
+// Lightning send — CashuSendQuote (UNPAID/PENDING/EXPIRED/FAILED/PAID)
+// ---------------------------------------------------------------------------
+
+type CashuSendQuoteBase = {
+  id: string;
+  /** ISO 8601 */
+  createdAt: string;
+  /** ISO 8601 */
+  expiresAt: string;
+  userId: string;
+  accountId: string;
+  paymentRequest: string;
+  paymentHash: string;
+  amountRequested: Money;
+  amountRequestedInMsat: number;
+  amountReceived: Money;
+  lightningFeeReserve: Money;
+  cashuFee: Money;
+  /** ID of the melt quote. */
+  quoteId: string;
+  proofs: CashuProof[];
+  amountReserved: Money;
+  /** undefined when paying a bolt11 directly. */
+  destinationDetails?: DestinationDetails;
+  keysetId: string;
+  keysetCounter: number;
+  numberOfChangeOutputs: number;
+  transactionId: string;
+  version: number;
+};
+
+export type CashuSendQuote = CashuSendQuoteBase &
+  (
+    | { state: 'UNPAID' }
+    | { state: 'PENDING' }
+    | { state: 'EXPIRED' }
+    | { state: 'FAILED'; failureReason: string }
+    | {
+        state: 'PAID';
+        paymentPreimage: string;
+        lightningFee: Money;
+        amountSpent: Money;
+        totalFee: Money;
+      }
+  );
+
+// ---------------------------------------------------------------------------
+// Token send — CashuSendSwap (DRAFT/PENDING/COMPLETED/FAILED/REVERSED)
+// ---------------------------------------------------------------------------
+
+type CashuSendSwapBase = {
+  id: string;
+  accountId: string;
+  userId: string;
+  /** Proofs from the account to be spent (reserved, removed from balance). */
+  inputProofs: CashuProof[];
+  /** Defined only when a swap is needed to get the exact proofs to send. */
+  keysetId?: string;
+  keysetCounter?: number;
+  outputAmounts?: { send: number[]; change: number[] };
+  inputAmount: Money;
+  amountReceived: Money;
+  cashuReceiveFee: Money;
+  amountToSend: Money;
+  cashuSendFee: Money;
+  amountSpent: Money;
+  totalFee: Money;
+  transactionId: string;
+  /** <- Date, not ISO string (master verbatim: `z.date()`). */
+  createdAt: Date;
+  version: number;
+};
+
+export type CashuSendSwap = CashuSendSwapBase &
+  (
+    | {
+        state: 'DRAFT';
+        keysetId: string;
+        keysetCounter: number;
+        outputAmounts: { send: number[]; change: number[] };
+      }
+    | { state: 'PENDING' | 'COMPLETED'; tokenHash: string; proofsToSend: CashuProof[] }
+    | { state: 'FAILED'; failureReason: string }
+    | { state: 'REVERSED' }
+  );
+
+export type PendingCashuSendSwap = CashuSendSwap & { state: 'PENDING' };
+
+// ---------------------------------------------------------------------------
+// Cashu token melt data (shared by both CASHU_TOKEN receive variants)
+// receive/cashu-token-melt-data.ts — lifted verbatim (full master shape)
+// ---------------------------------------------------------------------------
+
+export type CashuTokenMeltData = {
+  sourceMintUrl: string;
+  tokenAmount: Money;
+  /**
+   * The source-token proofs to be melted.
+   * Master: `z.array(ProofSchema)` (@cashu/cashu-ts `Proof[]`); `CashuProtocolProof`
+   * is a PR1 placeholder element type (see ./dependencies) — re-typed in Slice 2/3.
+   */
+  tokenProofs: CashuProtocolProof[];
+  meltQuoteId: string;
+  /** Whether the melt has been initiated on the source mint. */
+  meltInitiated: boolean;
+  cashuReceiveFee: Money;
+  lightningFeeReserve: Money;
+  /** Available only when the melt is completed. */
+  lightningFee?: Money;
+};
+
+// ---------------------------------------------------------------------------
+// Cashu receive — CashuReceiveQuote (type LIGHTNING|CASHU_TOKEN ∧ state)
+// ---------------------------------------------------------------------------
+
+type CashuReceiveQuoteBase = {
+  id: string;
+  userId: string;
+  accountId: string;
+  /** ID of the mint quote. */
+  quoteId: string;
+  /** Amount credited to the account. */
+  amount: Money;
+  description?: string;
+  /** ISO 8601 */
+  createdAt: string;
+  /** ISO 8601 */
+  expiresAt: string;
+  paymentRequest: string;
+  paymentHash: string;
+  /** BIP32 path for quote locking/signing. */
+  lockingDerivationPath: string;
+  transactionId: string;
+  mintingFee?: Money;
+  totalFee: Money;
+  version: number;
+};
+
+export type CashuReceiveQuote = CashuReceiveQuoteBase &
+  ({ type: 'LIGHTNING' } | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }) &
+  (
+    | { state: 'UNPAID' | 'EXPIRED' }
+    | {
+        state: 'PAID' | 'COMPLETED';
+        keysetId: string;
+        keysetCounter: number;
+        outputAmounts: number[];
+      }
+    | { state: 'FAILED'; failureReason: string }
+  );

--- a/packages/wallet-sdk/src/types/cashu.ts
+++ b/packages/wallet-sdk/src/types/cashu.ts
@@ -19,53 +19,142 @@ import type { CashuProof } from './account';
 // DestinationDetails (discriminated on `sendType`)
 // ---------------------------------------------------------------------------
 
+/**
+ * Additional details about where a lightning send is going, discriminated on
+ * `sendType`. Undefined on the quote when paying a bolt11 invoice directly.
+ */
 export type DestinationDetails =
-  | { sendType: 'AGICASH_CONTACT'; contactId: string }
-  | { sendType: 'LN_ADDRESS'; lnAddress: string };
+  | {
+      sendType: 'AGICASH_CONTACT';
+      /** The ID of the Agicash contact receiving the payment. */
+      contactId: string;
+    }
+  | {
+      sendType: 'LN_ADDRESS';
+      /** The lightning address that the invoice was fetched from. */
+      lnAddress: string;
+    };
 
 // ---------------------------------------------------------------------------
 // Lightning send — CashuSendQuote (UNPAID/PENDING/EXPIRED/FAILED/PAID)
 // ---------------------------------------------------------------------------
 
 type CashuSendQuoteBase = {
+  /** UUID of the quote. */
   id: string;
-  /** ISO 8601 */
+  /** Date and time the send was created in ISO 8601 format. */
   createdAt: string;
-  /** ISO 8601 */
+  /** Date and time the send quote expires in ISO 8601 format. */
   expiresAt: string;
+  /** UUID of the user that the quote belongs to. */
   userId: string;
+  /** UUID of the Agicash account to send from. */
   accountId: string;
+  /** Bolt 11 payment request that is a destination of the send. */
   paymentRequest: string;
+  /** Payment hash of the lightning invoice. */
   paymentHash: string;
+  /**
+   * Amount requested to send.
+   * For payment requests that have the amount defined, the amount will match what is defined in the request and will always be in BTC currency.
+   * For amountless payment requests, the amount will be the amount defined by the sender (what gets sent to mint in this case is this amount converted to BTC using our exchange rate at the time of quote creation).
+   */
   amountRequested: Money;
+  /**
+   * Amount requested to send converted to milli-satoshis.
+   * For amountless payment requests, this is the amount that gets sent to the mint when creating a melt quote.
+   * It will be the amount requested converted to milli-satoshis using our exchange rate at the time of quote creation.
+   */
   amountRequestedInMsat: number;
+  /**
+   * Amount that the receiver receives.
+   * This is the amount requested in the currency of the account we are sending from.
+   * If the currency of the account we are sending from is not BTC, the mint will do the conversion using their exchange rate at the time of quote creation.
+   */
   amountReceived: Money;
+  /**
+   * Fee reserve for the lightning network fee.
+   * Currency will be the same as the currency of the account we are sending from.
+   * If payment ends up being cheaper than the fee reserve, the difference will be returned as change.
+   */
   lightningFeeReserve: Money;
+  /**
+   * Cashu mint fee for the proofs used.
+   * Currency will be the same as the currency of the account we are sending from.
+   */
   cashuFee: Money;
   /** ID of the melt quote. */
   quoteId: string;
+  /**
+   * Cashu proofs to melt.
+   * Amounts are denominated in the cashu units (e.g. sats for BTC accounts, cents for USD accounts).
+   * Sum of the proof amounts is equal or greater than the amount to send plus the fee reserve. Any overflow will be returned as change.
+   */
   proofs: CashuProof[];
+  /**
+   * The amount reserved for the send.
+   * This is the sum of all proofs used as inputs to the cashu melt operation.
+   * These proofs are reserved until the send is completed or failed.
+   * When the send is completed, the change is returned to the account.
+   */
   amountReserved: Money;
-  /** undefined when paying a bolt11 directly. */
+  /**
+   * Destination details of the send.
+   * This will be undefined if the send is directly paying a bolt11.
+   */
   destinationDetails?: DestinationDetails;
+  /** ID of the keyset used for the send. */
   keysetId: string;
+  /** Counter value for the keyset at the time the time of send. */
   keysetCounter: number;
+  /** Number of ouputs that will be used for the send change. */
   numberOfChangeOutputs: number;
+  /** UUID of the corresponding transaction. */
   transactionId: string;
+  /**
+   * Version of the send quote.
+   * Can be used for optimistic locking.
+   */
   version: number;
 };
 
+/**
+ * A LIGHTNING send quote (`send/cashu-send-quote.ts`). Drives a bolt11 / ln-address
+ * payment funded by melting cashu proofs. Structurally distinct from the token-send
+ * {@link CashuSendSwap}; carries no `token` field. The `state` union narrows the
+ * payment lifecycle UNPAID → PENDING → PAID (or EXPIRED / FAILED) and is the
+ * canonical progress signal (no separate result type).
+ */
 export type CashuSendQuote = CashuSendQuoteBase &
   (
     | { state: 'UNPAID' }
     | { state: 'PENDING' }
     | { state: 'EXPIRED' }
-    | { state: 'FAILED'; failureReason: string }
+    | {
+        state: 'FAILED';
+        /** Reason for the failure of the send quote. */
+        failureReason: string;
+      }
     | {
         state: 'PAID';
+        /** Lightning payment preimage. */
         paymentPreimage: string;
+        /**
+         * Actual Lightning Network fee that was charged.
+         * Currency will be the same as the currency of the account we are sending from.
+         * This will be undefined until the send is completed.
+         */
         lightningFee: Money;
+        /**
+         * Total amount spent on the lightning payment.
+         * This is the amount to send plus the actual fee paid to the lightning network.
+         * Currency will be the same as the currency of the account we are sending from.
+         */
         amountSpent: Money;
+        /**
+         * The total fee for the transaction.
+         * This is the sum of `lightningFee` and `cashuFee`.
+         */
         totalFee: Money;
       }
   );
@@ -75,28 +164,96 @@ export type CashuSendQuote = CashuSendQuoteBase &
 // ---------------------------------------------------------------------------
 
 type CashuSendSwapBase = {
+  /** The UUID of the swap. */
   id: string;
+  /** The UUID of the account that the swap belongs to. */
   accountId: string;
+  /** The UUID of the user that the swap belongs to. */
   userId: string;
-  /** Proofs from the account to be spent (reserved, removed from balance). */
+  /**
+   * The proofs from the account that will be spent.
+   * These are reserved and thus removed from the account's balance.
+   */
   inputProofs: CashuProof[];
-  /** Defined only when a swap is needed to get the exact proofs to send. */
+  /**
+   * The keyset id used to generate the output data at the time the swap was created.
+   * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
+   */
   keysetId?: string;
+  /**
+   * The keyset counter used to generate the output data at the time the swap was created.
+   * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
+   */
   keysetCounter?: number;
-  outputAmounts?: { send: number[]; change: number[] };
+  /**
+   * The output data used for deterministic outputs when we swap the inputProofs for proofsToSend.
+   * This will be defined only when the cashu swap is needed to get the exact amount of proofs to send.
+   */
+  outputAmounts?: {
+    /** The output amounts to use when constructing the send output data. */
+    send: number[];
+    /** The output amounts to use when constructing the change output data. */
+    change: number[];
+  };
+  /** The sum of the inputProofs. */
   inputAmount: Money;
+  /** The amount received by the receiver. */
   amountReceived: Money;
+  /** The swap fee that will be incurred when the receiver claims the token. */
   cashuReceiveFee: Money;
+  /**
+   * Amount that sender needs to create a token for in order for the receiver to receive exactly `amountReceived`.
+   * This is `amountReceived` plus `cashuReceiveFee`.
+   */
   amountToSend: Money;
+  /**
+   * The swap fee that will be incurred when swapping the input proofs to get `amountToSend` worth of proofs to send.
+   * When the `inputAmount` equals `amountToSend`, no swap is needed and this will be zero.
+   */
   cashuSendFee: Money;
+  /**
+   * The total amount spent.
+   * This is the sum of `amountToSend` and `cashuSendFee`.
+   */
   amountSpent: Money;
+  /**
+   * The total fee for the transaction.
+   * This is the sum of `cashuSendFee` and `cashuReceiveFee`.
+   */
   totalFee: Money;
+  /** The UUID of the transaction that the swap belongs to. */
   transactionId: string;
-  /** <- Date, not ISO string (master verbatim: `z.date()`). */
+  /**
+   * The date the swap was created.
+   * NOTE: a `Date`, not an ISO string (master verbatim: `z.date()`).
+   */
   createdAt: Date;
+  /**
+   * Version of the send swap.
+   * Can be used for optimistic locking.
+   */
   version: number;
 };
 
+/**
+ * A TOKEN send (`send/cashu-send-swap.ts`). Spends proofs from an account (or
+ * swaps them if there is no exact amount with available proofs) and encodes them
+ * into a token to share with the receiver.
+ *
+ * If the source account has exact amount of proofs to send, no swap is needed and
+ * the send swap is created in the PENDING state. Otherwise, the swap is done to get
+ * the exact amount of proofs to send, so the send swap is created in the DRAFT state.
+ *
+ * When in the DRAFT state, the proofs from the account that we will use for the
+ * swap have been reserved for this send swap. To move the swap to the PENDING state,
+ * the inputProofs are swapped for proofsToSend.
+ *
+ * When PENDING, the proofsToSend exist and we are just waiting for them to be spent.
+ * In this state, the transaction can be reversed by swapping the proofsToSend back
+ * into the account (see {@link CashuSendOps.reverse}).
+ *
+ * Once the proofsToSend are spent, the swap is COMPLETED.
+ */
 export type CashuSendSwap = CashuSendSwapBase &
   (
     | {
@@ -107,13 +264,21 @@ export type CashuSendSwap = CashuSendSwapBase &
       }
     | {
         state: 'PENDING' | 'COMPLETED';
+        /** The hash of the token being sent. */
         tokenHash: string;
+        /**
+         * The proofs that will be sent. If we have the exact proofs to send,
+         * then this will be the same as inputProofs and no cashu swap will occur.
+         * If the inputProofs sum to more than the amount to send, then this
+         * will be the result of swapping the inputProofs for the amount to send.
+         */
         proofsToSend: CashuProof[];
       }
     | { state: 'FAILED'; failureReason: string }
     | { state: 'REVERSED' }
   );
 
+/** A {@link CashuSendSwap} narrowed to the PENDING state (reclaimable via reverse). */
 export type PendingCashuSendSwap = CashuSendSwap & { state: 'PENDING' };
 
 // ---------------------------------------------------------------------------
@@ -121,21 +286,38 @@ export type PendingCashuSendSwap = CashuSendSwap & { state: 'PENDING' };
 // receive/cashu-token-melt-data.ts — lifted verbatim (full master shape)
 // ---------------------------------------------------------------------------
 
+/**
+ * Data related to cross-account cashu token receives.
+ * Cross-account (to a different cashu account or a spark account) cashu token receives
+ * always require a melt operation where token proofs are melted to make a lightning payment.
+ * Shared by both CASHU_TOKEN receive variants (cashu + spark).
+ */
 export type CashuTokenMeltData = {
+  /** URL of the source mint where the token proofs originate from. */
   sourceMintUrl: string;
+  /** The amount of the token melted. */
   tokenAmount: Money;
   /**
-   * The source-token proofs to be melted.
+   * The proofs from the source cashu token that will be melted.
    * Master: `z.array(ProofSchema)` (@cashu/cashu-ts `Proof[]`); `CashuProtocolProof`
    * is a PR1 placeholder element type (see ./dependencies) — re-typed in Slice 2/3.
    */
   tokenProofs: CashuProtocolProof[];
+  /** ID of the melt quote on the source mint. */
   meltQuoteId: string;
   /** Whether the melt has been initiated on the source mint. */
   meltInitiated: boolean;
+  /** The fee that is paid for spending the token proofs as inputs to the melt operation. */
   cashuReceiveFee: Money;
+  /** The fee reserved for the lightning payment to destination account. */
   lightningFeeReserve: Money;
-  /** Available only when the melt is completed. */
+  /**
+   * The actual Lightning Network fee that was charged after the transaction completed.
+   * This may be less than the `lightningFeeReserve` if the payment was cheaper than expected.
+   * The difference between the `lightningFeeReserve` and the `lightningFee` is a change.
+   * For cashu token receives over lightning, we are currently not returning the change to the user.
+   * Available only when the melt is completed.
+   */
   lightningFee?: Money;
 };
 
@@ -144,40 +326,101 @@ export type CashuTokenMeltData = {
 // ---------------------------------------------------------------------------
 
 type CashuReceiveQuoteBase = {
+  /** UUID of the quote. */
   id: string;
+  /** UUID of the user that the quote belongs to. */
   userId: string;
+  /** UUID of the Agicash account that the quote belongs to. */
   accountId: string;
-  /** ID of the mint quote. */
+  /**
+   * ID of the mint quote.
+   * Once the quote is paid, the mint quote id is used to mint the tokens.
+   */
   quoteId: string;
-  /** Amount credited to the account. */
+  /**
+   * Amount of the quote.
+   * This is the amount that gets credited to the account.
+   */
   amount: Money;
+  /** Description of the receive. */
   description?: string;
-  /** ISO 8601 */
+  /** Date and time the receive quote was created in ISO 8601 format. */
   createdAt: string;
-  /** ISO 8601 */
+  /** Date and time the receive quote expires in ISO 8601 format. */
   expiresAt: string;
+  /** Bolt 11 payment request for the quote. */
   paymentRequest: string;
+  /** Payment hash of the quote's lightning invoice. */
   paymentHash: string;
-  /** BIP32 path for quote locking/signing. */
+  /**
+   * BIP32 derivation path used for locking and signing the quote.
+   * This is the full path used to derive the locking key from the cashu seed.
+   * The last index is unhardened so that we can derive public keys without requiring the private key.
+   * @example "m/129372'/0'/0'/4321"
+   */
   lockingDerivationPath: string;
+  /** UUID of the corresponding transaction. */
   transactionId: string;
+  /**
+   * Optional fee that the mint charges to mint ecash.
+   * This amount is added to the payment request amount so the amount in the payment request is equal to `amount` plus `mintingFee`.
+   * The sender pays the fee. The receiver will receive `amount` worth of ecash, while the mint keeps the `mintingFee`.
+   */
   mintingFee?: Money;
+  /**
+   * The total fee for the transaction.
+   * For receives of type LIGHTNING, this will be zero.
+   * For receive of type CASHU_TOKEN, this will be the sum of the `mintingFee` (if it exists), `cashuReceiveFee` and `lightningFeeReserve`.
+   * `mintingFee` is included for cashu token receives because the receiver of the token needs to make a lightning payment to the destination
+   * mint so it practically becomes a part of the receive fee.
+   *
+   * For CASHU_TOKEN receives, we are currently not returning the change to the user. If we ever do, the totalFee should be updated
+   * to use lightningFee instead of lightningFeeReserve once actual fee is known.
+   */
   totalFee: Money;
+  /**
+   * Version of the receive quote.
+   * Can be used for optimistic locking.
+   */
   version: number;
 };
 
+/**
+ * A cashu receive quote (`receive/cashu-receive-quote.ts`). Two orthogonal
+ * discriminators: `type` (LIGHTNING vs CASHU_TOKEN) ∧ `state` (UNPAID/EXPIRED,
+ * PAID/COMPLETED, FAILED). A CASHU_TOKEN receive carries the {@link CashuTokenMeltData}
+ * needed to melt the source token to a Lightning payment for cross-account claims.
+ */
 export type CashuReceiveQuote = CashuReceiveQuoteBase &
   (
-    | { type: 'LIGHTNING' }
-    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+    | {
+        /** The money is received via Lightning. */
+        type: 'LIGHTNING';
+      }
+    | {
+        /**
+         * The money is received as a cashu token. Those proofs are then used to mint tokens for the receiver's account via Lightning.
+         * Used for cross-account cashu token receives where the receiver chooses to claim a token to an account different from the mint/unit the token originated from, thus requiring a lightning payment.
+         */
+        type: 'CASHU_TOKEN';
+        /** Data related to cashu token receive. */
+        tokenReceiveData: CashuTokenMeltData;
+      }
   ) &
   (
     | { state: 'UNPAID' | 'EXPIRED' }
     | {
         state: 'PAID' | 'COMPLETED';
+        /** ID of the keyset used to create the blinded messages. */
         keysetId: string;
+        /** Counter value for the keyset at the time of quote payment. */
         keysetCounter: number;
+        /** Amounts for each blinded message created for this receive. */
         outputAmounts: number[];
       }
-    | { state: 'FAILED'; failureReason: string }
+    | {
+        state: 'FAILED';
+        /** Reason this quote was failed. */
+        failureReason: string;
+      }
   );

--- a/packages/wallet-sdk/src/types/contact.ts
+++ b/packages/wallet-sdk/src/types/contact.ts
@@ -11,17 +11,32 @@
  * `UserProfile`. PR1 follows the CONTRACT. Reconcile during Slice 4 (lift vs spec).
  */
 
+/**
+ * A saved contact — another Agicash user the owner can pay. CREATE/DELETE only
+ * (no `version` column), so ordering/dedupe is by op-type + refetch.
+ */
 export type Contact = {
+  /** UUID of the contact row. */
   id: string;
+  /** Id of the user that this contact belongs to */
   ownerId: string;
+  /** Username of the user within this app that this contact references */
   username: string;
-  /** Lightning Address of the referenced user. */
+  /** Lightning Address of the user that this contact references */
   lud16: string;
+  /** When the contact was created. */
   createdAt: Date;
 };
 
+/**
+ * A public, addable user profile returned by {@link ContactsDomain.search}
+ * (before it becomes a saved {@link Contact}).
+ */
 export type UserProfile = {
+  /** UUID of the user. */
   id: string;
+  /** The user's handle. */
   username: string;
+  /** The user's Lightning Address, computed `${username}@${domain}`. */
   lud16: string;
 };

--- a/packages/wallet-sdk/src/types/contact.ts
+++ b/packages/wallet-sdk/src/types/contact.ts
@@ -1,0 +1,27 @@
+/**
+ * Contact domain types — §8 of the contract.
+ *
+ * Shapes per the contract. `lud16` is computed `${username}@${domain}` at runtime.
+ * Contacts have NO `version` column (CREATE/DELETE only) → ordering/dedupe is
+ * op-type + refetch.
+ *
+ * NOTE (master drift — flag for review): master's `app/features/contacts/contact.ts`
+ * `Contact.createdAt` is a `string` (ISO) and `UserProfile = Pick<User,'id'|'username'>`
+ * (no `lud16`). The contract (§8) specifies `createdAt: Date` and a `lud16` on
+ * `UserProfile`. PR1 follows the CONTRACT. Reconcile during Slice 4 (lift vs spec).
+ */
+
+export type Contact = {
+  id: string;
+  ownerId: string;
+  username: string;
+  /** Lightning Address of the referenced user. */
+  lud16: string;
+  createdAt: Date;
+};
+
+export type UserProfile = {
+  id: string;
+  username: string;
+  lud16: string;
+};

--- a/packages/wallet-sdk/src/types/dependencies.ts
+++ b/packages/wallet-sdk/src/types/dependencies.ts
@@ -1,0 +1,125 @@
+/**
+ * Type dependencies the contract references but does NOT own.
+ *
+ * PR1 (contract-as-code) ships these as thin placeholders so the contract
+ * typechecks standalone with ZERO new runtime/package deps. Each is wired to its
+ * real source in a later slice (per the build plan: app-resident large modules
+ * are NOT moved in PR1; external packages are imported only once they are in the
+ * workspace + installed).
+ */
+
+// ---------------------------------------------------------------------------
+// External package types (import once the deps are added to the package)
+// ---------------------------------------------------------------------------
+
+/**
+ * Live Breez/Spark SDK instance held on a spark `Account`.
+ * TODO(Slice-0): `import type { BreezSdk } from '@agicash/breez-sdk-spark'`
+ * (add `@agicash/breez-sdk-spark` to the package deps + root catalog first).
+ */
+export type BreezSdk = unknown;
+
+/**
+ * Live cashu wallet handle (mint info / keysets / keys / seed) held on a cashu
+ * `Account` — the per-mint protocol-metadata memo (§0 state kind 2).
+ * TODO(Slice-3): import the real `ExtendedCashuWallet` from the SDK-internal
+ * `lib/cashu` (extracted from `app/lib/cashu`).
+ */
+export type ExtendedCashuWallet = unknown;
+
+/**
+ * Spark network discriminant.
+ * TODO(Slice-2): lift `SparkNetwork` verbatim from
+ * `app/features/agicash-db/json-models/spark-account-details-db-data.ts`.
+ */
+export type SparkNetwork = 'MAINNET' | 'REGTEST';
+
+/**
+ * A raw cashu-ts protocol `Proof` (distinct from the domain `CashuProof`).
+ * Carried by `CashuTokenMeltData.tokenProofs` (master: `z.array(ProofSchema)`).
+ * TODO(Slice-2/3): `import type { Proof } from '@cashu/cashu-ts'` (alias here as
+ * `CashuProtocolProof`); shape = `app/lib/cashu/types.ts#ProofSchema`.
+ */
+export type CashuProtocolProof = unknown;
+
+/**
+ * The `dleq` / `witness` sub-fields of a cashu-ts `Proof`, referenced by
+ * `CashuProof`.
+ * TODO(Slice-2/3): `import type { Proof } from '@cashu/cashu-ts'` and use
+ * `Proof['dleq']` / `Proof['witness']` (matches `app/lib/cashu/types.ts#ProofSchema`).
+ */
+export type ProofDleq = unknown;
+export type ProofWitness = unknown;
+
+// ---------------------------------------------------------------------------
+// Utility types
+// ---------------------------------------------------------------------------
+
+/**
+ * `DistributedOmit` distributes `Omit` over a union (each member omits `K`).
+ * Used by `RedactedAccount`.
+ * TODO(Slice-2): `import type { DistributedOmit } from 'type-fest'` once the
+ * package depends on `type-fest`. This local form is behaviour-equivalent.
+ */
+export type DistributedOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+/**
+ * Supabase `Json` scalar — referenced by the (internal) transaction-details
+ * parser surface. Public types don't use it; kept here for the parser seam.
+ * TODO(Slice-4): import `Json` from the lifted `agicash-db/database.ts` types.
+ */
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+// ---------------------------------------------------------------------------
+// Parsed-destination payload types (scan, §3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decoded BOLT11 invoice carried by a `bolt11` `ParsedDestination`.
+ * Shape = `app/lib/bolt11/index.ts#DecodedBolt11` (verbatim).
+ * TODO(Slice-2): import the real type from the SDK-internal `lib/bolt11`
+ * (extracted from `app/lib/bolt11`).
+ */
+export type Bolt11Invoice = {
+  amountMsat: number | undefined;
+  amountSat: number | undefined;
+  createdAtUnixMs: number;
+  expiryUnixMs: number;
+  network: string | undefined;
+  description: string | undefined;
+  payeeNodeKey: string;
+  paymentHash: string;
+};
+
+/**
+ * Parsed cashu token metadata carried by a `cashu-token` `ParsedDestination`.
+ * Master = `@cashu/cashu-ts`'s `TokenMetadata` (returned by `extractCashuToken`).
+ * TODO(Slice-2/3): `import type { TokenMetadata } from '@cashu/cashu-ts'` (alias
+ * to `ParsedToken`); `extractCashuToken` returns `{ encoded; metadata: TokenMetadata }`.
+ */
+export type ParsedToken = {
+  /** the re-encoded token string */
+  encoded: string;
+  /** cashu-ts TokenMetadata (mint/unit/amount summary) */
+  metadata: unknown;
+};
+
+/**
+ * Pluggable storage adapter (web = browser, mcp = fs/sqlite) threaded into the
+ * OpenSecret SDK and used for session resume.
+ * TODO(Slice-0): replace with the real `StorageAdapter` type from
+ * `@agicash/opensecret-sdk` (its `configure({ storage })` contract).
+ */
+export type StorageAdapter = {
+  getItem(key: string): Promise<string | null> | string | null;
+  setItem(key: string, value: string): Promise<void> | void;
+  removeItem(key: string): Promise<void> | void;
+};

--- a/packages/wallet-sdk/src/types/dependencies.ts
+++ b/packages/wallet-sdk/src/types/dependencies.ts
@@ -89,13 +89,21 @@ export type Json =
  * (extracted from `app/lib/bolt11`).
  */
 export type Bolt11Invoice = {
+  /** Invoice amount in millisatoshis, or undefined for amountless invoices. */
   amountMsat: number | undefined;
+  /** Invoice amount in satoshis, or undefined for amountless invoices. */
   amountSat: number | undefined;
+  /** Invoice creation time, Unix epoch milliseconds. */
   createdAtUnixMs: number;
+  /** Invoice expiry time, Unix epoch milliseconds. */
   expiryUnixMs: number;
+  /** Network the invoice is for (e.g. "bitcoin"/"testnet"), or undefined. */
   network: string | undefined;
+  /** Invoice description/memo, or undefined. */
   description: string | undefined;
+  /** Public key of the payee node. */
   payeeNodeKey: string;
+  /** Payment hash of the invoice. */
   paymentHash: string;
 };
 
@@ -119,7 +127,10 @@ export type ParsedToken = {
  * `@agicash/opensecret-sdk` (its `configure({ storage })` contract).
  */
 export type StorageAdapter = {
+  /** Read a stored value by key (null if absent); may be sync or async. */
   getItem(key: string): Promise<string | null> | string | null;
+  /** Write a value under a key; may be sync or async. */
   setItem(key: string, value: string): Promise<void> | void;
+  /** Delete a stored value by key; may be sync or async. */
   removeItem(key: string): Promise<void> | void;
 };

--- a/packages/wallet-sdk/src/types/money.ts
+++ b/packages/wallet-sdk/src/types/money.ts
@@ -1,0 +1,39 @@
+/**
+ * Money / Currency value types.
+ *
+ * PR1 (contract-as-code) ships these as standalone placeholders so the contract
+ * typechecks with no runtime dependencies. `Money` is declared as an opaque class
+ * shell (no method bodies) — the public domain types only ever reference it as a
+ * type, never construct it here.
+ *
+ * TODO(Slice-0): replace this module with a re-export of the real `Money`
+ * (+ `Currency`, `CurrencyUnit`) lifted from `app/lib/money/{index,money,types}.ts`
+ * (verbatim; leaf + dependency-free). Web then imports `Money` from this package.
+ * Source of truth: app/lib/money/types.ts (Currency/CurrencyUnit) + money.ts (Money).
+ */
+
+/** supported currencies — verbatim from app/lib/money/types.ts */
+export type Currency = 'USD' | 'BTC';
+
+export type UsdUnit = 'usd' | 'cent';
+export type BtcUnit = 'btc' | 'sat' | 'msat';
+
+/** Unit to denominate the given currency — verbatim from app/lib/money/types.ts */
+export type CurrencyUnit<T extends Currency = Currency> = T extends 'USD'
+  ? UsdUnit
+  : T extends 'BTC'
+    ? BtcUnit
+    : never;
+
+/**
+ * Opaque placeholder for the real `Money` value object.
+ *
+ * Declared as a class so domain types can use `Money` as both a type and (later)
+ * a `z.instanceof(Money)` target without churn. No logic lives here in PR1.
+ *
+ * TODO(Slice-0): delete and re-export the real `Money` from `app/lib/money`.
+ */
+export declare class Money<T extends Currency = Currency> {
+  /** Brand to keep the placeholder nominal (prevents structural collapse to `{}`). */
+  private readonly __moneyBrand: T;
+}

--- a/packages/wallet-sdk/src/types/money.ts
+++ b/packages/wallet-sdk/src/types/money.ts
@@ -15,7 +15,9 @@
 /** supported currencies — verbatim from app/lib/money/types.ts */
 export type Currency = 'USD' | 'BTC';
 
+/** Denomination units for USD amounts. */
 export type UsdUnit = 'usd' | 'cent';
+/** Denomination units for BTC amounts. */
 export type BtcUnit = 'btc' | 'sat' | 'msat';
 
 /** Unit to denominate the given currency — verbatim from app/lib/money/types.ts */

--- a/packages/wallet-sdk/src/types/scan.ts
+++ b/packages/wallet-sdk/src/types/scan.ts
@@ -1,0 +1,20 @@
+/**
+ * Scan / payment-intent types — §3 of the contract.
+ *
+ * `ParsedDestination` is the contract's reshape of master's
+ * `app/features/scan/classify-input.ts#ClassifiedInput` into kinds
+ * `bolt11` / `ln-address` / `cashu-token`. `PaymentIntent` is the input to
+ * `accounts.suggestFor`.
+ */
+import type { Bolt11Invoice, ParsedToken } from './dependencies';
+import type { Money } from './money';
+
+export type ParsedDestination =
+  | { kind: 'bolt11'; invoice: Bolt11Invoice }
+  | { kind: 'ln-address'; address: string }
+  | { kind: 'cashu-token'; token: ParsedToken };
+
+export type PaymentIntent =
+  | { kind: 'send'; destination: ParsedDestination; amount?: Money }
+  | { kind: 'receive'; amount?: Money }
+  | { kind: 'token-receive'; token: string };

--- a/packages/wallet-sdk/src/types/scan.ts
+++ b/packages/wallet-sdk/src/types/scan.ts
@@ -9,11 +9,23 @@
 import type { Bolt11Invoice, ParsedToken } from './dependencies';
 import type { Money } from './money';
 
+/**
+ * The classified result of {@link ScanDomain.parse} — what a scanned/pasted
+ * string resolves to. `kind` discriminates the payload: a decoded BOLT11
+ * invoice, a Lightning address (resolved to an invoice later, when the amount is
+ * known), or a parsed cashu token.
+ */
 export type ParsedDestination =
   | { kind: 'bolt11'; invoice: Bolt11Invoice }
   | { kind: 'ln-address'; address: string }
   | { kind: 'cashu-token'; token: ParsedToken };
 
+/**
+ * What the user wants to do, fed into {@link AccountsDomain.suggestFor} to pick
+ * an account. A `send` carries the parsed destination (and an optional amount
+ * for amountless invoices / ln-addresses); a `receive` carries an optional
+ * amount; a `token-receive` carries the raw token string.
+ */
 export type PaymentIntent =
   | { kind: 'send'; destination: ParsedDestination; amount?: Money }
   | { kind: 'receive'; amount?: Money }

--- a/packages/wallet-sdk/src/types/spark.ts
+++ b/packages/wallet-sdk/src/types/spark.ts
@@ -74,7 +74,10 @@ type SparkReceiveQuoteBase = {
 };
 
 export type SparkReceiveQuote = SparkReceiveQuoteBase &
-  ({ type: 'LIGHTNING' } | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }) &
+  (
+    | { type: 'LIGHTNING' }
+    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+  ) &
   (
     | { state: 'UNPAID' | 'EXPIRED' }
     | { state: 'PAID'; paymentPreimage: string; sparkTransferId: string }

--- a/packages/wallet-sdk/src/types/spark.ts
+++ b/packages/wallet-sdk/src/types/spark.ts
@@ -13,39 +13,73 @@ import type { CashuTokenMeltData } from './cashu';
 // ---------------------------------------------------------------------------
 
 type SparkSendQuoteBase = {
+  /** UUID of the quote. */
   id: string;
-  /** ISO 8601 */
+  /** Date and time the send quote was created in ISO 8601 format. */
   createdAt: string;
-  /** ISO 8601; nullish */
+  /** Date and time the send quote expires in ISO 8601 format. */
   expiresAt?: string | null;
+  /** Amount being sent. */
   amount: Money;
+  /** Estimated fee for the lightning payment. */
   estimatedFee: Money;
+  /** Lightning invoice being paid. */
   paymentRequest: string;
+  /** Payment hash of the lightning invoice. */
   paymentHash: string;
+  /** ID of the corresponding transaction. */
   transactionId: string;
+  /** ID of the user that the quote belongs to. */
   userId: string;
+  /** ID of the account that the quote belongs to. */
   accountId: string;
+  /** Row version. Used for optimistic locking. */
   version: number;
-  /** When true, `amount` holds the user-specified amount. */
+  /**
+   * Whether the payment request is amountless.
+   * When true, the amount field contains the user-specified amount.
+   */
   paymentRequestIsAmountless: boolean;
 };
 
+/**
+ * A Spark Lightning send quote (`send/spark-send-quote.ts`).
+ * Created when a user confirms a lightning payment through their Spark wallet.
+ * The quote starts in UNPAID state, transitions to PENDING when payment is initiated,
+ * and finally to COMPLETED or FAILED based on the payment result.
+ */
 export type SparkSendQuote = SparkSendQuoteBase &
   (
     | { state: 'UNPAID' }
-    | { state: 'PENDING'; sparkId: string; sparkTransferId: string; fee: Money }
+    | {
+        state: 'PENDING';
+        /** ID of the send request in spark system. */
+        sparkId: string;
+        /** Spark transfer ID. */
+        sparkTransferId: string;
+        /** Actual fee of the lightning payment. */
+        fee: Money;
+      }
     | {
         state: 'COMPLETED';
+        /** ID of the send request in spark system. */
         sparkId: string;
+        /** Spark transfer ID. */
         sparkTransferId: string;
+        /** Actual fee of the lightning payment. */
         fee: Money;
+        /** Payment preimage proving the payment was successful. */
         paymentPreimage: string;
       }
     | {
         state: 'FAILED';
+        /** Reason for failure. */
         failureReason: string;
+        /** ID of the send request in spark system. */
         sparkId?: string;
+        /** Spark transfer ID. */
         sparkTransferId?: string;
+        /** Actual fee of the lightning payment. */
         fee?: Money;
       }
   );
@@ -55,31 +89,81 @@ export type SparkSendQuote = SparkSendQuoteBase &
 // ---------------------------------------------------------------------------
 
 type SparkReceiveQuoteBase = {
+  /** UUID of the quote. */
   id: string;
+  /** ID of the receive request in Spark system. */
   sparkId: string;
-  /** ISO 8601 */
+  /** Date and time the receive quote was created in ISO 8601 format. */
   createdAt: string;
-  /** ISO 8601 */
+  /** Date and time the receive quote expires in ISO 8601 format. */
   expiresAt: string;
+  /** Amount of the quote. */
   amount: Money;
+  /** Description of the receive. */
   description?: string;
+  /** Bolt 11 payment request. */
   paymentRequest: string;
+  /** Payment hash of the lightning invoice. */
   paymentHash: string;
+  /** Optional public key of the wallet receiving the lightning invoice. */
   receiverIdentityPubkey?: string;
+  /** UUID of the corresponding transaction. */
   transactionId: string;
+  /** UUID of the user that the quote belongs to. */
   userId: string;
+  /** UUID of the account that the quote belongs to. */
   accountId: string;
+  /**
+   * The total fee for the transaction.
+   * For receives of type LIGHTNING, this will be zero.
+   * For receive of type CASHU_TOKEN, this will be the sum of the `cashuReceiveFee` and `lightningFeeReserve`.
+   *
+   * For CASHU_TOKEN receives, we are currently not returning the change to the user. If we ever do, the totalFee should be updated
+   * to use lightningFee instead of lightningFeeReserve once actual fee is known.
+   */
   totalFee: Money;
+  /**
+   * Version of the receive quote.
+   * Can be used for optimistic locking.
+   */
   version: number;
 };
 
+/**
+ * A Spark receive quote (`receive/spark-receive-quote.ts`).
+ * Created when a user requests to receive funds via Lightning through their Spark wallet.
+ * Two orthogonal discriminators: `type` (LIGHTNING vs CASHU_TOKEN) ∧ `state`
+ * (UNPAID/EXPIRED, PAID, FAILED). A CASHU_TOKEN receive melts a provided cashu token
+ * to pay the Spark Lightning invoice.
+ */
 export type SparkReceiveQuote = SparkReceiveQuoteBase &
   (
-    | { type: 'LIGHTNING' }
-    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+    | {
+        /** The money is received via regular Lightning flow. User provides the lightning invoice to the payer who then pays the invoice. */
+        type: 'LIGHTNING';
+      }
+    | {
+        /**
+         * The money is received as cashu token. User provides the cashu token and cashu proofs are then melted by the Agicash app and used to pay Spark lightning invoice.
+         * Used for receiving cashu tokens to Spark accounts.
+         */
+        type: 'CASHU_TOKEN';
+        /** Data related to cashu token receive. */
+        tokenReceiveData: CashuTokenMeltData;
+      }
   ) &
   (
     | { state: 'UNPAID' | 'EXPIRED' }
-    | { state: 'PAID'; paymentPreimage: string; sparkTransferId: string }
-    | { state: 'FAILED'; failureReason: string }
+    | {
+        state: 'PAID';
+        /** Payment preimage. */
+        paymentPreimage: string;
+        /** Spark transfer ID. */
+        sparkTransferId: string;
+      }
+    | {
+        state: 'FAILED';
+        /** Reason for the failure. */
+        failureReason: string;
+      }
   );

--- a/packages/wallet-sdk/src/types/spark.ts
+++ b/packages/wallet-sdk/src/types/spark.ts
@@ -1,0 +1,82 @@
+/**
+ * Spark quote domain types — §6 of the contract.
+ *
+ * Lifted verbatim (as the zod/mini `z.infer` shapes) from:
+ *   - `app/features/send/spark-send-quote.ts`      (SparkSendQuote)
+ *   - `app/features/receive/spark-receive-quote.ts` (SparkReceiveQuote)
+ */
+import type { Money } from './money';
+import type { CashuTokenMeltData } from './cashu';
+
+// ---------------------------------------------------------------------------
+// Spark send — SparkSendQuote (UNPAID/PENDING/COMPLETED/FAILED)
+// ---------------------------------------------------------------------------
+
+type SparkSendQuoteBase = {
+  id: string;
+  /** ISO 8601 */
+  createdAt: string;
+  /** ISO 8601; nullish */
+  expiresAt?: string | null;
+  amount: Money;
+  estimatedFee: Money;
+  paymentRequest: string;
+  paymentHash: string;
+  transactionId: string;
+  userId: string;
+  accountId: string;
+  version: number;
+  /** When true, `amount` holds the user-specified amount. */
+  paymentRequestIsAmountless: boolean;
+};
+
+export type SparkSendQuote = SparkSendQuoteBase &
+  (
+    | { state: 'UNPAID' }
+    | { state: 'PENDING'; sparkId: string; sparkTransferId: string; fee: Money }
+    | {
+        state: 'COMPLETED';
+        sparkId: string;
+        sparkTransferId: string;
+        fee: Money;
+        paymentPreimage: string;
+      }
+    | {
+        state: 'FAILED';
+        failureReason: string;
+        sparkId?: string;
+        sparkTransferId?: string;
+        fee?: Money;
+      }
+  );
+
+// ---------------------------------------------------------------------------
+// Spark receive — SparkReceiveQuote (type LIGHTNING|CASHU_TOKEN ∧ state)
+// ---------------------------------------------------------------------------
+
+type SparkReceiveQuoteBase = {
+  id: string;
+  sparkId: string;
+  /** ISO 8601 */
+  createdAt: string;
+  /** ISO 8601 */
+  expiresAt: string;
+  amount: Money;
+  description?: string;
+  paymentRequest: string;
+  paymentHash: string;
+  receiverIdentityPubkey?: string;
+  transactionId: string;
+  userId: string;
+  accountId: string;
+  totalFee: Money;
+  version: number;
+};
+
+export type SparkReceiveQuote = SparkReceiveQuoteBase &
+  ({ type: 'LIGHTNING' } | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }) &
+  (
+    | { state: 'UNPAID' | 'EXPIRED' }
+    | { state: 'PAID'; paymentPreimage: string; sparkTransferId: string }
+    | { state: 'FAILED'; failureReason: string }
+  );

--- a/packages/wallet-sdk/src/types/transaction-details.ts
+++ b/packages/wallet-sdk/src/types/transaction-details.ts
@@ -11,103 +11,289 @@ import type { Money } from './money';
 import type { DestinationDetails } from './cashu';
 
 // --- Cashu token send ------------------------------------------------------
+/** Details of a CASHU_TOKEN SEND transaction. */
 export type CashuTokenSendTransactionDetails = {
+  /**
+   * The amount of the token sent.
+   * This is the sum of `amountReceived` and `cashuReceiveFee`.
+   */
   tokenAmount: Money;
+  /** The URL of the mint that issued the token. */
   tokenMintUrl: string;
+  /**
+   * Amount reserved for the send.
+   * This is the sum of the input proofs and is greater or equal to `tokenAmount`.
+   * When the source account doesn't have the exact amount of proofs required for `tokenAmount`, the transaction requires
+   * a swap, which then also incurs `cashuSendFee`. When this happens this amount is greater than the `amountReceived`
+   * plus `totalFee`.
+   */
   amountReserved: Money;
+  /**
+   * Amount debited from the account.
+   * When the transaction doesn't require a swap, this will be equal to `amountReserved`.
+   * When the transaction requires a swap, this will be equal to `amountReserved` until the swap is completed.
+   * After the swap is completed, this will be equal to the amount actually spent (`amountReceived` plus `totalFee`).
+   * Change is returned to the source account when the swap is completed.
+   */
   amount: Money;
+  /**
+   * Amount that the recipient receives.
+   * This is `amount` minus `totalFee`.
+   */
   amountReceived: Money;
+  /** The fee that we include in the token for the receiver to claim exactly `amountReceived`. */
   cashuReceiveFee: Money;
+  /**
+   * The swap fee that will be incurred when swapping the input proofs to get `tokenAmount` worth of proofs to send.
+   * When the `amountReserved` equals `tokenAmount`, no swap is needed and this will be zero.
+   */
   cashuSendFee: Money;
+  /**
+   * The total fee for the transaction.
+   * This is the sum of `cashuSendFee` and `cashuReceiveFee`.
+   */
   totalFee: Money;
 };
 
 // --- Cashu token receive ---------------------------------------------------
+/** Details of a CASHU_TOKEN RECEIVE transaction. */
 export type CashuTokenReceiveTransactionDetails = {
+  /** The amount of the token being claimed. */
   tokenAmount: Money;
+  /** The URL of the mint that issued the token. */
   tokenMintUrl: string;
+  /** The description of the transaction. */
   description?: string;
+  /**
+   * Amount credited to the account.
+   * This is the `tokenAmount` minus `totalFee`.
+   */
   amount: Money;
+  /**
+   * The cashu fee for the receive.
+   * When receiving to the same mint as the one that issued the token, this is the fee for the swap inputs.
+   * When receiving to a different mint or to Spark, this is the fee for the melt inputs.
+   */
   cashuReceiveFee: Money;
+  /**
+   * The fee that the destination mint charged to mint the ecash.
+   * This is defined only when the token is received to cashu account with mint different than the one that issued the token being received,
+   * but only if the destination mint has a minting fee.
+   * In this case the receiving account creates a mint quote, and then the ln invoice of the mint quote is paid by melting the token proofs.
+   */
   mintingFee?: Money;
+  /**
+   * The fee reserved for the lightning payment.
+   * This is defined when receving the token to spark account or cashu account with mint different than the one that issued the token being
+   * received.
+   */
   lightningFeeReserve?: Money;
+  /**
+   * The total fee for the transaction.
+   * This is the sum of `cashuReceiveFee`, `lightningFeeReserve`, and `mintingFee`.
+   * We are currently not returning the change to the user for cashu token receives over lightning which is why `lightningFeeReserve` is calculated
+   * as the fee instead of the actual lightning fee for the melt.
+   */
   totalFee: Money;
 };
 
 // --- Cashu lightning send (Incomplete | Completed) -------------------------
+/** Details of a CASHU_LIGHTNING SEND transaction that is not yet completed. */
 export type IncompleteCashuLightningSendTransactionDetails = {
+  /** The bolt11 payment request the the transaction is paying. */
   paymentRequest: string;
+  /** Payment hash of the lightning invoice. */
   paymentHash: string;
+  /**
+   * Additional details related to the transaction.
+   * This will be undefined if the send is directly paying a bolt11.
+   */
   destinationDetails?: DestinationDetails;
+  /**
+   * The amount reserved for the send.
+   * This is the sum of all proofs used as inputs to the cashu melt operation.
+   * These proofs are reserved until the send is completed or failed.
+   * When the send is completed, the change is returned to the account.
+   */
   amountReserved: Money;
+  /**
+   * Amount that the receiver receives.
+   * This is the amount requested in the currency of the account we are sending from.
+   * If the currency of the account we are sending from is not BTC, the mint will do
+   * the conversion using their exchange rate at the time of quote creation.
+   */
   amountReceived: Money;
+  /**
+   * The amount reserved to cover the maximum potential Lightning Network fee.
+   * If the actual Lightning fee ends up being lower than this reserve,
+   * the difference is returned as change to the user.
+   */
   lightningFeeReserve: Money;
+  /** The fee incurred to spend the proofs in the cashu melt operation. */
   cashuSendFee: Money;
+  /**
+   * Estimated total fee for the transaction.
+   * This is the sum of `lightningFeeReserve` and `cashuSendFee` and is the max potential fee for the transaction.
+   */
   estimatedTotalFee: Money;
+  /**
+   * The amount debited from the account.
+   * When the transaction is not completed, this is equal to `amountReserved`.
+   * When the transaction is completed, this is equal to the sum of `amountReceived` and `totalFee`.
+   * This is the sum of `amountReceived` and `totalFee`.
+   */
   amount: Money;
+  /** UUID linking paired send/receive transactions for internal transfers. */
   transferId?: string;
 };
+/** Details of a completed CASHU_LIGHTNING SEND transaction. */
 export type CompletedCashuLightningSendTransactionDetails =
   IncompleteCashuLightningSendTransactionDetails & {
+    /**
+     * The preimage of the lightning payment.
+     * If the lightning payment is settled internally in the mint, this will be an empty string or '0x0000000000000000000000000000000000000000000000000000000000000000'
+     */
     preimage: string;
+    /**
+     * The actual Lightning Network fee that was charged after the transaction completed.
+     * This may be less than the `lightningFeeReserve` if the payment was cheaper than expected.
+     * The difference between `lightningFeeReserve` and `lightningFee`, along with any overpaid inputs, is returned as change to the user.
+     */
     lightningFee: Money;
+    /**
+     * The total fee for the transaction.
+     * This is the sum of `lightningFee` and `cashuSendFee`.
+     */
     totalFee: Money;
   };
+/** Details of a CASHU_LIGHTNING SEND transaction (incomplete or completed). */
 export type CashuLightningSendTransactionDetails =
   | IncompleteCashuLightningSendTransactionDetails
   | CompletedCashuLightningSendTransactionDetails;
 
 // --- Cashu lightning receive ----------------------------------------------
+/** Details of a CASHU_LIGHTNING RECEIVE transaction. */
 export type CashuLightningReceiveTransactionDetails = {
+  /**
+   * The bolt11 payment request.
+   * If the mint has a minting fee, the amount in the payment request will be a sum of `amount` and `mintingFee`.
+   */
   paymentRequest: string;
+  /** The payment hash of the lightning invoice. */
   paymentHash: string;
+  /** The description of the transaction. */
   description?: string;
+  /**
+   * Optional fee charged by the mint to deposit money into the account.
+   * The payer of the lightning invoice pays this fee.
+   */
   mintingFee?: Money;
+  /** The amount credited to the account. */
   amount: Money;
+  /**
+   * The total fee for the receive.
+   * In this case it is equal to `mintingFee` or zero if the mint has no minting fee.
+   */
   totalFee: Money;
+  /** UUID linking paired send/receive transactions for internal transfers. */
   transferId?: string;
 };
 
 // --- Spark lightning send (Incomplete | Completed) -------------------------
+/** Details of a SPARK_LIGHTNING SEND transaction that is not yet completed. */
 export type IncompleteSparkLightningSendTransactionDetails = {
+  /**
+   * Amount that the receiver receives.
+   * This is the invoice amount in the currency of the account we are sending from.
+   */
   amountReceived: Money;
+  /**
+   * The estimated fee for the Lightning Network payment.
+   * If the actual fee ends up being different than this estimate, the completed transaction will reflect the actual fee paid.
+   */
   estimatedFee: Money;
+  /** Bolt 11 payment request. */
   paymentRequest: string;
+  /** The payment hash of the lightning invoice. */
   paymentHash: string;
+  /**
+   * Amount debited from the account.
+   * While the transaction is not initiated yet and actual fee is not known, this will be the sum of `amountReceived` and `estimatedFee`.
+   * This should be a very brief period of time, since the payment is initiated immediately after the quote is created.
+   * When the transaction is initiated, and the actual fee is known, this will be the sum of `amountReceived` and `totalFee`.
+   */
   amount: Money;
+  /**
+   * The actual fee for the transaction.
+   * While the transaction is not initiated yet and actual fee is not known, this will be equal to `estimatedFee`.
+   * This should be a very brief period of time, since the payment is initiated immediately after the quote is created.
+   * Once the transaction is initiated, this will be set to actual fee spent for the transaction.
+   */
   fee: Money;
+  /**
+   * The ID of the send request in Spark system.
+   * Available after the payment is initiated.
+   */
   sparkId?: string;
+  /**
+   * The ID of the transfer in Spark system.
+   * Available after the payment is initiated.
+   */
   sparkTransferId?: string;
+  /** UUID linking paired send/receive transactions for internal transfers. */
   transferId?: string;
 };
+/** Details of a completed SPARK_LIGHTNING SEND transaction. */
 export type CompletedSparkLightningSendTransactionDetails =
   Required<IncompleteSparkLightningSendTransactionDetails> & {
+    /** The preimage of the lightning payment. */
     paymentPreimage: string;
+    /** transferId remains optional — only present for TRANSFER transactions. */
     transferId?: string;
   };
+/** Details of a SPARK_LIGHTNING SEND transaction (incomplete or completed). */
 export type SparkLightningSendTransactionDetails =
   | IncompleteSparkLightningSendTransactionDetails
   | CompletedSparkLightningSendTransactionDetails;
 
 // --- Spark lightning receive (Incomplete | Completed) ----------------------
+/** Details of a SPARK_LIGHTNING RECEIVE transaction that is not yet completed. */
 export type IncompleteSparkLightningReceiveTransactionDetails = {
+  /** Bolt 11 payment request. */
   paymentRequest: string;
+  /** The payment hash of the lightning invoice. */
   paymentHash: string;
+  /** The ID of the receive request in Spark system. */
   sparkId: string;
+  /** The description of the transaction. */
   description?: string;
+  /**
+   * Amount credited to the account.
+   * This is the amount of the bolt 11 payment request.
+   */
   amount: Money;
+  /** UUID linking paired send/receive transactions for internal transfers. */
   transferId?: string;
 };
+/** Details of a completed SPARK_LIGHTNING RECEIVE transaction. */
 export type CompletedSparkLightningReceiveTransactionDetails =
   IncompleteSparkLightningReceiveTransactionDetails & {
+    /** The payment preimage of the lightning payment. */
     paymentPreimage: string;
+    /** The ID of the transfer in Spark system. */
     sparkTransferId: string;
   };
+/** Details of a SPARK_LIGHTNING RECEIVE transaction (incomplete or completed). */
 export type SparkLightningReceiveTransactionDetails =
   | IncompleteSparkLightningReceiveTransactionDetails
   | CompletedSparkLightningReceiveTransactionDetails;
 
 // --- The domain union ------------------------------------------------------
+/**
+ * The protocol-specific detail payload carried by a {@link Transaction}, narrowed
+ * by the transaction's type/direction/state. The SDK owns and exposes this domain
+ * union; the parallel DB-data union and its parsers stay SDK-internal.
+ */
 export type TransactionDetails =
   | CashuTokenSendTransactionDetails
   | CashuTokenReceiveTransactionDetails

--- a/packages/wallet-sdk/src/types/transaction-details.ts
+++ b/packages/wallet-sdk/src/types/transaction-details.ts
@@ -1,0 +1,117 @@
+/**
+ * TransactionDetails — the 6-variant PUBLIC domain union (§7 of the contract).
+ *
+ * Lifted verbatim (as the zod/mini `z.infer` shapes) from
+ * `app/features/transactions/transaction-details/transaction-details-types.ts`
+ * + the 6 per-variant files. The SDK OWNS this domain type (public); the parallel
+ * DB-data union + its `z.pipe` parsers are INTERNAL to the SDK (decision 7-ii) and
+ * are NOT part of PR1.
+ */
+import type { Money } from './money';
+import type { DestinationDetails } from './cashu';
+
+// --- Cashu token send ------------------------------------------------------
+export type CashuTokenSendTransactionDetails = {
+  tokenAmount: Money;
+  tokenMintUrl: string;
+  amountReserved: Money;
+  amount: Money;
+  amountReceived: Money;
+  cashuReceiveFee: Money;
+  cashuSendFee: Money;
+  totalFee: Money;
+};
+
+// --- Cashu token receive ---------------------------------------------------
+export type CashuTokenReceiveTransactionDetails = {
+  tokenAmount: Money;
+  tokenMintUrl: string;
+  description?: string;
+  amount: Money;
+  cashuReceiveFee: Money;
+  mintingFee?: Money;
+  lightningFeeReserve?: Money;
+  totalFee: Money;
+};
+
+// --- Cashu lightning send (Incomplete | Completed) -------------------------
+export type IncompleteCashuLightningSendTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  destinationDetails?: DestinationDetails;
+  amountReserved: Money;
+  amountReceived: Money;
+  lightningFeeReserve: Money;
+  cashuSendFee: Money;
+  estimatedTotalFee: Money;
+  amount: Money;
+  transferId?: string;
+};
+export type CompletedCashuLightningSendTransactionDetails =
+  IncompleteCashuLightningSendTransactionDetails & {
+    preimage: string;
+    lightningFee: Money;
+    totalFee: Money;
+  };
+export type CashuLightningSendTransactionDetails =
+  | IncompleteCashuLightningSendTransactionDetails
+  | CompletedCashuLightningSendTransactionDetails;
+
+// --- Cashu lightning receive ----------------------------------------------
+export type CashuLightningReceiveTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  description?: string;
+  mintingFee?: Money;
+  amount: Money;
+  totalFee: Money;
+  transferId?: string;
+};
+
+// --- Spark lightning send (Incomplete | Completed) -------------------------
+export type IncompleteSparkLightningSendTransactionDetails = {
+  amountReceived: Money;
+  estimatedFee: Money;
+  paymentRequest: string;
+  paymentHash: string;
+  amount: Money;
+  fee: Money;
+  sparkId?: string;
+  sparkTransferId?: string;
+  transferId?: string;
+};
+export type CompletedSparkLightningSendTransactionDetails =
+  Required<IncompleteSparkLightningSendTransactionDetails> & {
+    paymentPreimage: string;
+    transferId?: string;
+  };
+export type SparkLightningSendTransactionDetails =
+  | IncompleteSparkLightningSendTransactionDetails
+  | CompletedSparkLightningSendTransactionDetails;
+
+// --- Spark lightning receive (Incomplete | Completed) ----------------------
+export type IncompleteSparkLightningReceiveTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  sparkId: string;
+  description?: string;
+  amount: Money;
+  transferId?: string;
+};
+export type CompletedSparkLightningReceiveTransactionDetails =
+  IncompleteSparkLightningReceiveTransactionDetails & {
+    paymentPreimage: string;
+    sparkTransferId: string;
+  };
+export type SparkLightningReceiveTransactionDetails =
+  | IncompleteSparkLightningReceiveTransactionDetails
+  | CompletedSparkLightningReceiveTransactionDetails;
+
+// --- The domain union ------------------------------------------------------
+export type TransactionDetails =
+  | CashuTokenSendTransactionDetails
+  | CashuTokenReceiveTransactionDetails
+  | CashuLightningSendTransactionDetails
+  | CashuLightningReceiveTransactionDetails
+  | SparkLightningReceiveTransactionDetails
+  | SparkLightningSendTransactionDetails;

--- a/packages/wallet-sdk/src/types/transaction.ts
+++ b/packages/wallet-sdk/src/types/transaction.ts
@@ -23,42 +23,103 @@ import type {
 } from './transaction-details';
 
 // --- enums (transaction-enums.ts) ------------------------------------------
+
+/** Whether the transaction sends money out or receives it in. */
 export type TransactionDirection = 'SEND' | 'RECEIVE';
+
+/** Protocol + rail of the transaction. */
 export type TransactionType =
   | 'CASHU_LIGHTNING'
   | 'CASHU_TOKEN'
   | 'SPARK_LIGHTNING';
+
+/**
+ * State of the transaction.
+ * - DRAFT: The transaction is drafted but might never be initiated and thus completed.
+ * - PENDING: The transaction was initiated and is being processed.
+ * - COMPLETED: The transaction has been completed. At this point the sender cannot reverse the transaction.
+ * - FAILED: The transaction has failed.
+ * - REVERSED: The transaction was reversed and money was returned to the account.
+ */
 export type TransactionState =
   | 'DRAFT'
   | 'PENDING'
   | 'COMPLETED'
   | 'FAILED'
   | 'REVERSED';
+
+/** Why the transaction exists: an organic payment, a Cash App buy, or an internal transfer leg. */
 export type TransactionPurpose = 'PAYMENT' | 'BUY_CASHAPP' | 'TRANSFER';
 
 // --- BaseTransaction -------------------------------------------------------
+
+/** Fields shared by every transaction variant. */
 export type BaseTransaction = {
+  /** UUID of the transaction. */
   id: string;
+  /** UUID of the user that the transaction belongs to. */
   userId: string;
+  /** Direction of the transaction. */
   direction: TransactionDirection;
+  /** Type of the transaction. */
   type: TransactionType;
+  /**
+   * State of the transaction.
+   * Transaction states are:
+   * - DRAFT: The transaction is drafted but might never be initiated and thus completed.
+   * - PENDING: The transaction was initiated and is being processed.
+   * - COMPLETED: The transaction has been completed. At this point the sender cannot reverse the transaction.
+   * - FAILED: The transaction has failed.
+   * - REVERSED: The transaction was reversed and money was returned to the account.
+   */
   state: TransactionState;
-  /** null when the account was since deleted (denormalized fields still describe it). */
+  /**
+   * UUID of the account that the transaction was sent from or received to.
+   * For SEND transactions, it is the account that the transaction was sent from.
+   * For RECEIVE transactions, it is the account that the transaction was received to.
+   * Null when the account has since been deleted; the denormalized
+   * accountName/Type/Purpose fields still describe the account at the time
+   * of the transaction.
+   */
   accountId: string | null;
+  /** Name of the account at the time this transaction was created. */
   accountName: string;
+  /** Type of the account at the time this transaction was created. */
   accountType: AccountType;
+  /** Purpose of the account at the time this transaction was created. */
   accountPurpose: AccountPurpose;
+  /** Amount of the transaction. */
   amount: Money;
+  /** Transaction details. */
   details: TransactionDetails;
+  /** UUID of the transaction that is reversed by this transaction. */
   reversedTransactionId?: string | null;
+  /**
+   * The purpose of this transaction (e.g. a Cash App buy or an internal transfer).
+   * Defaults to 'PAYMENT' for organic send/receive transactions.
+   */
   purpose: TransactionPurpose;
+  /**
+   * Whether or not the transaction has been acknowledged by the user.
+   * - `null`: There is nothing to acknowledge.
+   * - `pending`: The transaction has entered a state where the user should acknowledge it.
+   * - `acknowledged`: The transaction has been acknowledged by the user.
+   */
   acknowledgmentStatus: 'pending' | 'acknowledged' | null;
-  /** ISO 8601 */
+  /** Date and time the transaction was created in ISO 8601 format. */
   createdAt: string;
+  /** Date and time the transaction was set to pending in ISO 8601 format. */
   pendingAt?: string | null;
+  /** Date and time the transaction was completed in ISO 8601 format. */
   completedAt?: string | null;
+  /** Date and time the transaction failed in ISO 8601 format. */
   failedAt?: string | null;
+  /** Date and time the transaction was reversed in ISO 8601 format. */
   reversedAt?: string | null;
+  /**
+   * Version of the transaction.
+   * Incremented on every update.
+   */
   version: number;
 };
 
@@ -127,6 +188,12 @@ type TransactionByType =
   | IncompleteSparkLightningSendTransaction
   | CompletedSparkLightningSendTransaction;
 
+/**
+ * A wallet transaction — the public history item. The union of the 9
+ * type/direction/state variants intersected with a purpose discriminator:
+ * `purpose: 'TRANSFER'` injects `details: { transferId }` (the leg of an internal
+ * transfer), otherwise `purpose: 'PAYMENT' | 'BUY_CASHAPP'`.
+ */
 export type Transaction =
   | (TransactionByType & {
       purpose: 'TRANSFER';
@@ -134,9 +201,15 @@ export type Transaction =
     })
   | (TransactionByType & { purpose: 'PAYMENT' | 'BUY_CASHAPP' });
 
-/** Cursor pagination (state-sorted: PENDING first). */
+/**
+ * Opaque pagination cursor for {@link TransactionsDomain.list}. Encodes the
+ * state-sort key (PENDING first) plus `createdAt`/`id` for stable ordering.
+ */
 export type TransactionCursor = {
+  /** Sort rank derived from transaction state (PENDING sorts first). */
   stateSortOrder: number;
+  /** ISO 8601 creation time of the boundary row. */
   createdAt: string;
+  /** UUID of the boundary row (tie-breaker). */
   id: string;
 };

--- a/packages/wallet-sdk/src/types/transaction.ts
+++ b/packages/wallet-sdk/src/types/transaction.ts
@@ -1,0 +1,136 @@
+/**
+ * Transaction domain types — §7 of the contract.
+ *
+ * Lifted verbatim (as the zod/mini `z.infer` shapes) from
+ * `app/features/transactions/transaction.ts` + `transaction-enums.ts`:
+ * a union of 9 (type × direction × state) variants ∧ a purpose-discriminator.
+ * `purpose: 'TRANSFER'` injects `details: { transferId }`, else
+ * `purpose: 'PAYMENT' | 'BUY_CASHAPP'`.
+ */
+import type { Money } from './money';
+import type { AccountPurpose, AccountType } from './account';
+import type {
+  CashuLightningReceiveTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
+  CashuTokenSendTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  CompletedSparkLightningReceiveTransactionDetails,
+  CompletedSparkLightningSendTransactionDetails,
+  IncompleteCashuLightningSendTransactionDetails,
+  IncompleteSparkLightningReceiveTransactionDetails,
+  IncompleteSparkLightningSendTransactionDetails,
+  TransactionDetails,
+} from './transaction-details';
+
+// --- enums (transaction-enums.ts) ------------------------------------------
+export type TransactionDirection = 'SEND' | 'RECEIVE';
+export type TransactionType = 'CASHU_LIGHTNING' | 'CASHU_TOKEN' | 'SPARK_LIGHTNING';
+export type TransactionState =
+  | 'DRAFT'
+  | 'PENDING'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'REVERSED';
+export type TransactionPurpose = 'PAYMENT' | 'BUY_CASHAPP' | 'TRANSFER';
+
+// --- BaseTransaction -------------------------------------------------------
+export type BaseTransaction = {
+  id: string;
+  userId: string;
+  direction: TransactionDirection;
+  type: TransactionType;
+  state: TransactionState;
+  /** null when the account was since deleted (denormalized fields still describe it). */
+  accountId: string | null;
+  accountName: string;
+  accountType: AccountType;
+  accountPurpose: AccountPurpose;
+  amount: Money;
+  details: TransactionDetails;
+  reversedTransactionId?: string | null;
+  purpose: TransactionPurpose;
+  acknowledgmentStatus: 'pending' | 'acknowledged' | null;
+  /** ISO 8601 */
+  createdAt: string;
+  pendingAt?: string | null;
+  completedAt?: string | null;
+  failedAt?: string | null;
+  reversedAt?: string | null;
+  version: number;
+};
+
+// --- the 9 type×direction(×state) variants, each pinning a concrete `details`
+type CashuTokenSendTransaction = BaseTransaction & {
+  type: 'CASHU_TOKEN';
+  direction: 'SEND';
+  details: CashuTokenSendTransactionDetails;
+};
+type CashuTokenReceiveTransaction = BaseTransaction & {
+  type: 'CASHU_TOKEN';
+  direction: 'RECEIVE';
+  details: CashuTokenReceiveTransactionDetails;
+};
+type IncompleteCashuLightningSendTransaction = BaseTransaction & {
+  type: 'CASHU_LIGHTNING';
+  direction: 'SEND';
+  state: 'PENDING' | 'FAILED';
+  details: IncompleteCashuLightningSendTransactionDetails;
+};
+type CompletedCashuLightningSendTransaction = BaseTransaction & {
+  type: 'CASHU_LIGHTNING';
+  direction: 'SEND';
+  state: 'COMPLETED';
+  details: CompletedCashuLightningSendTransactionDetails;
+};
+type CashuLightningReceiveTransaction = BaseTransaction & {
+  type: 'CASHU_LIGHTNING';
+  direction: 'RECEIVE';
+  details: CashuLightningReceiveTransactionDetails;
+};
+type IncompleteSparkLightningReceiveTransaction = BaseTransaction & {
+  type: 'SPARK_LIGHTNING';
+  direction: 'RECEIVE';
+  state: 'DRAFT' | 'PENDING' | 'FAILED';
+  details: IncompleteSparkLightningReceiveTransactionDetails;
+};
+type CompletedSparkLightningReceiveTransaction = BaseTransaction & {
+  type: 'SPARK_LIGHTNING';
+  direction: 'RECEIVE';
+  state: 'COMPLETED';
+  details: CompletedSparkLightningReceiveTransactionDetails;
+};
+type IncompleteSparkLightningSendTransaction = BaseTransaction & {
+  type: 'SPARK_LIGHTNING';
+  direction: 'SEND';
+  state: 'DRAFT' | 'PENDING' | 'FAILED';
+  details: IncompleteSparkLightningSendTransactionDetails;
+};
+type CompletedSparkLightningSendTransaction = BaseTransaction & {
+  type: 'SPARK_LIGHTNING';
+  direction: 'SEND';
+  state: 'COMPLETED';
+  details: CompletedSparkLightningSendTransactionDetails;
+};
+
+/** Union of all transaction type/direction/state variants. */
+type TransactionByType =
+  | CashuTokenSendTransaction
+  | CashuTokenReceiveTransaction
+  | IncompleteCashuLightningSendTransaction
+  | CompletedCashuLightningSendTransaction
+  | CashuLightningReceiveTransaction
+  | IncompleteSparkLightningReceiveTransaction
+  | CompletedSparkLightningReceiveTransaction
+  | IncompleteSparkLightningSendTransaction
+  | CompletedSparkLightningSendTransaction;
+
+export type Transaction =
+  | (TransactionByType & { purpose: 'TRANSFER'; details: { transferId: string } })
+  | (TransactionByType & { purpose: 'PAYMENT' | 'BUY_CASHAPP' });
+
+/** Cursor pagination (state-sorted: PENDING first). */
+export type TransactionCursor = {
+  stateSortOrder: number;
+  createdAt: string;
+  id: string;
+};

--- a/packages/wallet-sdk/src/types/transaction.ts
+++ b/packages/wallet-sdk/src/types/transaction.ts
@@ -24,7 +24,10 @@ import type {
 
 // --- enums (transaction-enums.ts) ------------------------------------------
 export type TransactionDirection = 'SEND' | 'RECEIVE';
-export type TransactionType = 'CASHU_LIGHTNING' | 'CASHU_TOKEN' | 'SPARK_LIGHTNING';
+export type TransactionType =
+  | 'CASHU_LIGHTNING'
+  | 'CASHU_TOKEN'
+  | 'SPARK_LIGHTNING';
 export type TransactionState =
   | 'DRAFT'
   | 'PENDING'
@@ -125,7 +128,10 @@ type TransactionByType =
   | CompletedSparkLightningSendTransaction;
 
 export type Transaction =
-  | (TransactionByType & { purpose: 'TRANSFER'; details: { transferId: string } })
+  | (TransactionByType & {
+      purpose: 'TRANSFER';
+      details: { transferId: string };
+    })
   | (TransactionByType & { purpose: 'PAYMENT' | 'BUY_CASHAPP' });
 
 /** Cursor pagination (state-sorted: PENDING first). */

--- a/packages/wallet-sdk/src/types/transfer.ts
+++ b/packages/wallet-sdk/src/types/transfer.ts
@@ -1,0 +1,32 @@
+/**
+ * Transfer domain types — §9 of the contract (cross-account, cashu<->spark via LN).
+ *
+ * Shapes per the contract. `TransferQuote` is ephemeral (not persisted); the
+ * paired send+receive quotes persist, linked by `transferId`.
+ *
+ * NOTE: the contract's `TransferLeg` ({ account; fee }) is a deliberately slimmer
+ * public shape than master's internal `TransferReceiveSide`/`TransferSendSide`
+ * (which also carry the live `lightningQuote`). PR1 follows the contract's public
+ * shape; the internal sides stay SDK-internal (Slice 4).
+ */
+import type { CashuAccount, SparkAccount } from './account';
+import type { Money } from './money';
+
+export type TransferLeg =
+  | { account: CashuAccount; fee: Money }
+  | { account: SparkAccount; fee: Money };
+
+export type TransferQuote = {
+  amount: Money;
+  amountToReceive: Money;
+  totalFees: Money;
+  totalCost: Money;
+  receive: TransferLeg;
+  send: TransferLeg;
+};
+
+export type TransferResult = {
+  transferId: string;
+  receiveTransactionId: string;
+  sendTransactionId: string;
+};

--- a/packages/wallet-sdk/src/types/transfer.ts
+++ b/packages/wallet-sdk/src/types/transfer.ts
@@ -12,21 +12,46 @@
 import type { CashuAccount, SparkAccount } from './account';
 import type { Money } from './money';
 
+/**
+ * One side (source or destination) of a transfer: the account involved and the
+ * fee charged on that leg. A deliberately slimmer public shape than master's
+ * internal `TransferSendSide`/`TransferReceiveSide` (which also carry the live
+ * lightning quote).
+ */
 export type TransferLeg =
   | { account: CashuAccount; fee: Money }
   | { account: SparkAccount; fee: Money };
 
+/**
+ * An ephemeral cost preview for a cross-account transfer (cashu↔spark via
+ * Lightning), produced by {@link TransfersDomain.createQuote}. Not persisted —
+ * the underlying paired send+receive quotes persist, linked by `transferId`.
+ */
 export type TransferQuote = {
+  /** The amount the user asked to transfer. */
   amount: Money;
+  /** What the destination account will actually receive after fees. */
   amountToReceive: Money;
+  /** Sum of both legs' fees. */
   totalFees: Money;
+  /** Total debited from the source: `amountToReceive` + `totalFees`. */
   totalCost: Money;
+  /** The destination leg (account credited + its fee). */
   receive: TransferLeg;
+  /** The source leg (account debited + its fee). */
   send: TransferLeg;
 };
 
+/**
+ * The outcome of {@link TransfersDomain.executeQuote}. A transfer is TWO
+ * transactions — a debit and a credit — linked by `transferId`; this returns the
+ * ids of both plus the shared link.
+ */
 export type TransferResult = {
+  /** Links the paired send + receive transactions. */
   transferId: string;
+  /** UUID of the credit (receive) transaction. */
   receiveTransactionId: string;
+  /** UUID of the debit (send) transaction. */
   sendTransactionId: string;
 };

--- a/packages/wallet-sdk/src/types/user.ts
+++ b/packages/wallet-sdk/src/types/user.ts
@@ -1,0 +1,36 @@
+/**
+ * User domain types — §4 of the contract.
+ *
+ * Lifted verbatim from `app/features/user/user.ts`:
+ * `User = CommonUserData ∧ (FullUser | GuestUser)`.
+ */
+import type { Currency } from './money';
+
+type CommonUserData = {
+  id: string;
+  username: string;
+  emailVerified: boolean;
+  /** ISO 8601 */
+  createdAt: string;
+  /** ISO 8601 */
+  updatedAt: string;
+  defaultBtcAccountId: string;
+  defaultUsdAccountId: string | null;
+  defaultCurrency: Currency;
+  cashuLockingXpub: string;
+  encryptionPublicKey: string;
+  sparkIdentityPublicKey: string;
+  termsAcceptedAt: string | null;
+  giftCardMintTermsAcceptedAt: string | null;
+};
+
+export type FullUser = CommonUserData & {
+  email: string;
+  isGuest: false;
+};
+
+export type GuestUser = CommonUserData & {
+  isGuest: true;
+};
+
+export type User = FullUser | GuestUser;

--- a/packages/wallet-sdk/src/types/user.ts
+++ b/packages/wallet-sdk/src/types/user.ts
@@ -6,31 +6,50 @@
  */
 import type { Currency } from './money';
 
+/** Fields shared by every user, whether full (email) or guest. */
 type CommonUserData = {
+  /** UUID of the user. */
   id: string;
+  /** The user's unique handle within the app. */
   username: string;
+  /** Whether the user has verified their email address. */
   emailVerified: boolean;
-  /** ISO 8601 */
+  /** Account creation time, ISO 8601. */
   createdAt: string;
-  /** ISO 8601 */
+  /** Last update time, ISO 8601. */
   updatedAt: string;
+  /** UUID of the account used by default for BTC. */
   defaultBtcAccountId: string;
+  /** UUID of the account used by default for USD, or null if none. */
   defaultUsdAccountId: string | null;
+  /** The user's preferred display currency. */
   defaultCurrency: Currency;
+  /** Extended public key used to derive cashu quote-locking keys. */
   cashuLockingXpub: string;
+  /** Public key used to encrypt the user's data at rest. */
   encryptionPublicKey: string;
+  /** The user's Spark identity public key. */
   sparkIdentityPublicKey: string;
+  /** When the user accepted the terms of service (null if not yet accepted). */
   termsAcceptedAt: string | null;
+  /** When the user accepted the gift-card mint terms (null if not yet accepted). */
   giftCardMintTermsAcceptedAt: string | null;
 };
 
+/** A signed-up user with a verified-or-pending email address. */
 export type FullUser = CommonUserData & {
+  /** The user's email address. */
   email: string;
   isGuest: false;
 };
 
+/** An anonymous guest user (no email); can be upgraded to a {@link FullUser}. */
 export type GuestUser = CommonUserData & {
   isGuest: true;
 };
 
+/**
+ * The current user — either a {@link FullUser} or a {@link GuestUser}. Lifted
+ * verbatim from `app/features/user/user.ts`.
+ */
 export type User = FullUser | GuestUser;


### PR DESCRIPTION
PR1 of the **@agicash/wallet-sdk** build = **the contract as code**: the public domain types + domain interfaces (declarations only) + the `Sdk` class shape + `SdkConfig` + the event layer (`SdkEventMap` + `EventEmitter` interface) + the error classes. **No implementation** — no method bodies, no orchestrator, no wiring — per the no-cache SDK contract (`agicash-sdk-nocache-contract.md`). Domain types are lifted verbatim from master (§15 source map); it typechecks standalone (`tsc --noEmit`, TS 5.9.3) with **zero new runtime deps**.

**Type-dependency TODOs deferred to the implementation slices** (thin placeholders so the contract compiles standalone):
- `Money`/`Currency`/`CurrencyUnit` → re-export `app/lib/money` (Slice 0)
- `BreezSdk` → `@agicash/breez-sdk-spark` (Slice 0)
- `ExtendedCashuWallet`, `CashuProtocolProof`, `Proof` dleq/witness → SDK-internal `lib/cashu` (Slice 2/3)
- `SparkNetwork`, `DistributedOmit`, `Json` → json-models / `type-fest` / db types (Slice 2/4)
- `Bolt11Invoice` (master `DecodedBolt11`), `ParsedToken` (cashu-ts `TokenMetadata`) → `lib/bolt11` / `@cashu/cashu-ts` (Slice 2)
- `StorageAdapter` → `@agicash/opensecret-sdk` (Slice 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)