### PR TITLE
feat(wallet-sdk): reactive contract-as-code (PR1)

### DIFF
--- a/packages/wallet-sdk/src/domains.ts
+++ b/packages/wallet-sdk/src/domains.ts
@@ -1,0 +1,214 @@
+// All domain interfaces — reactive contract (design B)
+// Rule: observable fetch -> Query<T>;  derivation -> sync;  action/write -> Promise
+
+import type {
+  Account,
+  AddAccountConfig,
+  CashuAccount,
+  SparkAccount,
+} from './types/account';
+import type {
+  CashuReceiveQuote,
+  CashuSendQuote,
+  CashuSendSwap,
+  ReceiveTokenResult,
+} from './types/cashu';
+import type { Contact } from './types/contact';
+import type { BackgroundState } from './types/events';
+import type { Currency, Money } from './types/money';
+import type { Query } from './types/query';
+import type { ParsedDestination, PaymentIntent } from './types/scan';
+import type { SparkReceiveQuote, SparkSendQuote } from './types/spark';
+import type { Transaction, TransactionCursor } from './types/transaction';
+import type { TransferQuote, TransferResult } from './types/transfer';
+import type { User, UserProfile } from './types/user';
+
+// ---- AccountSuggestion ----
+
+export type AccountSuggestion = {
+  recommended: Account;
+  alternatives: Account[]; // sufficient balance, lower priority
+  insufficient: Account[];
+  reason: string; // e.g. "gift-card-mint match" | "default cashu"
+};
+
+// ---- Auth param shapes ----
+
+export type SignInParams = { email: string; password: string };
+export type SignUpParams = { email: string; password: string };
+export type ChangePasswordParams = { current: string; new: string };
+export type UpgradeGuestParams = { email: string; password: string };
+export type CompleteOAuthParams = { code: string; state?: string };
+
+// ---- Domains ----
+
+export interface AccountsDomain {
+  /** Observable fetch — returns Query<T> */
+  list(): Query<Account[]>;
+  /** Observable fetch — returns Query<T> */
+  get(id: string): Query<Account | null>;
+  /** Observable fetch — returns Query<T> */
+  getDefault(params?: { currency?: Currency }): Query<Account | null>;
+  /** Pure derivation — sync */
+  getBalance(account: Account): Money;
+  /** Pure derivation over passed-in accounts — sync */
+  suggestFor(intent: PaymentIntent, accounts: Account[]): AccountSuggestion;
+  add(config: AddAccountConfig): Promise<Account>;
+  setDefault(account: Account): Promise<void>;
+}
+
+export interface ScanDomain {
+  parse(input: string): Promise<ParsedDestination>;
+}
+
+export interface AuthDomain {
+  signIn(params: SignInParams): Promise<User>;
+  signUp(params: SignUpParams): Promise<User>;
+  signInGuest(): Promise<User>;
+  signOut(): Promise<void>;
+  refresh(): Promise<void>;
+  resetPassword(email: string): Promise<void>;
+  changePassword(params: ChangePasswordParams): Promise<void>;
+  upgradeGuest(params: UpgradeGuestParams): Promise<User>;
+  /** Web-only; MCP daemon cannot do Google auth */
+  beginGoogleSignIn(): Promise<{ authUrl: string }>;
+  completeOAuth(params: CompleteOAuthParams): Promise<User>;
+}
+
+export interface UserDomain {
+  /** Observable fetch — returns Query<T> */
+  getCurrentUser(): Query<User | null>;
+  /** throws DomainError if the username is taken */
+  updateUsername(username: string): Promise<User>;
+}
+
+export interface CashuSendOps {
+  /** destination = bolt11 OR ln-address (resolved internally via LNURL-pay) */
+  createLightningQuote(params: {
+    account: CashuAccount;
+    destination: string;
+    amount?: Money;
+  }): Promise<CashuSendQuote>;
+  createTokenQuote(params: {
+    account: CashuAccount;
+    amount: Money;
+  }): Promise<CashuSendSwap>;
+  /**
+   * Orchestrator kickoff — resolves on kick-off; terminal state arrives via send:completed/send:failed.
+   * FULL OBJECT — caller passes the quote it just received.
+   */
+  executeQuote(quote: CashuSendQuote): Promise<CashuSendQuote>;
+  failQuote(quote: CashuSendQuote, reason: string): Promise<void>;
+  /**
+   * User-initiated reclaim of a PENDING token-send.
+   * FULL OBJECT; gated PENDING (isTransactionReversable).
+   */
+  reverse(swap: CashuSendSwap): Promise<CashuSendSwap>;
+  /** Observable fetch — returns Query<T> */
+  get(id: string): Query<CashuSendQuote | CashuSendSwap | null>;
+}
+
+export interface CashuReceiveOps {
+  /**
+   * Claim a received cashu token. The receive-swap/quote is internal (DB-persisted,
+   * processor-driven). Swallows errors to result (mirrors master claimToken).
+   * destinationAccount omitted -> default same-mint resolution.
+   */
+  receiveToken(params: {
+    token: string;
+    destinationAccount?: Account;
+  }): Promise<ReceiveTokenResult>;
+  createLightningQuote(params: {
+    account: CashuAccount;
+    amount: Money;
+    purpose?: 'PAYMENT' | 'BUY_CASHAPP';
+  }): Promise<CashuReceiveQuote>;
+  /** Observable fetch — returns Query<T> */
+  get(quoteId: string): Query<CashuReceiveQuote | null>;
+}
+
+export interface CashuDomain {
+  send: CashuSendOps;
+  receive: CashuReceiveOps;
+}
+
+export interface SparkSendOps {
+  /** destination = bolt11 OR ln-address (resolved internally via LNURL-pay) */
+  createLightningQuote(params: {
+    account: SparkAccount;
+    destination: string;
+    amount?: Money;
+  }): Promise<SparkSendQuote>;
+  /**
+   * FULL OBJECT; Breez sendPayment, UNPAID->PENDING, terminal via Breez callback.
+   */
+  executeQuote(quote: SparkSendQuote): Promise<SparkSendQuote>;
+  failQuote(quote: SparkSendQuote, reason: string): Promise<void>;
+  /** Observable fetch — returns Query<T> */
+  get(quoteId: string): Query<SparkSendQuote | null>;
+}
+
+export interface SparkReceiveOps {
+  createLightningQuote(params: {
+    account: SparkAccount;
+    amount: Money;
+    description?: string;
+    purpose?: 'PAYMENT' | 'BUY_CASHAPP';
+  }): Promise<SparkReceiveQuote>;
+  /** Observable fetch — returns Query<T> */
+  get(quoteId: string): Query<SparkReceiveQuote | null>;
+}
+
+export interface SparkDomain {
+  send: SparkSendOps;
+  receive: SparkReceiveOps;
+}
+
+export interface TransactionsDomain {
+  /** Observable fetch — returns Query<T> */
+  list(params?: {
+    accountId?: string;
+    cursor?: TransactionCursor;
+    pageSize?: number;
+  }): Query<{
+    transactions: Transaction[];
+    nextCursor: TransactionCursor | null;
+  }>;
+  /** Observable fetch — returns Query<T> */
+  get(id: string): Query<Transaction | null>;
+  /** Observable fetch — returns Query<T> */
+  countPendingAck(): Query<number>;
+  acknowledge(transaction: Transaction): Promise<void>;
+}
+
+export interface ContactsDomain {
+  /** Observable fetch — returns Query<T> */
+  list(): Query<Contact[]>;
+  /** Observable fetch — returns Query<T> */
+  get(id: string): Query<Contact | null>;
+  add(params: { username: string }): Promise<Contact>;
+  remove(contact: Contact): Promise<void>;
+  /** One-shot search — min 3 chars, excludes existing contacts */
+  search(params: { query: string }): Promise<UserProfile[]>;
+}
+
+export interface TransfersDomain {
+  createQuote(params: {
+    sourceAccount: Account;
+    destinationAccount: Account;
+    amount: Money;
+  }): Promise<TransferQuote>;
+  executeQuote(quote: TransferQuote): Promise<TransferResult>;
+}
+
+export interface BackgroundDomain {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  /** Observable fetch — returns Query<T> */
+  state(): Query<BackgroundState>;
+}
+
+export interface ExchangeRateDomain {
+  /** Observable fetch — returns Query<T> */
+  get(params: { from: Currency; to: Currency }): Query<Money>;
+}

--- a/packages/wallet-sdk/src/helpers.ts
+++ b/packages/wallet-sdk/src/helpers.ts
@@ -1,0 +1,7 @@
+// Exported pure helpers
+
+/**
+ * Returns the CashApp deep-link URL for a Lightning payment request.
+ * Pure — the amount is already encoded in the invoice.
+ */
+export declare function cashAppDeepLink(paymentRequest: string): string;

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -1,1 +1,126 @@
-// @agicash/wallet-sdk
+// @agicash/wallet-sdk — reactive contract (design B)
+// TanStack is hidden behind Query<T>; reads return Query<T>, derivations are sync, writes return Promise.
+
+// ---- Core reactive types ----
+export type { Query, QueryState } from './types/query';
+
+// ---- Value types ----
+export type { Money, Currency } from './types/money';
+
+// ---- Error classes + classifier ----
+export {
+  SdkError,
+  ConcurrencyError,
+  DomainError,
+  NotFoundError,
+  classify,
+} from './types/errors';
+
+// ---- Events ----
+export type {
+  SdkEventMap,
+  EventEmitter,
+  BackgroundState,
+} from './types/events';
+
+// ---- Domain types ----
+export type {
+  AccountType,
+  AccountState,
+  AccountPurpose,
+  SparkNetwork,
+  ProofDleq,
+  ProofWitness,
+  CashuProof,
+  ExtendedCashuWallet,
+  BreezSdk,
+  Account,
+  ExtendedAccount,
+  CashuAccount,
+  SparkAccount,
+  RedactedAccount,
+  AddAccountConfig,
+} from './types/account';
+
+export type { User, UserProfile } from './types/user';
+
+export type {
+  Bolt11Invoice,
+  ParsedToken,
+  ParsedDestination,
+  PaymentIntent,
+} from './types/scan';
+
+export type {
+  DestinationDetails,
+  CashuSendQuote,
+  CashuSendSwap,
+  CashuTokenMeltData,
+  CashuReceiveQuote,
+  ReceiveTokenResult,
+} from './types/cashu';
+
+export type { SparkSendQuote, SparkReceiveQuote } from './types/spark';
+
+export type {
+  TransactionDirection,
+  TransactionType,
+  TransactionState,
+  TransactionPurpose,
+  TransactionDetails,
+  CashuTokenSendTransactionDetails,
+  CashuTokenReceiveTransactionDetails,
+  IncompleteCashuLightningSendTransactionDetails,
+  CompletedCashuLightningSendTransactionDetails,
+  CashuLightningSendTransactionDetails,
+  CashuLightningReceiveTransactionDetails,
+  IncompleteSparkLightningSendTransactionDetails,
+  CompletedSparkLightningSendTransactionDetails,
+  SparkLightningSendTransactionDetails,
+  IncompleteSparkLightningReceiveTransactionDetails,
+  CompletedSparkLightningReceiveTransactionDetails,
+  SparkLightningReceiveTransactionDetails,
+  BaseTransaction,
+  Transaction,
+  TransactionCursor,
+} from './types/transaction';
+
+export type { Contact } from './types/contact';
+
+export type {
+  TransferLeg,
+  TransferQuote,
+  TransferResult,
+} from './types/transfer';
+
+// ---- Domain interfaces ----
+export type {
+  AccountSuggestion,
+  SignInParams,
+  SignUpParams,
+  ChangePasswordParams,
+  UpgradeGuestParams,
+  CompleteOAuthParams,
+  AccountsDomain,
+  ScanDomain,
+  AuthDomain,
+  UserDomain,
+  CashuSendOps,
+  CashuReceiveOps,
+  CashuDomain,
+  SparkSendOps,
+  SparkReceiveOps,
+  SparkDomain,
+  TransactionsDomain,
+  ContactsDomain,
+  TransfersDomain,
+  BackgroundDomain,
+  ExchangeRateDomain,
+} from './domains';
+
+// ---- Sdk class + config ----
+export type { StorageAdapter, SdkConfig } from './sdk';
+export { Sdk } from './sdk';
+
+// ---- Pure helpers ----
+export { cashAppDeepLink } from './helpers';

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -1,0 +1,75 @@
+// Sdk class shape + SdkConfig
+
+import type {
+  AccountsDomain,
+  AuthDomain,
+  BackgroundDomain,
+  CashuDomain,
+  ContactsDomain,
+  ExchangeRateDomain,
+  ScanDomain,
+  SparkDomain,
+  TransactionsDomain,
+  TransfersDomain,
+  UserDomain,
+} from './domains';
+import type { EventEmitter, SdkEventMap } from './types/events';
+
+// ---- StorageAdapter (pluggable — web=browser, mcp=fs/sqlite) ----
+
+export interface StorageAdapter {
+  getItem(key: string): string | null | Promise<string | null>;
+  setItem(key: string, value: string): void | Promise<void>;
+  removeItem(key: string): void | Promise<void>;
+}
+
+// ---- SdkConfig ----
+
+export type SdkConfig = {
+  /** Enclave/auth backend (VITE_OPEN_SECRET_API_URL + _CLIENT_ID) */
+  openSecret: { url: string; clientId: string };
+  /**
+   * DB/realtime; schema pinned to 'wallet'.
+   * Access token = the OpenSecret JWT (RLS-scoped).
+   * SDK OWNS the client — consumer never gets a handle, only provides these params.
+   */
+  supabase: { url: string; anonKey: string; serviceRoleKey?: string };
+  /** Spark/Breez SDK */
+  breezApiKey?: string;
+  /** Pluggable storage — web = browser, mcp = fs/sqlite */
+  storage: StorageAdapter;
+  /**
+   * SDK leader-election INSTANCE id (auto-generated if omitted).
+   * Distinct from openSecret.clientId.
+   */
+  clientId?: string;
+  /**
+   * App domain for LN-address composition (Contact.lud16 = `${username}@${domain}`).
+   * Defaults to '' — set it for valid LN-address/contact features.
+   */
+  domain?: string;
+};
+
+// ---- Sdk ----
+
+export declare class Sdk {
+  static create(config: SdkConfig): Promise<Sdk>;
+
+  readonly auth: AuthDomain;
+  readonly user: UserDomain;
+  readonly accounts: AccountsDomain;
+  readonly cashu: CashuDomain;
+  readonly spark: SparkDomain;
+  readonly transactions: TransactionsDomain;
+  readonly contacts: ContactsDomain;
+  readonly transfers: TransfersDomain;
+  readonly scan: ScanDomain;
+  readonly exchangeRate: ExchangeRateDomain;
+  readonly background: BackgroundDomain;
+  readonly events: EventEmitter<SdkEventMap>;
+
+  /**
+   * Close WS subs (mints + Supabase + Breez), halt orchestrators, clear timers.
+   */
+  destroy(): Promise<void>;
+}

--- a/packages/wallet-sdk/src/types/account.ts
+++ b/packages/wallet-sdk/src/types/account.ts
@@ -1,0 +1,104 @@
+// Account domain types — master verbatim (app/features/accounts/account.ts)
+// Note: `wallet` fields hold LIVE handles (not serializable).
+
+import type { Currency, Money } from './money';
+
+export type AccountType = 'cashu' | 'spark';
+export type AccountState = 'active' | 'expired';
+export type AccountPurpose = 'transactional' | 'gift-card' | 'offer';
+export type SparkNetwork = 'MAINNET' | 'REGTEST';
+
+// ---- Cashu proof (app/features/accounts/cashu-account.ts, zod/mini z.infer) ----
+
+// Minimal re-export of the DLEQ proof fields from @cashu/cashu-ts
+export type ProofDleq = {
+  e: string;
+  s: string;
+  r?: string;
+};
+
+export type ProofWitness = {
+  signatures?: string[];
+};
+
+export type CashuProof = {
+  id: string;
+  accountId: string;
+  userId: string;
+  keysetId: string;
+  amount: number;
+  secret: string;
+  unblindedSignature: string;
+  publicKeyY: string;
+  dleq: ProofDleq | undefined;
+  witness: ProofWitness | undefined;
+  state: 'UNSPENT' | 'RESERVED' | 'SPENT';
+  version: number;
+  createdAt: string;
+  reservedAt?: string | null;
+  spentAt?: string | null;
+};
+
+// ---- Live wallet handles (opaque — implementation in deps not imported here) ----
+
+/** Mint info/keysets/keys/seed (protocol-metadata memo). LIVE handle, not serializable. */
+export declare abstract class ExtendedCashuWallet {}
+
+/** Live Breez SDK instance (a connection). NOT DB data. Stub-that-throws when offline. */
+export declare abstract class BreezSdk {}
+
+// ---- Account union ----
+
+export type Account = {
+  id: string;
+  name: string;
+  type: AccountType;
+  purpose: AccountPurpose;
+  state: AccountState;
+  /** Gates canSendToLightning / canReceiveFromLightning */
+  isOnline: boolean;
+  currency: Currency;
+  createdAt: string; // ISO 8601
+  version: number;
+  expiresAt: string | null; // ISO 8601; null for non-expiring accounts
+} & (
+  | {
+      type: 'cashu';
+      mintUrl: string;
+      isTestMint: boolean;
+      /** NUT-13 deterministic-secret counters (keysetId -> counter) */
+      keysetCounters: Record<string, number>;
+      proofs: CashuProof[];
+      /** LIVE handle — not serializable */
+      wallet: ExtendedCashuWallet;
+    }
+  | {
+      type: 'spark';
+      balance: Money | null;
+      network: SparkNetwork;
+      /** LIVE Breez SDK instance */
+      wallet: BreezSdk;
+    }
+);
+
+// ---- Derivations (master verbatim) ----
+
+type DistributedOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+export type ExtendedAccount<T extends AccountType = AccountType> = Extract<
+  Account,
+  { type: T }
+> & { isDefault: boolean };
+
+export type CashuAccount = Extract<Account, { type: 'cashu' }>;
+export type SparkAccount = Extract<Account, { type: 'spark' }>;
+/** Server-safe — no decryptable proofs */
+export type RedactedAccount = DistributedOmit<Account, 'proofs'>;
+
+// ---- Add account config ----
+
+export type AddAccountConfig =
+  | { type: 'cashu'; mintUrl: string; currency: Currency; name?: string }
+  | { type: 'spark'; currency: Currency; name?: string };

--- a/packages/wallet-sdk/src/types/cashu.ts
+++ b/packages/wallet-sdk/src/types/cashu.ts
@@ -1,0 +1,147 @@
+// Cashu domain types — master verbatim
+// send/cashu-send-quote.ts, send/cashu-send-swap.ts, receive/cashu-receive-quote.ts
+
+import type { CashuProof } from './account';
+import type { Money } from './money';
+
+// ---- DestinationDetails (on lightning send) ----
+
+export type DestinationDetails =
+  | { sendType: 'AGICASH_CONTACT'; contactId: string }
+  | { sendType: 'LN_ADDRESS'; lnAddress: string };
+
+// ---- CashuSendQuote (lightning send) — states: UNPAID/PENDING/EXPIRED/FAILED/PAID ----
+
+type CashuSendQuoteBase = {
+  id: string;
+  userId: string;
+  accountId: string;
+  transactionId: string;
+  createdAt: string; // ISO 8601
+  expiresAt: string; // ISO 8601
+  paymentRequest: string;
+  paymentHash: string;
+  amountRequested: Money;
+  amountRequestedInMsat: number;
+  amountReceived: Money;
+  lightningFeeReserve: Money;
+  cashuFee: Money;
+  quoteId: string; // melt quote id
+  proofs: CashuProof[];
+  amountReserved: Money;
+  destinationDetails?: DestinationDetails; // undefined when paying a bolt11 directly
+  keysetId: string;
+  keysetCounter: number;
+  numberOfChangeOutputs: number;
+  version: number;
+};
+
+export type CashuSendQuote = CashuSendQuoteBase &
+  (
+    | { state: 'UNPAID' }
+    | { state: 'PENDING' }
+    | { state: 'EXPIRED' }
+    | { state: 'FAILED'; failureReason: string }
+    | {
+        state: 'PAID';
+        paymentPreimage: string;
+        lightningFee: Money;
+        amountSpent: Money;
+        totalFee: Money;
+      }
+  );
+
+// ---- CashuSendSwap (token send) — states: DRAFT/PENDING/COMPLETED/FAILED/REVERSED ----
+// NOTE: createdAt is Date (master z.date()), unlike the ISO string on other types.
+
+type CashuSendSwapBase = {
+  id: string;
+  accountId: string;
+  userId: string;
+  transactionId: string;
+  inputProofs: CashuProof[]; // reserved from the account
+  inputAmount: Money;
+  amountReceived: Money;
+  amountToSend: Money;
+  amountSpent: Money;
+  cashuReceiveFee: Money;
+  cashuSendFee: Money;
+  totalFee: Money;
+  // present only when a swap is needed to get exact proofs:
+  keysetId?: string;
+  keysetCounter?: number;
+  outputAmounts?: { send: number[]; change: number[] };
+  createdAt: Date; // <- Date, not ISO string (master verbatim)
+  version: number;
+};
+
+export type CashuSendSwap = CashuSendSwapBase &
+  (
+    | {
+        state: 'DRAFT';
+        keysetId: string;
+        keysetCounter: number;
+        outputAmounts: { send: number[]; change: number[] };
+      }
+    | {
+        state: 'PENDING' | 'COMPLETED';
+        tokenHash: string;
+        proofsToSend: CashuProof[];
+      }
+    | { state: 'FAILED'; failureReason: string }
+    | { state: 'REVERSED' }
+  );
+
+// ---- CashuTokenMeltData (shared by cashu + spark receive token paths) ----
+
+export type CashuTokenMeltData = {
+  sourceMintUrl: string;
+  tokenAmount: Money;
+  meltQuoteId: string;
+  cashuReceiveFee: Money;
+  lightningFeeReserve: Money;
+  lightningFee?: Money;
+};
+
+// ---- CashuReceiveQuote ----
+// Two orthogonal discriminators: type (LIGHTNING | CASHU_TOKEN) ∧ state
+
+type CashuReceiveQuoteBase = {
+  id: string;
+  userId: string;
+  accountId: string;
+  transactionId: string;
+  quoteId: string; // mint quote id
+  amount: Money; // amount credited to the account
+  description?: string;
+  createdAt: string; // ISO 8601
+  expiresAt: string; // ISO 8601
+  paymentRequest: string;
+  paymentHash: string;
+  lockingDerivationPath: string; // BIP32 path for quote locking/signing
+  mintingFee?: Money;
+  totalFee: Money;
+  version: number;
+};
+
+export type CashuReceiveQuote = CashuReceiveQuoteBase &
+  (
+    | { type: 'LIGHTNING' }
+    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+  ) &
+  (
+    | { state: 'UNPAID' | 'EXPIRED' }
+    | {
+        state: 'PAID' | 'COMPLETED';
+        keysetId: string;
+        keysetCounter: number;
+        outputAmounts: number[];
+      }
+    | { state: 'FAILED'; failureReason: string }
+  );
+
+// ---- receiveToken result ----
+
+export type ReceiveTokenResult =
+  | { success: true; destinationAccount: { id: string; purpose: string } }
+  | { success: false; message: string };

--- a/packages/wallet-sdk/src/types/contact.ts
+++ b/packages/wallet-sdk/src/types/contact.ts
@@ -1,0 +1,13 @@
+// Contact types — master verbatim (app/features/contacts/)
+
+export type Contact = {
+  id: string;
+  createdAt: string; // ISO string (master z.string(), verbatim)
+  ownerId: string;
+  username: string;
+  /**
+   * Materialized by the repository as `${username}@${domain}` at parse time.
+   * The DB row stores only `username`; `domain` comes from SdkConfig.domain.
+   */
+  lud16: string;
+};

--- a/packages/wallet-sdk/src/types/errors.ts
+++ b/packages/wallet-sdk/src/types/errors.ts
@@ -1,0 +1,42 @@
+// SDK error hierarchy
+
+export class SdkError extends Error {
+  readonly code: string;
+  constructor(message: string, code: string) {
+    super(message);
+    this.name = 'SdkError';
+    this.code = code;
+  }
+}
+
+/** Transient/stale conflict — caller (or orchestrator) should refetch + retry. */
+export class ConcurrencyError extends SdkError {
+  constructor(message: string, code: string) {
+    super(message, code);
+    this.name = 'ConcurrencyError';
+  }
+}
+
+/** User-facing error — never retry. Surface message directly to the user. */
+export class DomainError extends SdkError {
+  constructor(message: string, code: string) {
+    super(message, code);
+    this.name = 'DomainError';
+  }
+}
+
+/** Entity not found. */
+export class NotFoundError extends SdkError {
+  constructor(message: string, code: string) {
+    super(message, code);
+    this.name = 'NotFoundError';
+  }
+}
+
+/**
+ * Pure error classifier — consumed by both the SDK orchestrator and web hooks.
+ * Keeps to the four-bucket contract (gudnuf 5/21).
+ */
+export declare function classify(
+  err: unknown,
+): 'transient' | 'permanent' | 'already-resolved' | 'unhandled';

--- a/packages/wallet-sdk/src/types/events.ts
+++ b/packages/wallet-sdk/src/types/events.ts
@@ -1,0 +1,61 @@
+// SdkEventMap + EventEmitter
+
+import type { Account } from './account';
+import type { Contact } from './contact';
+import type { SdkError } from './errors';
+import type { Money } from './money';
+import type { Transaction } from './transaction';
+import type { User } from './user';
+
+export type BackgroundState =
+  | 'stopped'
+  | 'starting'
+  | 'follower'
+  | 'leader'
+  | 'stopping';
+
+export type SdkEventMap = {
+  'send:pending': {
+    quoteId: string;
+    transactionId: string;
+    protocol: 'cashu' | 'spark';
+  };
+  'send:completed': {
+    quoteId: string;
+    transactionId: string;
+    amount: Money;
+    protocol: 'cashu' | 'spark';
+  };
+  'send:failed': {
+    quoteId: string;
+    error: SdkError;
+    protocol: 'cashu' | 'spark';
+  };
+  'receive:completed': {
+    quoteId: string;
+    transactionId: string;
+    amount: Money;
+    protocol: 'cashu' | 'spark';
+  };
+  'receive:expired': { quoteId: string; protocol: 'cashu' | 'spark' };
+  'receive:failed': {
+    quoteId: string;
+    error: SdkError;
+    protocol: 'cashu' | 'spark';
+  };
+  // NO transfer:* events (decision 5): a transfer surfaces as two transaction:* events linked by transferId.
+  'account:updated': { account: Account; op: 'created' | 'updated' };
+  'transaction:created': { transaction: Transaction };
+  'transaction:updated': { transaction: Transaction };
+  'contact:created': { contact: Contact };
+  'contact:deleted': { contactId: string };
+  'auth:signed-in': { user: User };
+  'auth:signed-out': Record<string, never>;
+  'auth:session-expired': Record<string, never>;
+  'background:state': { state: BackgroundState };
+};
+
+export interface EventEmitter<M> {
+  on<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
+  once<K extends keyof M>(event: K, handler: (data: M[K]) => void): () => void;
+}

--- a/packages/wallet-sdk/src/types/money.ts
+++ b/packages/wallet-sdk/src/types/money.ts
@@ -1,0 +1,18 @@
+// Money + Currency — domain value types
+
+export type Currency = 'BTC' | 'USD';
+
+/**
+ * Money is an opaque value type (master uses a class).
+ * Declared as an abstract class so TS treats it as a nominal type
+ * (not structurally assignable from a plain object).
+ */
+export declare abstract class Money {
+  abstract readonly amount: number;
+  abstract readonly currency: Currency;
+  abstract toString(): string;
+
+  static sats(n: number): Money;
+  static usd(cents: number): Money;
+  static zero(currency: Currency): Money;
+}

--- a/packages/wallet-sdk/src/types/query.ts
+++ b/packages/wallet-sdk/src/types/query.ts
@@ -1,0 +1,20 @@
+// Core reactive types (design B — TanStack hidden behind Query<T>)
+// Web depends only on these; no react-query/TanStack import required.
+
+export type QueryState<T> = {
+  status: 'pending' | 'error' | 'success';
+  data: T | undefined;
+  error: unknown;
+  isPending: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  /** Background-refresh indicator */
+  isFetching: boolean;
+};
+
+export type Query<T> = {
+  subscribe(onData: (d: T) => void, onError?: (e: unknown) => void): () => void;
+  toPromise(): Promise<T>;
+  refetch(): Promise<T>;
+  getSnapshot(): QueryState<T>;
+};

--- a/packages/wallet-sdk/src/types/scan.ts
+++ b/packages/wallet-sdk/src/types/scan.ts
@@ -1,0 +1,28 @@
+// Scan + PaymentIntent + ParsedDestination types
+
+import type { Money } from './money';
+
+export type Bolt11Invoice = {
+  paymentRequest: string;
+  paymentHash: string;
+  amountMsat?: number;
+  description?: string;
+  expiryTimestamp?: number;
+};
+
+export type ParsedToken = {
+  token: string;
+  amount?: number;
+  mintUrl?: string;
+};
+
+export type ParsedDestination =
+  | { kind: 'bolt11'; invoice: Bolt11Invoice }
+  | { kind: 'ln-address'; address: string }
+  | { kind: 'cashu-token'; token: ParsedToken }
+  | { kind: 'agicash-contact'; contactId: string; username: string };
+
+export type PaymentIntent =
+  | { kind: 'send'; destination: ParsedDestination; amount?: Money }
+  | { kind: 'receive'; amount?: Money }
+  | { kind: 'token-receive'; token: string };

--- a/packages/wallet-sdk/src/types/spark.ts
+++ b/packages/wallet-sdk/src/types/spark.ts
@@ -1,0 +1,73 @@
+// Spark domain types — master verbatim
+// send/spark-send-quote.ts, receive/spark-receive-quote.ts
+
+import type { CashuTokenMeltData } from './cashu';
+import type { Money } from './money';
+
+// ---- SparkSendQuote — states: UNPAID/PENDING/COMPLETED/FAILED ----
+
+type SparkSendQuoteBase = {
+  id: string;
+  userId: string;
+  accountId: string;
+  transactionId: string;
+  amount: Money;
+  estimatedFee: Money;
+  paymentRequest: string;
+  paymentHash: string;
+  paymentRequestIsAmountless: boolean;
+  createdAt: string; // ISO 8601
+  expiresAt?: string | null; // ISO 8601; nullish
+  version: number;
+};
+
+export type SparkSendQuote = SparkSendQuoteBase &
+  (
+    | { state: 'UNPAID' }
+    | { state: 'PENDING'; sparkId: string; sparkTransferId: string; fee: Money }
+    | {
+        state: 'COMPLETED';
+        sparkId: string;
+        sparkTransferId: string;
+        fee: Money;
+        paymentPreimage: string;
+      }
+    | {
+        state: 'FAILED';
+        failureReason: string;
+        sparkId?: string;
+        sparkTransferId?: string;
+        fee?: Money;
+      }
+  );
+
+// ---- SparkReceiveQuote ----
+// Two orthogonal discriminators: type (LIGHTNING | CASHU_TOKEN) ∧ state
+
+type SparkReceiveQuoteBase = {
+  id: string;
+  sparkId: string;
+  userId: string;
+  accountId: string;
+  transactionId: string;
+  amount: Money;
+  paymentRequest: string;
+  paymentHash: string;
+  description?: string;
+  receiverIdentityPubkey?: string;
+  createdAt: string; // ISO 8601
+  expiresAt: string; // ISO 8601
+  totalFee: Money;
+  version: number;
+};
+
+export type SparkReceiveQuote = SparkReceiveQuoteBase &
+  (
+    | { type: 'LIGHTNING' }
+    | { type: 'CASHU_TOKEN'; tokenReceiveData: CashuTokenMeltData }
+  ) &
+  (
+    | { state: 'UNPAID' | 'EXPIRED' }
+    | { state: 'PAID'; paymentPreimage: string; sparkTransferId: string }
+    | { state: 'FAILED'; failureReason: string }
+  );

--- a/packages/wallet-sdk/src/types/transaction.ts
+++ b/packages/wallet-sdk/src/types/transaction.ts
@@ -1,0 +1,172 @@
+// Transaction domain types — master verbatim
+// app/features/transactions/transaction.ts + transaction-enums.ts
+// app/features/transactions/transaction-details/transaction-details-types.ts
+
+import type { AccountPurpose, AccountType } from './account';
+import type { DestinationDetails } from './cashu';
+import type { Money } from './money';
+
+// ---- Enums ----
+
+export type TransactionDirection = 'SEND' | 'RECEIVE';
+export type TransactionType =
+  | 'CASHU_LIGHTNING'
+  | 'CASHU_TOKEN'
+  | 'SPARK_LIGHTNING';
+export type TransactionState =
+  | 'DRAFT'
+  | 'PENDING'
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'REVERSED';
+export type TransactionPurpose = 'PAYMENT' | 'BUY_CASHAPP' | 'TRANSFER';
+
+// ---- Transaction Details — domain union (public) ----
+// DB-data union and per-variant z.pipe parsers are SDK-internal (decision 7-ii).
+
+export type CashuTokenSendTransactionDetails = {
+  tokenAmount: Money;
+  tokenMintUrl: string;
+  amountReserved: Money;
+  amount: Money;
+  amountReceived: Money;
+  cashuReceiveFee: Money;
+  cashuSendFee: Money;
+  totalFee: Money;
+};
+
+export type CashuTokenReceiveTransactionDetails = {
+  tokenAmount: Money;
+  tokenMintUrl: string;
+  description?: string;
+  amount: Money;
+  cashuReceiveFee: Money;
+  mintingFee?: Money;
+  lightningFeeReserve?: Money;
+  totalFee: Money;
+};
+
+export type IncompleteCashuLightningSendTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  destinationDetails?: DestinationDetails;
+  amountReserved: Money;
+  amountReceived: Money;
+  lightningFeeReserve: Money;
+  cashuSendFee: Money;
+  estimatedTotalFee: Money;
+  amount: Money;
+  transferId?: string;
+};
+
+export type CompletedCashuLightningSendTransactionDetails =
+  IncompleteCashuLightningSendTransactionDetails & {
+    preimage: string;
+    lightningFee: Money;
+    totalFee: Money;
+  };
+
+export type CashuLightningSendTransactionDetails =
+  | IncompleteCashuLightningSendTransactionDetails
+  | CompletedCashuLightningSendTransactionDetails;
+
+export type CashuLightningReceiveTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  description?: string;
+  mintingFee?: Money;
+  amount: Money;
+  totalFee: Money;
+  transferId?: string;
+};
+
+export type IncompleteSparkLightningSendTransactionDetails = {
+  amountReceived: Money;
+  estimatedFee: Money;
+  paymentRequest: string;
+  paymentHash: string;
+  amount: Money;
+  fee: Money;
+  sparkId?: string;
+  sparkTransferId?: string;
+  transferId?: string;
+};
+
+export type CompletedSparkLightningSendTransactionDetails =
+  Required<IncompleteSparkLightningSendTransactionDetails> & {
+    paymentPreimage: string;
+    transferId?: string;
+  };
+
+export type SparkLightningSendTransactionDetails =
+  | IncompleteSparkLightningSendTransactionDetails
+  | CompletedSparkLightningSendTransactionDetails;
+
+export type IncompleteSparkLightningReceiveTransactionDetails = {
+  paymentRequest: string;
+  paymentHash: string;
+  sparkId: string;
+  description?: string;
+  amount: Money;
+  transferId?: string;
+};
+
+export type CompletedSparkLightningReceiveTransactionDetails =
+  IncompleteSparkLightningReceiveTransactionDetails & {
+    paymentPreimage: string;
+    sparkTransferId: string;
+  };
+
+export type SparkLightningReceiveTransactionDetails =
+  | IncompleteSparkLightningReceiveTransactionDetails
+  | CompletedSparkLightningReceiveTransactionDetails;
+
+export type TransactionDetails =
+  | CashuTokenSendTransactionDetails
+  | CashuTokenReceiveTransactionDetails
+  | CashuLightningSendTransactionDetails
+  | CashuLightningReceiveTransactionDetails
+  | SparkLightningReceiveTransactionDetails
+  | SparkLightningSendTransactionDetails;
+
+// ---- BaseTransaction ----
+
+export type BaseTransaction = {
+  id: string;
+  userId: string;
+  direction: TransactionDirection;
+  type: TransactionType;
+  state: TransactionState;
+  /** null when the account was since deleted */
+  accountId: string | null;
+  accountName: string;
+  accountType: AccountType;
+  accountPurpose: AccountPurpose;
+  amount: Money;
+  details: TransactionDetails;
+  reversedTransactionId?: string | null;
+  purpose: TransactionPurpose;
+  acknowledgmentStatus: 'pending' | 'acknowledged' | null;
+  createdAt: string; // ISO 8601
+  pendingAt?: string | null;
+  completedAt?: string | null;
+  failedAt?: string | null;
+  reversedAt?: string | null;
+  version: number;
+};
+
+// The 9 type×direction(×state) variants are expressed via the base + purpose union.
+// (Variant narrowing is the SDK implementation's responsibility.)
+
+export type Transaction =
+  | (BaseTransaction & {
+      purpose: 'TRANSFER';
+      details: BaseTransaction['details'] & { transferId: string };
+    })
+  | (BaseTransaction & { purpose: 'PAYMENT' | 'BUY_CASHAPP' });
+
+export type TransactionCursor = {
+  stateSortOrder: number;
+  createdAt: string;
+  id: string;
+};

--- a/packages/wallet-sdk/src/types/transfer.ts
+++ b/packages/wallet-sdk/src/types/transfer.ts
@@ -1,0 +1,27 @@
+// Transfer domain types
+
+import type { CashuAccount, SparkAccount } from './account';
+import type { Money } from './money';
+
+export type TransferLeg =
+  | { account: CashuAccount; fee: Money }
+  | { account: SparkAccount; fee: Money };
+
+/**
+ * Ephemeral cost-preview — not persisted.
+ * The paired send+receive quotes persist, linked by transferId.
+ */
+export type TransferQuote = {
+  amount: Money;
+  amountToReceive: Money;
+  totalFees: Money;
+  totalCost: Money;
+  receive: TransferLeg;
+  send: TransferLeg;
+};
+
+export type TransferResult = {
+  transferId: string;
+  receiveTransactionId: string;
+  sendTransactionId: string;
+};

--- a/packages/wallet-sdk/src/types/user.ts
+++ b/packages/wallet-sdk/src/types/user.ts
@@ -1,0 +1,25 @@
+// User domain types — master verbatim (app/features/user/user.ts)
+
+type CommonUserData = {
+  id: string;
+  username: string;
+  emailVerified: boolean;
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+  defaultBtcAccountId: string;
+  defaultUsdAccountId: string | null;
+  defaultCurrency: import('./money').Currency;
+  cashuLockingXpub: string;
+  encryptionPublicKey: string;
+  sparkIdentityPublicKey: string;
+  termsAcceptedAt: string | null;
+  giftCardMintTermsAcceptedAt: string | null;
+};
+
+type FullUser = CommonUserData & { email: string; isGuest: false };
+type GuestUser = CommonUserData & { isGuest: true };
+
+export type User = FullUser | GuestUser;
+
+/** Raw search hit — master app/features/user/user.ts:30. NO lud16 (unlike Contact). */
+export type UserProfile = Pick<User, 'id' | 'username'>;


### PR DESCRIPTION
## Summary

- Contract-as-code for design B (with-cache / reactive) of the `@agicash/wallet-sdk`
- TanStack is hidden behind the lib-agnostic `Query<T>` / `QueryState<T>` types — web depends on React + `Query<T>` only, no react-query import needed
- Reads return `Query<T>` (observable); pure derivations (`getBalance`, `suggestFor`) stay sync; writes/actions return `Promise`
- All domain types (`Account`, `CashuSendQuote`, `CashuSendSwap`, `Transaction`, `Contact`, etc.) lifted verbatim from the no-cache contract
- Types and interfaces only — no implementation / method bodies; clean base for the 8-PR domain-extraction stack

## Files

- `src/types/query.ts` — `Query<T>`, `QueryState<T>`
- `src/types/{money,errors,events,account,user,scan,cashu,spark,transaction,contact,transfer}.ts` — all domain types
- `src/domains.ts` — all domain interfaces (`AccountsDomain`, `CashuDomain`, `SparkDomain`, …)
- `src/sdk.ts` — `Sdk` class shape + `SdkConfig`
- `src/helpers.ts` — `cashAppDeepLink` pure helper
- `src/index.ts` — re-exports everything

## Test plan

- [ ] `bun --filter='@agicash/wallet-sdk' run typecheck` passes (green locally)
- [ ] `bun --filter='*' run test` passes — 133 web-wallet tests green, wallet-sdk has no test script (no CI failure)
- [ ] `biome check packages/wallet-sdk/src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)