### PR TITLE
feat(wallet-sdk): real auth + user domains (PR3, reactive design B)

### DIFF
--- a/packages/wallet-sdk/src/domains/auth.test.ts
+++ b/packages/wallet-sdk/src/domains/auth.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { GuestAccountStorage } from '../internal/guest-account-storage';
+import type { OpenSecretClient } from '../internal/open-secret';
+import type { SessionResolver } from '../internal/session';
+import type { User } from '../types/user';
+import { AuthDomainImpl } from './auth';
+
+/** A signed-in user fixture returned by the (faked) session resolver. */
+const signedInUser = { id: 'user-1', username: 'alice' } as unknown as User;
+
+/** A `Promise<void>`-returning mock body (non-empty, to satisfy the no-empty-block lint). */
+const resolved = () => Promise.resolve();
+
+/**
+ * Build an {@link AuthDomainImpl} over mocked collaborators, exposing the mocks so a test
+ * can assert calls. `storedGuest` seeds the guest-credential store.
+ */
+function makeAuth(storedGuest: { id: string; password: string } | null = null) {
+  const openSecret = {
+    signIn: mock(resolved),
+    signUp: mock(resolved),
+    signUpGuest: mock(() => Promise.resolve({ id: 'guest-new' })),
+    signInGuest: mock(resolved),
+    signOut: mock(resolved),
+    refresh: mock(resolved),
+    convertGuestToUserAccount: mock(resolved),
+    changePassword: mock(resolved),
+    requestPasswordReset: mock(resolved),
+    initiateGoogleAuth: mock(() =>
+      Promise.resolve({ authUrl: 'https://auth/url' }),
+    ),
+    handleGoogleCallback: mock(resolved),
+  } as unknown as OpenSecretClient;
+
+  const session = {
+    completeSignIn: mock(() => Promise.resolve(signedInUser)),
+    completeSignOut: mock(() => undefined),
+  } as unknown as SessionResolver;
+
+  const guestStorage = {
+    get: mock(() => Promise.resolve(storedGuest)),
+    store: mock(resolved),
+    clear: mock(resolved),
+  } as unknown as GuestAccountStorage;
+
+  const auth = new AuthDomainImpl(openSecret, session, guestStorage);
+  return { auth, openSecret, session, guestStorage };
+}
+
+describe('AuthDomainImpl.signIn', () => {
+  test('calls OpenSecret.signIn then resolves + returns the user', async () => {
+    const { auth, openSecret, session } = makeAuth();
+
+    const user = await auth.signIn({
+      email: 'a@b.com',
+      password: 'pw',
+    });
+
+    expect(openSecret.signIn).toHaveBeenCalledWith('a@b.com', 'pw');
+    expect(session.completeSignIn).toHaveBeenCalledTimes(1);
+    expect(user).toBe(signedInUser);
+  });
+});
+
+describe('AuthDomainImpl.signInGuest', () => {
+  test('with no stored guest: creates one, stores creds, completes sign-in', async () => {
+    const { auth, openSecret, guestStorage } = makeAuth(null);
+
+    await auth.signInGuest();
+
+    expect(openSecret.signUpGuest).toHaveBeenCalledTimes(1);
+    // signInGuest (re-sign-in path) must NOT be used when minting a fresh guest
+    expect(openSecret.signInGuest).not.toHaveBeenCalled();
+    expect(guestStorage.store).toHaveBeenCalledTimes(1);
+    const stored = (guestStorage.store as ReturnType<typeof mock>).mock
+      .calls[0][0];
+    expect(stored.id).toBe('guest-new');
+    expect(typeof stored.password).toBe('string');
+  });
+
+  test('with a stored guest: re-signs into it, does not mint a new one', async () => {
+    const { auth, openSecret, guestStorage } = makeAuth({
+      id: 'guest-existing',
+      password: 'secret',
+    });
+
+    await auth.signInGuest();
+
+    expect(openSecret.signInGuest).toHaveBeenCalledWith(
+      'guest-existing',
+      'secret',
+    );
+    expect(openSecret.signUpGuest).not.toHaveBeenCalled();
+    expect(guestStorage.store).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthDomainImpl.upgradeGuest', () => {
+  test('converts the account, clears guest creds, returns the user', async () => {
+    const { auth, openSecret, guestStorage } = makeAuth();
+
+    const user = await auth.upgradeGuest({
+      email: 'a@b.com',
+      password: 'pw',
+    });
+
+    expect(openSecret.convertGuestToUserAccount).toHaveBeenCalledWith(
+      'a@b.com',
+      'pw',
+    );
+    expect(guestStorage.clear).toHaveBeenCalledTimes(1);
+    expect(user).toBe(signedInUser);
+  });
+});
+
+describe('AuthDomainImpl.signOut', () => {
+  test('signs out of the enclave then completes the local sign-out', async () => {
+    const { auth, openSecret, session } = makeAuth();
+
+    await auth.signOut();
+
+    expect(openSecret.signOut).toHaveBeenCalledTimes(1);
+    expect(session.completeSignOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AuthDomainImpl.resetPassword', () => {
+  test('sends a hashed secret (not the plaintext email) to OpenSecret', async () => {
+    const { auth, openSecret } = makeAuth();
+
+    await auth.resetPassword('a@b.com');
+
+    expect(openSecret.requestPasswordReset).toHaveBeenCalledTimes(1);
+    const [email, hashedSecret] = (
+      openSecret.requestPasswordReset as ReturnType<typeof mock>
+    ).mock.calls[0];
+    expect(email).toBe('a@b.com');
+    // a SHA-256 hex digest of the generated secret
+    expect(hashedSecret).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('AuthDomainImpl.changePassword', () => {
+  test('passes current + new passwords through to the enclave', async () => {
+    const { auth, openSecret } = makeAuth();
+
+    await auth.changePassword({ current: 'old', new: 'new' });
+
+    expect(openSecret.changePassword).toHaveBeenCalledWith('old', 'new');
+  });
+});
+
+describe('AuthDomainImpl.beginGoogleSignIn', () => {
+  test('returns the enclave auth URL', async () => {
+    const { auth } = makeAuth();
+    expect(await auth.beginGoogleSignIn()).toEqual({
+      authUrl: 'https://auth/url',
+    });
+  });
+});
+
+describe('AuthDomainImpl.completeOAuth', () => {
+  test('forwards code/state/inviteCode and resolves the user', async () => {
+    const { auth, openSecret, session } = makeAuth();
+
+    const user = await auth.completeOAuth({
+      code: 'c',
+      state: 's',
+      inviteCode: 'inv',
+    });
+
+    expect(openSecret.handleGoogleCallback).toHaveBeenCalledWith(
+      'c',
+      's',
+      'inv',
+    );
+    expect(session.completeSignIn).toHaveBeenCalledTimes(1);
+    expect(user).toBe(signedInUser);
+  });
+
+  test("defaults inviteCode to '' when omitted", async () => {
+    const { auth, openSecret } = makeAuth();
+
+    await auth.completeOAuth({ code: 'c', state: 's' });
+
+    expect(openSecret.handleGoogleCallback).toHaveBeenCalledWith('c', 's', '');
+  });
+});

--- a/packages/wallet-sdk/src/domains/auth.ts
+++ b/packages/wallet-sdk/src/domains/auth.ts
@@ -1,0 +1,205 @@
+/**
+ * `AuthDomain` implementation — §4 of the contract, Slice 1.
+ *
+ * EXTRACTED (re-housed framework-free) from `apps/web-wallet/app/features/user/auth.ts`
+ * (the `useAuthActions` hook + the OpenSecret-SDK wrappers) and
+ * `apps/web-wallet/app/features/shared/auth.ts`. Master expresses auth as a React hook
+ * over TanStack-Query invalidation + `react-router` navigation + `window.localStorage`;
+ * all of that is stripped. What remains is the enclave calls + the agicash `User`
+ * resolution + the SDK's `auth:*` events:
+ *
+ *  - sign-in/up/guest/upgrade/OAuth-complete call OpenSecret, then resolve the
+ *    `wallet.users` DB row (via {@link SessionResolver.completeSignIn}) and return the
+ *    domain {@link User}, emitting `auth:signed-in`;
+ *  - sign-out calls OpenSecret then emits `auth:signed-out`;
+ *  - refresh / changePassword / resetPassword are thin enclave pass-throughs that master
+ *    expresses implicitly via the OS SDK (the contract names them explicitly).
+ *
+ * Every method is an ACTION → `Promise` (no observable reads here), so the reactive
+ * overlay (design B) leaves this domain unchanged from the no-cache extraction.
+ *
+ * No `getCurrentSession` method (contract decision 4 — methods return `User`, not a
+ * session; the JWT stays SDK-internal). OAuth is a browser REDIRECT (`beginGoogleSignIn`
+ * returns `{ authUrl }`), web-only.
+ *
+ * @module
+ */
+import type { AuthDomain } from '../domains';
+import type { User } from '../types/user';
+import { computeSHA256, generateRandomPassword } from '../internal/crypto';
+import type { GuestAccountStorage } from '../internal/guest-account-storage';
+import type { OpenSecretClient } from '../internal/open-secret';
+import type { SessionResolver } from '../internal/session';
+
+/** Length of a generated guest-account password (master `generateRandomPassword(32)`). */
+const GUEST_PASSWORD_LENGTH = 32;
+/** Length of the generated password-reset secret (master `generateRandomPassword(20)`). */
+const RESET_SECRET_LENGTH = 20;
+
+/** OAuth callback params handed to {@link AuthDomainImpl.completeOAuth}. */
+type OAuthCallbackParams = {
+  /** OAuth authorization code from the redirect. */
+  code: string;
+  /** OAuth `state` param from the redirect (CSRF + session correlation). */
+  state: string;
+  /** Optional invite code for new-user registration (defaults to `''`, as master does). */
+  inviteCode?: string;
+};
+
+/**
+ * The auth domain. Construct with the enclave client, the session resolver (id → DB user
+ * + `auth:*` emission), and the guest-credential store.
+ */
+export class AuthDomainImpl implements AuthDomain {
+  /**
+   * @param openSecret - the OpenSecret enclave client.
+   * @param session - resolves the agicash user + emits `auth:*`.
+   * @param guestStorage - persists guest credentials for same-device re-sign-in.
+   */
+  constructor(
+    private readonly openSecret: OpenSecretClient,
+    private readonly session: SessionResolver,
+    private readonly guestStorage: GuestAccountStorage,
+  ) {}
+
+  /**
+   * Sign in an existing user with email + password.
+   *
+   * @param params - `{ email, password }`.
+   * @returns the signed-in {@link User}.
+   */
+  async signIn(params: { email: string; password: string }): Promise<User> {
+    await this.openSecret.signIn(params.email, params.password);
+    return this.session.completeSignIn();
+  }
+
+  /**
+   * Create a new full (email) account and sign it in.
+   *
+   * @param params - `{ email, password }`.
+   * @returns the new {@link User}.
+   */
+  async signUp(params: { email: string; password: string }): Promise<User> {
+    await this.openSecret.signUp(params.email, params.password);
+    return this.session.completeSignIn();
+  }
+
+  /**
+   * Create and sign in an anonymous guest user. If this device already has a stored guest
+   * account, signs back into THAT account instead of minting a new one (master parity:
+   * `useAuthActions.signUpGuest`). The generated password is persisted via the storage
+   * adapter.
+   *
+   * @returns the guest {@link User}.
+   */
+  async signInGuest(): Promise<User> {
+    const existing = await this.guestStorage.get();
+    if (existing) {
+      await this.openSecret.signInGuest(existing.id, existing.password);
+      return this.session.completeSignIn();
+    }
+
+    const password = generateRandomPassword(GUEST_PASSWORD_LENGTH);
+    const { id } = await this.openSecret.signUpGuest(password);
+    await this.guestStorage.store({ id, password });
+    return this.session.completeSignIn();
+  }
+
+  /**
+   * Sign out the current user and clear the session.
+   *
+   * The OpenSecret SDK clears its own persisted tokens; this drops the cached Supabase
+   * token and emits `auth:signed-out`.
+   */
+  async signOut(): Promise<void> {
+    await this.openSecret.signOut();
+    this.session.completeSignOut();
+  }
+
+  /**
+   * Refresh the current session/access token (extends the session). Master expresses this
+   * implicitly via the OS SDK; the contract names it explicitly.
+   */
+  async refresh(): Promise<void> {
+    await this.openSecret.refresh();
+  }
+
+  /**
+   * Send a password-reset email to `email`.
+   *
+   * Re-houses master `useAuthActions.requestPasswordReset`: generate a random secret, send
+   * its SHA-256 hash to OpenSecret (the emailed code + this secret later confirm the reset
+   * via the enclave). The contract types this `Promise<void>`; the secret needed for the
+   * confirm step is held by OpenSecret's flow, so it is not surfaced here.
+   *
+   * @param email - the account email to reset.
+   */
+  async resetPassword(email: string): Promise<void> {
+    const secret = generateRandomPassword(RESET_SECRET_LENGTH);
+    const hashedSecret = await computeSHA256(secret);
+    await this.openSecret.requestPasswordReset(email, hashedSecret);
+  }
+
+  /**
+   * Change the signed-in user's password (requires the current password).
+   *
+   * @param params - `{ current, new }` passwords.
+   */
+  async changePassword(params: {
+    current: string;
+    new: string;
+  }): Promise<void> {
+    await this.openSecret.changePassword(params.current, params.new);
+  }
+
+  /**
+   * Upgrade the current guest user into a full email account, preserving funds/history.
+   * Clears the stored guest credentials on success (master parity:
+   * `useUpgradeGuestToFullAccount`).
+   *
+   * @param params - `{ email, password }` for the new full account.
+   * @returns the upgraded {@link User}.
+   */
+  async upgradeGuest(params: {
+    email: string;
+    password: string;
+  }): Promise<User> {
+    await this.openSecret.convertGuestToUserAccount(
+      params.email,
+      params.password,
+    );
+    await this.guestStorage.clear();
+    return this.session.completeSignIn();
+  }
+
+  /**
+   * Begin Google OAuth — returns the URL to redirect the browser to. OAuth is a REDIRECT
+   * flow, not a synchronous session; web-only (the MCP daemon cannot do Google auth).
+   *
+   * NOTE: master also stashes the pre-redirect `location.search`/`hash` into an OAuth
+   * login-session store and folds a `sessionId` into the `state` param so the post-redirect
+   * page can restore context. That stashing is browser/router-specific UI plumbing and is
+   * left to the web consumer (the SDK is framework-free); the SDK returns the enclave's
+   * `authUrl` directly.
+   *
+   * @returns `{ authUrl }` to redirect to.
+   */
+  async beginGoogleSignIn(): Promise<{ authUrl: string }> {
+    return this.openSecret.initiateGoogleAuth();
+  }
+
+  /**
+   * Complete OAuth from the redirect callback params; resolves with the user.
+   *
+   * @param params - `{ code, state, inviteCode? }` from the OAuth redirect.
+   * @returns the signed-in {@link User}.
+   */
+  async completeOAuth(params: OAuthCallbackParams): Promise<User> {
+    await this.openSecret.handleGoogleCallback(
+      params.code,
+      params.state,
+      params.inviteCode ?? '',
+    );
+    return this.session.completeSignIn();
+  }
+}

--- a/packages/wallet-sdk/src/domains/user.test.ts
+++ b/packages/wallet-sdk/src/domains/user.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { DomainError } from '../errors';
+import type { SessionResolver } from '../internal/session';
+import type { UserRepository } from '../internal/user-repository';
+import { QueryClient } from '../query';
+import type { Query } from '../types/query';
+import type { User } from '../types/user';
+import { UserDomainImpl } from './user';
+
+const currentUser = { id: 'user-1', username: 'alice' } as unknown as User;
+
+/** A fresh QueryClient per test (the SDK-internal one in production). */
+function makeClient(): QueryClient {
+  return new QueryClient();
+}
+
+/** Resolve the first emitted value of a `Query`, then unsubscribe. */
+function firstEmit<T>(q: Query<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const off = q.subscribe(
+      (data) => {
+        off();
+        resolve(data);
+      },
+      (err) => {
+        off();
+        reject(err);
+      },
+    );
+  });
+}
+
+describe('UserDomainImpl.getCurrentUser', () => {
+  test('returns a Query whose toPromise() resolves to the session user', async () => {
+    const session = {
+      getCurrentUser: mock(async () => currentUser),
+    } as unknown as SessionResolver;
+    const domain = new UserDomainImpl(
+      makeClient(),
+      session,
+      {} as unknown as UserRepository,
+    );
+
+    const query = domain.getCurrentUser();
+    // It is a Query<User | null>, not a bare Promise.
+    expect(typeof query.subscribe).toBe('function');
+    expect(typeof query.toPromise).toBe('function');
+    expect(typeof query.getSnapshot).toBe('function');
+
+    expect(await query.toPromise()).toBe(currentUser);
+    expect(session.getCurrentUser).toHaveBeenCalledTimes(1);
+  });
+
+  test('subscribe fires with the resolved user (the underlying session read still works)', async () => {
+    const session = {
+      getCurrentUser: mock(async () => currentUser),
+    } as unknown as SessionResolver;
+    const domain = new UserDomainImpl(
+      makeClient(),
+      session,
+      {} as unknown as UserRepository,
+    );
+
+    const emitted = await firstEmit(domain.getCurrentUser());
+    expect(emitted).toBe(currentUser);
+  });
+
+  test('resolves to null when signed out', async () => {
+    const session = {
+      getCurrentUser: mock(async () => null),
+    } as unknown as SessionResolver;
+    const domain = new UserDomainImpl(
+      makeClient(),
+      session,
+      {} as unknown as UserRepository,
+    );
+
+    expect(await domain.getCurrentUser().toPromise()).toBeNull();
+  });
+
+  test('is memoised per key — repeated calls return the SAME Query ref', () => {
+    const session = {
+      getCurrentUser: mock(async () => currentUser),
+    } as unknown as SessionResolver;
+    const domain = new UserDomainImpl(
+      makeClient(),
+      session,
+      {} as unknown as UserRepository,
+    );
+
+    expect(domain.getCurrentUser()).toBe(domain.getCurrentUser());
+  });
+});
+
+describe('UserDomainImpl.updateUsername', () => {
+  test('resolves the current user id then updates the username (stays a Promise)', async () => {
+    const updated = { ...currentUser, username: 'bob' };
+    const session = {
+      requireCurrentUser: mock(async () => currentUser),
+    } as unknown as SessionResolver;
+    const users = {
+      updateUsername: mock(async () => updated),
+    } as unknown as UserRepository;
+    const domain = new UserDomainImpl(makeClient(), session, users);
+
+    const result = await domain.updateUsername('bob');
+
+    expect(session.requireCurrentUser).toHaveBeenCalledTimes(1);
+    expect(users.updateUsername).toHaveBeenCalledWith('user-1', 'bob');
+    expect(result.username).toBe('bob');
+  });
+
+  test('propagates a DomainError from the repository (username taken)', async () => {
+    const session = {
+      requireCurrentUser: mock(async () => currentUser),
+    } as unknown as SessionResolver;
+    const users = {
+      updateUsername: mock(async () => {
+        throw new DomainError(
+          'This username is already taken',
+          'USERNAME_TAKEN',
+        );
+      }),
+    } as unknown as UserRepository;
+    const domain = new UserDomainImpl(makeClient(), session, users);
+
+    await expect(domain.updateUsername('taken')).rejects.toBeInstanceOf(
+      DomainError,
+    );
+  });
+});

--- a/packages/wallet-sdk/src/domains/user.ts
+++ b/packages/wallet-sdk/src/domains/user.ts
@@ -1,0 +1,100 @@
+/**
+ * `UserDomain` implementation — §4 of the contract, Slice 1 (reactive overlay, design B).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/user/user-hooks.tsx` (`useUser` / `useUpdateUsername` /
+ * `useUpdateUser`) + `app/features/user/user-repository.ts` (the read + the username
+ * update). Master expresses these as React hooks over TanStack-Query (a `useSuspenseQuery`
+ * read + a `useMutation` that writes the `UserCache`).
+ *
+ * REACTIVE OVERLAY: TanStack is no longer in the consumer — it is hidden inside the SDK.
+ *  - `getCurrentUser()` is an OBSERVABLE FETCH → returns `Query<User | null>`. The fetch
+ *    BODY is identical to the no-cache read (`SessionResolver.getCurrentUser`: enclave id
+ *    → `wallet.users` row → domain {@link User}); it is simply wrapped via {@link toQuery}
+ *    over the SDK-internal `QueryClient` and MEMOISED per key (`#q`) so repeated calls
+ *    return the SAME stable `Query` ref (matching the per-key-memo pattern the other
+ *    reactive domains use). Realtime / orchestrators (Slice 5) write the same client (e.g.
+ *    `setQueryData(['currentUser'], next)`) to push fresh values to subscribers.
+ *  - `updateUsername(...)` is an ACTION → stays `Promise` (lifted verbatim).
+ *
+ * @module
+ */
+import type { UserDomain } from '../domains';
+import type { SessionResolver } from '../internal/session';
+import type { UserRepository } from '../internal/user-repository';
+import { type QueryClient, toQuery } from '../query';
+import type { Query } from '../types/query';
+import type { User } from '../types/user';
+
+/** Stable query key for the current-user read (one per SDK instance). */
+const CURRENT_USER_KEY = ['currentUser'] as const;
+
+/**
+ * The user domain. Construct with the SDK-internal `QueryClient` (backs the observable
+ * `getCurrentUser` read), the session resolver (current-user resolution), and the
+ * `wallet.users` repository (username update).
+ */
+export class UserDomainImpl implements UserDomain {
+  /**
+   * Per-key memo of the `Query` handles this domain exposes, so repeated calls to
+   * `getCurrentUser()` return the SAME stable reference (consumers can use it as a
+   * `useSyncExternalStore`/effect dependency). Hidden inside the SDK.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous Query<T> memo, keyed by string
+  readonly #q = new Map<string, Query<any>>();
+
+  /**
+   * @param client - the SDK-internal TanStack `QueryClient` (never exposed to consumers).
+   * @param session - resolves the current agicash {@link User} (enclave id → DB row).
+   * @param users - the `wallet.users` repository (username update).
+   */
+  constructor(
+    private readonly client: QueryClient,
+    private readonly session: SessionResolver,
+    private readonly users: UserRepository,
+  ) {}
+
+  /**
+   * The currently signed-in user, or `null` if none — as an observable {@link Query}.
+   *
+   * Re-houses master `useUser`: the enclave user id → the `wallet.users` DB row → the
+   * domain {@link User}, resolving to `null` when signed out. The fetch body is exactly the
+   * no-cache read ({@link SessionResolver.getCurrentUser}); the reactive overlay wraps it in
+   * a {@link toQuery}-backed `Query` (memoised per key). `subscribe` fires with the
+   * user/`null`; `toPromise()` resolves to it; `getSnapshot()` exposes the curated state.
+   *
+   * @returns a stable `Query<User | null>`.
+   */
+  getCurrentUser(): Query<User | null> {
+    const key = JSON.stringify(CURRENT_USER_KEY);
+    let q = this.#q.get(key);
+    if (!q) {
+      q = toQuery<User | null>(this.client, CURRENT_USER_KEY, () =>
+        this.session.getCurrentUser(),
+      );
+      this.#q.set(key, q);
+    }
+    return q;
+  }
+
+  /**
+   * Change the signed-in user's username.
+   *
+   * Re-houses master `useUpdateUsername` → `WriteUserRepository.update({ username })`.
+   * Resolves the current user id from the session, updates the row, and returns the fresh
+   * {@link User}. Throws {@link DomainError} if the username is already taken (the
+   * repository maps the Postgres unique-violation to it). An ACTION → `Promise`.
+   *
+   * @param username - the new username.
+   * @returns the updated {@link User}.
+   * @throws DomainError if the username is taken.
+   * @throws Error if there is no authenticated user.
+   */
+  async updateUsername(username: string): Promise<User> {
+    const current = await this.session.requireCurrentUser();
+    // The realtime forwarder (Slice 5) also surfaces the row change as an event + writes
+    // the `['currentUser']` query; this returns the fresh user directly so the caller has
+    // it without awaiting that.
+    return this.users.updateUsername(current.id, username);
+  }
+}

--- a/packages/wallet-sdk/src/internal/crypto.test.ts
+++ b/packages/wallet-sdk/src/internal/crypto.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { computeSHA256, generateRandomPassword } from './crypto';
+
+describe('generateRandomPassword', () => {
+  test('returns a string of the requested length', () => {
+    expect(generateRandomPassword(32)).toHaveLength(32);
+    expect(generateRandomPassword(20)).toHaveLength(20);
+  });
+
+  test('defaults to length 24', () => {
+    expect(generateRandomPassword()).toHaveLength(24);
+  });
+
+  test('produces a different value each call (random)', () => {
+    const a = generateRandomPassword(32);
+    const b = generateRandomPassword(32);
+    expect(a).not.toBe(b);
+  });
+
+  test('only uses the allowed character set', () => {
+    const allowed = /^[a-zA-Z0-9!@#$%^&*()_+~]+$/;
+    expect(generateRandomPassword(200)).toMatch(allowed);
+  });
+});
+
+describe('computeSHA256', () => {
+  test('returns the known SHA-256 hex digest of "abc"', async () => {
+    // canonical SHA-256("abc")
+    expect(await computeSHA256('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    );
+  });
+
+  test('returns the digest of the empty string', async () => {
+    expect(await computeSHA256('')).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  test('is a 64-char lowercase hex string', async () => {
+    const digest = await computeSHA256('hello world');
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/packages/wallet-sdk/src/internal/crypto.ts
+++ b/packages/wallet-sdk/src/internal/crypto.ts
@@ -1,0 +1,54 @@
+/**
+ * Small crypto helpers — Slice 1 (auth + user).
+ *
+ * EXTRACTED (re-housed framework-free) from `app/lib/password-generator.ts` and
+ * `app/lib/sha256.ts`. The only re-housing is `window.crypto` → the global `crypto`
+ * (WebCrypto; available in browsers + Bun/Node ≥ 19 — the SDK's targets) and dropping
+ * master's `window.getMockPassword` test hook. Used for guest-account passwords and the
+ * password-reset secret hash.
+ *
+ * @module
+ */
+
+/** The character sets a generated password may draw from. */
+const LETTERS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const NUMBERS = '0123456789';
+const SPECIAL = '!@#$%^&*()_+~';
+
+/**
+ * Generate a cryptographically-random password.
+ *
+ * Verbatim logic from master `generateRandomPassword` (letters + numbers + special by
+ * default), re-housed off `window.crypto` onto the global `crypto.getRandomValues`.
+ *
+ * @param length - password length (default 24; master uses 32 for guest accounts, 20 for
+ *   the reset secret).
+ * @returns the generated password.
+ */
+export function generateRandomPassword(length = 24): string {
+  const charset = LETTERS + NUMBERS + SPECIAL;
+  const password: string[] = [];
+  for (let i = 0; i < length; i++) {
+    const randomIndex =
+      crypto.getRandomValues(new Uint32Array(1))[0] % charset.length;
+    password.push(charset[randomIndex]);
+  }
+  return password.join('');
+}
+
+/**
+ * SHA-256 a string and return the lowercase hex digest.
+ *
+ * Verbatim from master `computeSHA256` (WebCrypto `crypto.subtle.digest`). Used to hash
+ * the password-reset secret before sending it to OpenSecret.
+ *
+ * @param message - the input string.
+ * @returns the hex-encoded SHA-256 digest.
+ */
+export async function computeSHA256(message: string): Promise<string> {
+  const data = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/packages/wallet-sdk/src/internal/db-user.test.ts
+++ b/packages/wallet-sdk/src/internal/db-user.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test';
+import { type AgicashDbUser, dbUserToUser } from './db-user';
+
+/** A complete `wallet.users` row with an email (a full user). */
+const fullRow: AgicashDbUser = {
+  id: 'user-1',
+  username: 'alice',
+  email: 'alice@example.com',
+  email_verified: true,
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-02T00:00:00.000Z',
+  default_btc_account_id: 'btc-acct',
+  default_usd_account_id: 'usd-acct',
+  default_currency: 'BTC',
+  cashu_locking_xpub: 'xpub-1',
+  encryption_public_key: 'enc-pk',
+  spark_identity_public_key: 'spark-pk',
+  terms_accepted_at: '2024-01-01T00:00:00.000Z',
+  gift_card_mint_terms_accepted_at: null,
+};
+
+describe('dbUserToUser', () => {
+  test('maps a row with an email to a FullUser (isGuest: false)', () => {
+    const user = dbUserToUser(fullRow);
+
+    expect(user.isGuest).toBe(false);
+    // narrow for the email field
+    if (user.isGuest === false) {
+      expect(user.email).toBe('alice@example.com');
+    }
+    expect(user.id).toBe('user-1');
+    expect(user.username).toBe('alice');
+    expect(user.emailVerified).toBe(true);
+    expect(user.createdAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(user.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+    expect(user.defaultBtcAccountId).toBe('btc-acct');
+    expect(user.defaultUsdAccountId).toBe('usd-acct');
+    expect(user.defaultCurrency).toBe('BTC');
+    expect(user.cashuLockingXpub).toBe('xpub-1');
+    expect(user.encryptionPublicKey).toBe('enc-pk');
+    expect(user.sparkIdentityPublicKey).toBe('spark-pk');
+    expect(user.termsAcceptedAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(user.giftCardMintTermsAcceptedAt).toBeNull();
+  });
+
+  test('maps a row with no email to a GuestUser (isGuest: true)', () => {
+    const user = dbUserToUser({ ...fullRow, email: null });
+
+    expect(user.isGuest).toBe(true);
+    expect('email' in user).toBe(false);
+  });
+
+  test('defaults a null default_btc_account_id to an empty string', () => {
+    const user = dbUserToUser({ ...fullRow, default_btc_account_id: null });
+    expect(user.defaultBtcAccountId).toBe('');
+  });
+
+  test('passes through a null default_usd_account_id as null', () => {
+    const user = dbUserToUser({ ...fullRow, default_usd_account_id: null });
+    expect(user.defaultUsdAccountId).toBeNull();
+  });
+});

--- a/packages/wallet-sdk/src/internal/db-user.ts
+++ b/packages/wallet-sdk/src/internal/db-user.ts
@@ -1,0 +1,100 @@
+/**
+ * Internal DB ⇄ domain `User` mapping — Slice 1 (auth + user).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/user/user-repository.ts` (`ReadUserRepository.toUser`
+ * + the `users`-table reads/writes). Master expresses the user as a DB row in the
+ * `wallet.users` table keyed by the OpenSecret user id — the agicash domain `User`
+ * is NOT the OpenSecret `UserResponse`; it is that DB row mapped to the domain shape.
+ *
+ * This module owns:
+ *  - {@link AgicashDbUser} — the `wallet.users` row shape (master:
+ *    `agicash-db/database.ts#AgicashDbUser`, itself `database.types.ts` generated). Lifted
+ *    verbatim as a hand-written type so the SDK can type the otherwise-`any` Supabase
+ *    reads without pulling the full generated `Database` types (those land in a later slice).
+ *  - {@link dbUserToUser} — the row→domain mapper (verbatim logic from
+ *    `ReadUserRepository.toUser`: email present ⇒ `FullUser`, else `GuestUser`;
+ *    `default_btc_account_id` defaults to `''`).
+ *
+ * @module
+ */
+import type { Currency } from '../types/money';
+import type { FullUser, GuestUser, User } from '../types/user';
+
+/**
+ * A row of the `wallet.users` table.
+ *
+ * Lifted verbatim from master `agicash-db/database.ts#AgicashDbUser`
+ * (`Database['wallet']['Tables']['users']['Row']`, generated in
+ * `supabase/database.types.ts`). Hand-written here so the SDK can narrow the (currently
+ * untyped) Supabase client reads in this slice; replaced by the generated `Database`
+ * types when those are lifted into the package.
+ */
+export type AgicashDbUser = {
+  /** UUID primary key (matches the OpenSecret user id). */
+  id: string;
+  /** The user's unique handle. */
+  username: string;
+  /** The user's email, or null for a guest. */
+  email: string | null;
+  /** Whether the email has been verified. */
+  email_verified: boolean;
+  /** Row creation time, ISO 8601. */
+  created_at: string;
+  /** Row last-update time, ISO 8601. */
+  updated_at: string;
+  /** UUID of the default BTC account, or null if unset. */
+  default_btc_account_id: string | null;
+  /** UUID of the default USD account, or null if unset. */
+  default_usd_account_id: string | null;
+  /** The user's preferred display currency. */
+  default_currency: Currency;
+  /** Extended public key used to derive cashu quote-locking keys. */
+  cashu_locking_xpub: string;
+  /** Public key used to encrypt the user's data at rest. */
+  encryption_public_key: string;
+  /** The user's Spark identity public key. */
+  spark_identity_public_key: string;
+  /** When the user accepted the terms of service (null if not yet accepted). */
+  terms_accepted_at: string | null;
+  /** When the user accepted the gift-card mint terms (null if not yet accepted). */
+  gift_card_mint_terms_accepted_at: string | null;
+};
+
+/**
+ * Map a `wallet.users` DB row to the domain {@link User}.
+ *
+ * Verbatim logic from master `ReadUserRepository.toUser`: an `email` present ⇒ a
+ * {@link FullUser} (`isGuest: false`), otherwise a {@link GuestUser} (`isGuest: true`);
+ * `default_btc_account_id` falls back to `''` when null.
+ *
+ * @param dbUser - the DB row.
+ * @returns the domain user.
+ */
+export function dbUserToUser(dbUser: AgicashDbUser): User {
+  const commonData = {
+    id: dbUser.id,
+    username: dbUser.username,
+    emailVerified: dbUser.email_verified,
+    createdAt: dbUser.created_at,
+    updatedAt: dbUser.updated_at,
+    cashuLockingXpub: dbUser.cashu_locking_xpub,
+    encryptionPublicKey: dbUser.encryption_public_key,
+    sparkIdentityPublicKey: dbUser.spark_identity_public_key,
+    defaultBtcAccountId: dbUser.default_btc_account_id ?? '',
+    defaultUsdAccountId: dbUser.default_usd_account_id,
+    defaultCurrency: dbUser.default_currency,
+    termsAcceptedAt: dbUser.terms_accepted_at,
+    giftCardMintTermsAcceptedAt: dbUser.gift_card_mint_terms_accepted_at,
+  };
+
+  if (dbUser.email) {
+    return {
+      ...commonData,
+      email: dbUser.email,
+      isGuest: false,
+    } satisfies FullUser;
+  }
+
+  return { ...commonData, isGuest: true } satisfies GuestUser;
+}

--- a/packages/wallet-sdk/src/internal/guest-account-storage.ts
+++ b/packages/wallet-sdk/src/internal/guest-account-storage.ts
@@ -1,0 +1,83 @@
+/**
+ * Guest-account credential storage — Slice 1 (auth + user).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `app/features/user/guest-account-storage.ts`. A guest account has no email, so its
+ * generated id + password must be persisted to let the SAME device sign back into the
+ * SAME guest account (rather than minting a new one each time). Master persists this in
+ * `window.localStorage`; the SDK persists it through the injected {@link StorageAdapter}
+ * (so MCP/fs works too).
+ *
+ * @module
+ */
+import type { StorageAdapter } from '../sdk';
+
+/** Storage key the guest credentials are persisted under (matches master). */
+const STORAGE_KEY = 'guestAccount';
+
+/** The persisted guest credentials. */
+export type GuestAccount = {
+  /** The guest user's id (from OpenSecret `signUpGuest`). */
+  id: string;
+  /** The randomly-generated guest password. */
+  password: string;
+};
+
+/**
+ * Validate a parsed value as {@link GuestAccount} (both fields present + strings). Replaces
+ * master's `zod/mini` schema check without adding a zod dependency to the SDK for this one
+ * shape.
+ */
+function isGuestAccount(value: unknown): value is GuestAccount {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as GuestAccount).id === 'string' &&
+    typeof (value as GuestAccount).password === 'string'
+  );
+}
+
+/**
+ * A small store for the guest-account credentials, over the injected storage adapter.
+ *
+ * Re-houses master's `guestAccountStorage` singleton as an instance bound to the SDK's
+ * {@link StorageAdapter}. `get` tolerates absent / malformed data by returning `null`.
+ */
+export class GuestAccountStorage {
+  /**
+   * @param storage - the pluggable storage adapter.
+   */
+  constructor(private readonly storage: StorageAdapter) {}
+
+  /**
+   * The persisted guest credentials, or `null` if none / malformed.
+   *
+   * @returns the stored {@link GuestAccount} or `null`.
+   */
+  async get(): Promise<GuestAccount | null> {
+    const raw = await this.storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isGuestAccount(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Persist the guest credentials.
+   *
+   * @param account - the `{ id, password }` to store.
+   */
+  async store(account: GuestAccount): Promise<void> {
+    await this.storage.setItem(STORAGE_KEY, JSON.stringify(account));
+  }
+
+  /** Remove the persisted guest credentials (e.g. after upgrading to a full account). */
+  async clear(): Promise<void> {
+    await this.storage.removeItem(STORAGE_KEY);
+  }
+}

--- a/packages/wallet-sdk/src/internal/open-secret.ts
+++ b/packages/wallet-sdk/src/internal/open-secret.ts
@@ -1,5 +1,5 @@
 /**
- * OpenSecret client wiring — §1 / Slice 0 connection wiring.
+ * OpenSecret client wiring — §1 / Slice 0 connection wiring + Slice 1 auth wrappers.
  *
  * The `@agicash/opensecret` package (the enclave/auth backend) is configured via a
  * module-global `configure({ apiUrl, clientId })` and then used through standalone
@@ -19,8 +19,45 @@
  *
  * @module
  */
-import { configure, generateThirdPartyToken } from '@agicash/opensecret';
+import {
+  changePassword as osChangePassword,
+  configure,
+  confirmPasswordReset as osConfirmPasswordReset,
+  convertGuestToUserAccount as osConvertGuestToUserAccount,
+  fetchUser as osFetchUser,
+  generateThirdPartyToken,
+  handleGoogleCallback as osHandleGoogleCallback,
+  initiateGoogleAuth as osInitiateGoogleAuth,
+  refreshAccessToken as osRefreshAccessToken,
+  requestPasswordReset as osRequestPasswordReset,
+  signIn as osSignIn,
+  signInGuest as osSignInGuest,
+  signOut as osSignOut,
+  signUp as osSignUp,
+  signUpGuest as osSignUpGuest,
+} from '@agicash/opensecret';
+import { jwtDecode } from 'jwt-decode';
 import type { StorageAdapter } from '../sdk';
+
+/**
+ * The current OpenSecret user (master `AuthUser = UserResponse['user']`). This is the
+ * ENCLAVE user (id / email / verified flag), NOT the agicash domain `User` (which is a
+ * `wallet.users` DB row). The auth/user domains use `.id` to read the DB row.
+ */
+export type OpenSecretUser = {
+  id: string;
+  name: string | null;
+  email?: string;
+  email_verified: boolean;
+  login_method: string;
+  created_at: string;
+  updated_at: string;
+};
+
+/** localStorage key the OpenSecret SDK persists its access token under. */
+const ACCESS_TOKEN_KEY = 'access_token';
+/** localStorage key the OpenSecret SDK persists its refresh token under. */
+const REFRESH_TOKEN_KEY = 'refresh_token';
 
 /** Init params for the OpenSecret client (from `SdkConfig.openSecret`). */
 export type OpenSecretConfig = {
@@ -33,9 +70,12 @@ export type OpenSecretConfig = {
 /**
  * Thin facade over the module-global `@agicash/opensecret` SDK. One per `Sdk` instance.
  *
- * PR2 wires CONFIGURATION + the third-party-token fetch (the only OpenSecret surface the
- * core connection layer needs — it feeds the Supabase access-token provider). Auth
- * methods (`signIn` / `signUp` / OAuth / session-expiry) are wired in the auth slice.
+ * PR2 wired CONFIGURATION + the third-party-token fetch (the OpenSecret surface the core
+ * connection layer needs — it feeds the Supabase access-token provider). Slice 1 (auth +
+ * user) adds the auth wrappers (`signIn` / `signUp` / guest / OAuth / password) + session
+ * presence (`hasSession`) + the current enclave user (`fetchUser`). Each auth method is a
+ * thin pass-through; the SDK domain layer (see ../domains/auth) adds the DB-user
+ * resolution + events.
  */
 export class OpenSecretClient {
   /**
@@ -69,5 +109,136 @@ export class OpenSecretClient {
   async generateThirdPartyToken(audience?: string): Promise<string> {
     const { token } = await generateThirdPartyToken(audience);
     return token;
+  }
+
+  // --- session presence ------------------------------------------------------
+
+  /**
+   * Whether a (non-expired) OpenSecret session exists, read from the storage adapter.
+   *
+   * Re-houses master `shared/auth.ts#isLoggedIn` off `window.localStorage` onto the
+   * injected {@link StorageAdapter}: there must be both an access and a refresh token,
+   * and the refresh token must not be expired. Used to short-circuit `getCurrentUser`
+   * and the Supabase token provider to `null` when signed out (rather than letting the
+   * enclave request fail).
+   *
+   * @returns `true` when a live session is present.
+   */
+  async hasSession(): Promise<boolean> {
+    const [accessToken, refreshToken] = await Promise.all([
+      this.storage.getItem(ACCESS_TOKEN_KEY),
+      this.storage.getItem(REFRESH_TOKEN_KEY),
+    ]);
+    if (!accessToken || !refreshToken) {
+      return false;
+    }
+    const { exp } = jwtDecode(refreshToken);
+    return !!exp && exp * 1000 > Date.now();
+  }
+
+  // --- auth (OpenSecret SDK wrappers; framework-free) ------------------------
+  //
+  // Each is a thin pass-through to the module-global `@agicash/opensecret` function;
+  // the SDK domain layer (see ../domains/auth) adds the DB-user resolution + events.
+  // The OpenSecret SDK persists/clears its own access+refresh tokens internally.
+
+  /** Sign in an existing user (enclave). Persists the session internally. */
+  async signIn(email: string, password: string): Promise<void> {
+    await osSignIn(email, password);
+  }
+
+  /** Create a full (email) user and sign it in (enclave). `inviteCode` is `''` (master). */
+  async signUp(email: string, password: string): Promise<void> {
+    await osSignUp(email, password, '');
+  }
+
+  /** Create a guest user (enclave), returning its generated id. `inviteCode` is `''`. */
+  async signUpGuest(password: string): Promise<{ id: string }> {
+    const { id } = await osSignUpGuest(password, '');
+    return { id };
+  }
+
+  /** Sign in to an existing guest account by its id + generated password (enclave). */
+  async signInGuest(id: string, password: string): Promise<void> {
+    await osSignInGuest(id, password);
+  }
+
+  /** Sign out (enclave). Clears the persisted session internally. */
+  async signOut(): Promise<void> {
+    await osSignOut();
+  }
+
+  /** Refresh the access token (enclave). Updates the persisted session internally. */
+  async refresh(): Promise<void> {
+    await osRefreshAccessToken();
+  }
+
+  /** Convert the current guest user into a full (email) account (enclave). */
+  async convertGuestToUserAccount(
+    email: string,
+    password: string,
+  ): Promise<void> {
+    await osConvertGuestToUserAccount(email, password);
+  }
+
+  /** Change the signed-in user's password (enclave). */
+  async changePassword(
+    currentPassword: string,
+    newPassword: string,
+  ): Promise<void> {
+    await osChangePassword(currentPassword, newPassword);
+  }
+
+  /**
+   * Request a password reset (enclave). The caller hashes a freshly-generated secret and
+   * passes the hash; the secret is returned so the caller can later confirm the reset.
+   */
+  async requestPasswordReset(
+    email: string,
+    hashedSecret: string,
+  ): Promise<void> {
+    await osRequestPasswordReset(email, hashedSecret);
+  }
+
+  /** Confirm a password reset with the emailed code + the secret from the request (enclave). */
+  async confirmPasswordReset(
+    email: string,
+    alphanumericCode: string,
+    plaintextSecret: string,
+    newPassword: string,
+  ): Promise<void> {
+    await osConfirmPasswordReset(
+      email,
+      alphanumericCode,
+      plaintextSecret,
+      newPassword,
+    );
+  }
+
+  /** Begin Google OAuth (enclave); returns the raw `auth_url` to redirect to. `inviteCode` is `''`. */
+  async initiateGoogleAuth(): Promise<{ authUrl: string }> {
+    const { auth_url } = await osInitiateGoogleAuth('');
+    return { authUrl: auth_url };
+  }
+
+  /** Complete Google OAuth from the redirect callback params (enclave). Persists the session. */
+  async handleGoogleCallback(
+    code: string,
+    state: string,
+    inviteCode: string,
+  ): Promise<void> {
+    await osHandleGoogleCallback(code, state, inviteCode);
+  }
+
+  /**
+   * The current enclave user (`fetchUser`), or `null` when there is no session. Returns
+   * the OpenSecret user — the domain layer maps `.id` to the `wallet.users` DB row.
+   */
+  async fetchUser(): Promise<OpenSecretUser | null> {
+    if (!(await this.hasSession())) {
+      return null;
+    }
+    const { user } = await osFetchUser();
+    return user;
   }
 }

--- a/packages/wallet-sdk/src/internal/session.test.ts
+++ b/packages/wallet-sdk/src/internal/session.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+import type { SdkEventMap } from '../types/events';
+import type { User } from '../types/user';
+import { TypedEventEmitter } from './event-emitter';
+import type { OpenSecretClient, OpenSecretUser } from './open-secret';
+import { SessionResolver } from './session';
+import type { SupabaseSessionTokenProvider } from './supabase-session';
+import type { UserRepository } from './user-repository';
+
+/** A domain user fixture. */
+const domainUser: User = {
+  id: 'user-1',
+  username: 'alice',
+  email: 'alice@example.com',
+  isGuest: false,
+  emailVerified: true,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  defaultBtcAccountId: 'btc',
+  defaultUsdAccountId: null,
+  defaultCurrency: 'BTC',
+  cashuLockingXpub: 'xpub',
+  encryptionPublicKey: 'enc',
+  sparkIdentityPublicKey: 'spark',
+  termsAcceptedAt: null,
+  giftCardMintTermsAcceptedAt: null,
+};
+
+/** An OpenSecret enclave user fixture. */
+const osUser: OpenSecretUser = {
+  id: 'user-1',
+  name: null,
+  email: 'alice@example.com',
+  email_verified: true,
+  login_method: 'email',
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-01T00:00:00.000Z',
+};
+
+/**
+ * Build a {@link SessionResolver} over fakes. `currentOsUser` controls who the enclave
+ * reports (null = signed out); the user repo always maps id → {@link domainUser}. Returns
+ * the resolver plus the spies (token-cleared count, emitted events).
+ */
+function makeResolver(currentOsUser: OpenSecretUser | null) {
+  let cleared = 0;
+  const events = new TypedEventEmitter<SdkEventMap>();
+  const openSecret = {
+    fetchUser: async () => currentOsUser,
+  } as unknown as OpenSecretClient;
+  const users = {
+    get: async (id: string) => ({ ...domainUser, id }),
+  } as unknown as UserRepository;
+  const sessionToken = {
+    clear: () => {
+      cleared += 1;
+    },
+  } as unknown as SupabaseSessionTokenProvider;
+
+  const resolver = new SessionResolver(openSecret, users, sessionToken, events);
+  return { resolver, events, getCleared: () => cleared };
+}
+
+describe('SessionResolver.getCurrentUser', () => {
+  test('returns null when there is no enclave session', async () => {
+    const { resolver } = makeResolver(null);
+    expect(await resolver.getCurrentUser()).toBeNull();
+  });
+
+  test('resolves the DB user for the signed-in enclave id', async () => {
+    const { resolver } = makeResolver(osUser);
+    const user = await resolver.getCurrentUser();
+    expect(user?.id).toBe('user-1');
+    expect(user?.username).toBe('alice');
+  });
+});
+
+describe('SessionResolver.requireCurrentUser', () => {
+  test('throws when signed out', async () => {
+    const { resolver } = makeResolver(null);
+    await expect(resolver.requireCurrentUser()).rejects.toThrow(
+      'No authenticated user',
+    );
+  });
+});
+
+describe('SessionResolver.completeSignIn', () => {
+  test('clears the cached token, returns the user, and emits auth:signed-in', async () => {
+    const { resolver, events, getCleared } = makeResolver(osUser);
+    const received: User[] = [];
+    events.on('auth:signed-in', ({ user }) => received.push(user));
+
+    const user = await resolver.completeSignIn();
+
+    expect(getCleared()).toBe(1);
+    expect(user.id).toBe('user-1');
+    expect(received).toHaveLength(1);
+    expect(received[0]?.id).toBe('user-1');
+  });
+});
+
+describe('SessionResolver.completeSignOut', () => {
+  test('clears the cached token and emits auth:signed-out', () => {
+    const { resolver, events, getCleared } = makeResolver(osUser);
+    let signedOut = 0;
+    events.on('auth:signed-out', () => {
+      signedOut += 1;
+    });
+
+    resolver.completeSignOut();
+
+    expect(getCleared()).toBe(1);
+    expect(signedOut).toBe(1);
+  });
+});

--- a/packages/wallet-sdk/src/internal/session.ts
+++ b/packages/wallet-sdk/src/internal/session.ts
@@ -1,0 +1,98 @@
+/**
+ * Internal session resolver — Slice 1 (auth + user).
+ *
+ * The agicash domain {@link User} lives in the `wallet.users` DB row, keyed by the
+ * OpenSecret user id. Resolving "the current user" therefore takes two steps: ask the
+ * enclave who is signed in (`OpenSecretClient.fetchUser`), then read that id's DB row
+ * (`UserRepository.get`). Both the auth domain (whose methods return the user after a
+ * sign-in) and the user domain (`getCurrentUser` / `updateUsername`) need this, so it is
+ * factored here.
+ *
+ * This object also owns the post-auth bookkeeping shared by every sign-in path: dropping
+ * the cached Supabase token (so the next DB read re-fetches under the new session) and
+ * emitting `auth:signed-in`.
+ *
+ * @module
+ */
+import type { SdkEventMap } from '../types/events';
+import type { User } from '../types/user';
+import type { TypedEventEmitter } from './event-emitter';
+import type { OpenSecretClient } from './open-secret';
+import type { SupabaseSessionTokenProvider } from './supabase-session';
+import type { UserRepository } from './user-repository';
+
+/**
+ * Resolves + tracks the current authenticated user across the OpenSecret enclave and the
+ * `wallet.users` DB row. One per `Sdk` instance; shared by the auth + user domains.
+ */
+export class SessionResolver {
+  /**
+   * @param openSecret - the enclave client (who-is-signed-in + session ops).
+   * @param users - the `wallet.users` repository (id → domain user).
+   * @param sessionToken - the Supabase access-token cache (cleared on any session change).
+   * @param events - the SDK event emitter (`auth:*`).
+   */
+  constructor(
+    private readonly openSecret: OpenSecretClient,
+    private readonly users: UserRepository,
+    private readonly sessionToken: SupabaseSessionTokenProvider,
+    private readonly events: TypedEventEmitter<SdkEventMap>,
+  ) {}
+
+  /**
+   * The currently signed-in user, or `null` when there is no session.
+   *
+   * Re-houses master `useUser` / `ReadUserRepository.get`: enclave user id → DB row →
+   * domain {@link User}. Returns `null` (not a throw) when signed out, matching the
+   * contract's `getCurrentUser(): Query<User | null>` read (the wrapping into a `Query`
+   * happens one layer up, in {@link UserDomain}; this resolver is the fetch body).
+   *
+   * @returns the current user, or `null`.
+   */
+  async getCurrentUser(): Promise<User | null> {
+    const osUser = await this.openSecret.fetchUser();
+    if (!osUser) {
+      return null;
+    }
+    return this.users.get(osUser.id);
+  }
+
+  /**
+   * The current user, asserting there is one. Used by the auth methods that resolve the
+   * user immediately after a successful enclave sign-in (where a session is guaranteed),
+   * and by `updateUsername`.
+   *
+   * @returns the current user.
+   * @throws Error if no session exists (should not happen on a freshly-authenticated path).
+   */
+  async requireCurrentUser(): Promise<User> {
+    const user = await this.getCurrentUser();
+    if (!user) {
+      throw new Error('No authenticated user');
+    }
+    return user;
+  }
+
+  /**
+   * Resolve the current user after a sign-in transition, then drop the cached Supabase
+   * token (the next DB read re-fetches under the new identity) and emit `auth:signed-in`.
+   * The shared tail of every sign-in / sign-up / guest / upgrade / OAuth-complete path.
+   *
+   * @returns the freshly signed-in user.
+   */
+  async completeSignIn(): Promise<User> {
+    this.sessionToken.clear();
+    const user = await this.requireCurrentUser();
+    this.events.emit('auth:signed-in', { user });
+    return user;
+  }
+
+  /**
+   * Tear down the session locally after an enclave sign-out: drop the cached Supabase
+   * token and emit `auth:signed-out`.
+   */
+  completeSignOut(): void {
+    this.sessionToken.clear();
+    this.events.emit('auth:signed-out', {});
+  }
+}

--- a/packages/wallet-sdk/src/internal/stub-domains.ts
+++ b/packages/wallet-sdk/src/internal/stub-domains.ts
@@ -4,10 +4,11 @@
  * Each factory returns an object implementing its domain interface (§2-§10) where
  * every method throws {@link NotImplementedError} (or returns a rejected/throwing
  * Query for observable-fetch methods). The `Sdk` shell wires its domain accessors
- * to these so the public surface is fully present + type-correct in PR2, while the
- * real business logic lands in later slices (auth → S1, accounts/scan → S2,
- * cashu/spark → S3, transactions/contacts/transfers → S4, background → S5).
- * Swapping a stub for a real impl is the unit of work for each slice.
+ * to these so the public surface is fully present + type-correct, while the real
+ * business logic lands in later slices (auth + user → S1 (DONE — real impls wired in
+ * Sdk.create), accounts/scan → S2, cashu/spark → S3,
+ * transactions/contacts/transfers → S4, background → S5). Swapping a stub for a real
+ * impl is the unit of work for each slice.
  *
  * Implementing the interfaces (rather than casting) keeps the stubs honest: if a
  * contract method's signature changes, the stub fails to compile until updated.
@@ -16,7 +17,6 @@
  */
 import type {
   AccountsDomain,
-  AuthDomain,
   BackgroundDomain,
   CashuDomain,
   ContactsDomain,
@@ -25,7 +25,6 @@ import type {
   SparkDomain,
   TransactionsDomain,
   TransfersDomain,
-  UserDomain,
 } from '../domains';
 import { NotImplementedError } from '../errors';
 import type { Query } from '../types/query';
@@ -55,25 +54,8 @@ function stubQuery<T = any>(method: string): Query<T> {
   };
 }
 
-/** Stub `AuthDomain` (real impl: Slice 1). */
-export const createAuthStub = (): AuthDomain => ({
-  signIn: () => unimplemented('auth.signIn'),
-  signUp: () => unimplemented('auth.signUp'),
-  signInGuest: () => unimplemented('auth.signInGuest'),
-  signOut: () => unimplemented('auth.signOut'),
-  refresh: () => unimplemented('auth.refresh'),
-  resetPassword: () => unimplemented('auth.resetPassword'),
-  changePassword: () => unimplemented('auth.changePassword'),
-  upgradeGuest: () => unimplemented('auth.upgradeGuest'),
-  beginGoogleSignIn: () => unimplemented('auth.beginGoogleSignIn'),
-  completeOAuth: () => unimplemented('auth.completeOAuth'),
-});
-
-/** Stub `UserDomain` (real impl: Slice 1). */
-export const createUserStub = (): UserDomain => ({
-  getCurrentUser: () => stubQuery('user.getCurrentUser'),
-  updateUsername: () => unimplemented('user.updateUsername'),
-});
+// NOTE: `AuthDomain` + `UserDomain` are REAL as of Slice 1 (see ../domains/auth +
+// ../domains/user, wired in Sdk.create) — their stubs have been removed.
 
 /** Stub `AccountsDomain` (real impl: Slice 2). */
 export const createAccountsStub = (): AccountsDomain => ({

--- a/packages/wallet-sdk/src/internal/user-repository.test.ts
+++ b/packages/wallet-sdk/src/internal/user-repository.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test';
+import { DomainError, NotFoundError } from '../errors';
+import type { AgicashDbUser } from './db-user';
+import type { WalletSupabaseClient } from './supabase-client';
+import { UserRepository } from './user-repository';
+
+/** A representative `wallet.users` row. */
+const row: AgicashDbUser = {
+  id: 'user-1',
+  username: 'alice',
+  email: 'alice@example.com',
+  email_verified: true,
+  created_at: '2024-01-01T00:00:00.000Z',
+  updated_at: '2024-01-02T00:00:00.000Z',
+  default_btc_account_id: 'btc-acct',
+  default_usd_account_id: null,
+  default_currency: 'BTC',
+  cashu_locking_xpub: 'xpub-1',
+  encryption_public_key: 'enc-pk',
+  spark_identity_public_key: 'spark-pk',
+  terms_accepted_at: null,
+  gift_card_mint_terms_accepted_at: null,
+};
+
+/** The shape every terminal builder call (`single`/`maybeSingle`) resolves to. */
+type Result = { data: unknown; error: unknown };
+
+/**
+ * A fake Supabase client whose fluent `from(...).select/update/eq/...` chain is a no-op and
+ * whose terminal `single()` / `maybeSingle()` resolve to a pre-set result. Records the last
+ * `update(...)` payload so tests can assert what was written. Cast to the client type — only
+ * the methods the repository touches are implemented.
+ */
+function fakeDb(result: Result) {
+  let lastUpdate: unknown;
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    update: (payload: unknown) => {
+      lastUpdate = payload;
+      return chain;
+    },
+    eq: () => chain,
+    single: async () => result,
+    maybeSingle: async () => result,
+  };
+  const db = {
+    from: () => chain,
+  } as unknown as WalletSupabaseClient;
+  return { db, getLastUpdate: () => lastUpdate };
+}
+
+describe('UserRepository.get', () => {
+  test('returns the mapped domain user for an existing row', async () => {
+    const { db } = fakeDb({ data: row, error: null });
+    const repo = new UserRepository(db);
+
+    const user = await repo.get('user-1');
+
+    expect(user.id).toBe('user-1');
+    expect(user.username).toBe('alice');
+    expect(user.isGuest).toBe(false);
+  });
+
+  test('throws NotFoundError when no row exists', async () => {
+    const { db } = fakeDb({ data: null, error: null });
+    const repo = new UserRepository(db);
+
+    await expect(repo.get('missing')).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test('throws on a read error', async () => {
+    const { db } = fakeDb({ data: null, error: { message: 'boom' } });
+    const repo = new UserRepository(db);
+
+    await expect(repo.get('user-1')).rejects.toThrow('Failed to get user');
+  });
+});
+
+describe('UserRepository.updateUsername', () => {
+  test('writes the username and returns the updated user', async () => {
+    const updatedRow = { ...row, username: 'bob' };
+    const { db, getLastUpdate } = fakeDb({ data: updatedRow, error: null });
+    const repo = new UserRepository(db);
+
+    const user = await repo.updateUsername('user-1', 'bob');
+
+    expect(getLastUpdate()).toEqual({ username: 'bob' });
+    expect(user.username).toBe('bob');
+  });
+
+  test('throws DomainError when the username is taken (unique violation 23505)', async () => {
+    const { db } = fakeDb({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value' },
+    });
+    const repo = new UserRepository(db);
+
+    const promise = repo.updateUsername('user-1', 'taken');
+    await expect(promise).rejects.toBeInstanceOf(DomainError);
+    await expect(promise).rejects.toThrow('already taken');
+  });
+
+  test('throws a generic error for a non-unique-violation failure', async () => {
+    const { db } = fakeDb({
+      data: null,
+      error: { code: '500', message: 'server error' },
+    });
+    const repo = new UserRepository(db);
+
+    const promise = repo.updateUsername('user-1', 'bob');
+    await expect(promise).rejects.toThrow('Failed to update user');
+    await expect(promise).rejects.not.toBeInstanceOf(DomainError);
+  });
+});

--- a/packages/wallet-sdk/src/internal/user-repository.ts
+++ b/packages/wallet-sdk/src/internal/user-repository.ts
@@ -1,0 +1,104 @@
+/**
+ * Internal `wallet.users` repository — Slice 1 (auth + user).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/user/user-repository.ts`
+ * (`ReadUserRepository.get` + `WriteUserRepository.update`). Master expresses these as
+ * React-hook-constructed repositories over the TanStack-wired Supabase client; here they
+ * are plain async methods over the SDK-owned client (passed in), reading/writing the
+ * `wallet.users` table and mapping rows via {@link dbUserToUser}.
+ *
+ * Only the two reads/writes the auth + user domains need are ported: fetch-by-id and
+ * username update. The rest of master's user repository (upsert-with-accounts, default
+ * account resolution) belongs to later slices.
+ *
+ * @module
+ */
+import { DomainError, NotFoundError } from '../errors';
+import type { User } from '../types/user';
+import { type AgicashDbUser, dbUserToUser } from './db-user';
+import type { WalletSupabaseClient } from './supabase-client';
+
+/**
+ * Postgres unique-violation SQLSTATE. The `wallet.users.username` column is unique, so a
+ * `23505` on the username update means the chosen username is already taken — surfaced as
+ * a {@link DomainError} (the contract's `updateUsername` "throws DomainError if taken").
+ * Master raises `UniqueConstraintError` here; the SDK collapses it to `DomainError`.
+ */
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * Reads + writes for the `wallet.users` table, scoped (via RLS) to the signed-in user.
+ *
+ * Holds the SDK-owned Supabase client. Methods take the `userId` (the OpenSecret user id)
+ * the auth/user domain resolves from the current session.
+ */
+export class UserRepository {
+  /**
+   * @param db - the SDK-owned Supabase client (schema pinned to `wallet`).
+   */
+  constructor(private readonly db: WalletSupabaseClient) {}
+
+  /**
+   * Fetch the `wallet.users` row for `userId` and map it to the domain {@link User}.
+   *
+   * Verbatim logic from master `ReadUserRepository.get` (+ the row→domain mapping), minus
+   * the abort-signal plumbing. A missing row surfaces as {@link NotFoundError}.
+   *
+   * @param userId - the user id (matches the OpenSecret user id).
+   * @returns the domain user.
+   * @throws NotFoundError if no row exists for `userId`.
+   * @throws Error if the read otherwise fails.
+   */
+  async get(userId: string): Promise<User> {
+    const { data, error } = await this.db
+      .from('users')
+      .select()
+      .eq('id', userId)
+      .maybeSingle<AgicashDbUser>();
+
+    if (error) {
+      throw new Error('Failed to get user', { cause: error });
+    }
+    if (!data) {
+      throw new NotFoundError(`User ${userId} not found`, 'USER_NOT_FOUND');
+    }
+
+    return dbUserToUser(data);
+  }
+
+  /**
+   * Update the user's username and return the updated domain {@link User}.
+   *
+   * Verbatim logic from master `WriteUserRepository.update` (the `username` path): updates
+   * the row, selects it back, and maps it. A unique-violation ({@link UNIQUE_VIOLATION})
+   * means the username is taken → {@link DomainError} (master raised `UniqueConstraintError`;
+   * the SDK surfaces the contract's `DomainError`).
+   *
+   * @param userId - the user id.
+   * @param username - the new username.
+   * @returns the updated domain user.
+   * @throws DomainError if the username is already taken.
+   * @throws Error if the update otherwise fails.
+   */
+  async updateUsername(userId: string, username: string): Promise<User> {
+    const { data, error } = await this.db
+      .from('users')
+      .update({ username })
+      .eq('id', userId)
+      .select()
+      .single<AgicashDbUser>();
+
+    if (error) {
+      if (error.code === UNIQUE_VIOLATION) {
+        throw new DomainError(
+          'This username is already taken',
+          'USERNAME_TAKEN',
+        );
+      }
+      throw new Error('Failed to update user', { cause: error });
+    }
+
+    return dbUserToUser(data);
+  }
+}

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -31,11 +31,14 @@ import type {
   TransfersDomain,
   UserDomain,
 } from './domains';
+import { AuthDomainImpl } from './domains/auth';
+import { UserDomainImpl } from './domains/user';
 import { TypedEventEmitter } from './internal/event-emitter';
+import { GuestAccountStorage } from './internal/guest-account-storage';
 import { OpenSecretClient } from './internal/open-secret';
+import { SessionResolver } from './internal/session';
 import {
   createAccountsStub,
-  createAuthStub,
   createBackgroundStub,
   createCashuStub,
   createContactsStub,
@@ -44,7 +47,6 @@ import {
   createSparkStub,
   createTransactionsStub,
   createTransfersStub,
-  createUserStub,
 } from './internal/stub-domains';
 import {
   type SupabaseConnectionConfig,
@@ -52,6 +54,7 @@ import {
   createSupabaseClient,
 } from './internal/supabase-client';
 import { SupabaseSessionTokenProvider } from './internal/supabase-session';
+import { UserRepository } from './internal/user-repository';
 import { QueryClient } from './query';
 import type { EventEmitter, SdkEventMap } from './types/events';
 
@@ -201,17 +204,26 @@ export class Sdk {
   private readonly connections: SdkConnections;
 
   /**
-   * Private — construct via {@link Sdk.create}. Takes the assembled connection bundle and
-   * wires the domain accessors. PR2 wires every accessor to a stub; later slices replace
-   * the stub factories here with real implementations that receive `connections`.
+   * Private — construct via {@link Sdk.create}. Takes the assembled connection bundle plus
+   * the already-built real domains (`auth` + `user` as of Slice 1) and wires the domain
+   * accessors. Domains not yet implemented are wired to a stub; later slices replace each
+   * stub here with its real implementation.
+   *
+   * @param connections - the shared connection bundle.
+   * @param domains - the real domain implementations built in {@link Sdk.create}.
    */
-  private constructor(connections: SdkConnections) {
+  private constructor(
+    connections: SdkConnections,
+    domains: { auth: AuthDomain; user: UserDomain },
+  ) {
     this.connections = connections;
     this.events = connections.events;
 
-    // --- domain accessors (STUBS in PR2 — swap per slice) --------------------
-    this.auth = createAuthStub();
-    this.user = createUserStub();
+    // --- real domains (Slice 1: auth + user) ---------------------------------
+    this.auth = domains.auth;
+    this.user = domains.user;
+
+    // --- domain accessors still STUBBED (swap per slice) ---------------------
     this.accounts = createAccountsStub();
     this.scan = createScanStub();
     this.cashu = createCashuStub();
@@ -244,9 +256,14 @@ export class Sdk {
 
     // Access-token provider: the Supabase `accessToken` callback. Audience = the Supabase
     // project URL (so the mint-CAT audience stays separate, per master's two-audience use).
-    const sessionToken = new SupabaseSessionTokenProvider(() =>
-      openSecret.generateThirdPartyToken(config.supabase.url),
-    );
+    // Short-circuit to `null` when signed out (master `supabase-session.ts` gates on
+    // `isLoggedIn()`) so unauthenticated DB reads don't trigger a failing enclave call.
+    const sessionToken = new SupabaseSessionTokenProvider(async () => {
+      if (!(await openSecret.hasSession())) {
+        return null;
+      }
+      return openSecret.generateThirdPartyToken(config.supabase.url);
+    });
 
     // Supabase: SDK-owned client (schema 'wallet', RLS via the token provider).
     const supabaseConfig: SupabaseConnectionConfig = {
@@ -263,17 +280,35 @@ export class Sdk {
     // Never exposed to consumers — wired via SdkConnections.
     const queryClient = new QueryClient();
 
+    const events = new TypedEventEmitter<SdkEventMap>();
+
     const connections: SdkConnections = {
       supabase,
       openSecret,
       sessionToken,
       storage: config.storage,
-      events: new TypedEventEmitter<SdkEventMap>(),
+      events,
       queryClient,
       clientId: config.clientId ?? generateClientId(),
     };
 
-    return new Sdk(connections);
+    // --- Slice 1: auth + user domains ----------------------------------------
+    // The agicash domain `User` is the `wallet.users` row keyed by the OpenSecret user id,
+    // so both domains share a session resolver (enclave id → DB row + `auth:*` events) over
+    // one user repository. `getCurrentUser` is reactive, so the user domain also takes the
+    // SDK-internal QueryClient (it wraps the resolver read via `toQuery`).
+    const users = new UserRepository(supabase);
+    const session = new SessionResolver(
+      openSecret,
+      users,
+      sessionToken,
+      events,
+    );
+    const guestStorage = new GuestAccountStorage(config.storage);
+    const auth = new AuthDomainImpl(openSecret, session, guestStorage);
+    const user = new UserDomainImpl(queryClient, session, users);
+
+    return new Sdk(connections, { auth, user });
   }
 
   /**

--- a/packages/wallet-sdk/src/types/user.ts
+++ b/packages/wallet-sdk/src/types/user.ts
@@ -16,8 +16,10 @@ type CommonUserData = {
   giftCardMintTermsAcceptedAt: string | null;
 };
 
-type FullUser = CommonUserData & { email: string; isGuest: false };
-type GuestUser = CommonUserData & { isGuest: true };
+// Exported (Slice 1) so the internal DB→domain mapper (`internal/db-user.ts`) can
+// `satisfies FullUser` / `satisfies GuestUser` when narrowing a row to the domain user.
+export type FullUser = CommonUserData & { email: string; isGuest: false };
+export type GuestUser = CommonUserData & { isGuest: true };
 
 export type User = FullUser | GuestUser;
 


### PR DESCRIPTION
## What

PR3 of the **reactive** `@agicash/wallet-sdk` (design B): replaces the auth + user **stubs** in the reactive PR2 core (#1130) with real implementations of PR1's (#1129) `AuthDomain` + `UserDomain` interfaces.

This is a **verbatim lift** of the proven no-cache extraction (`sdk/pr3-auth-user`) onto the reactive PR2 base — **adaptation, not a rewrite**. The read bodies are identical to the no-cache version; only the **one observable read** changes its return wrapper to `Query<T>`.

## The recipe (also how PR4–7 will adapt)

- **observable fetch → `Query<T>`** via `toQuery(client, [stable-key], existingReadFn)`, memoised per key (stable ref).
- **derivation → sync** (none in PR3).
- **write / action → `Promise`** (everything else).

## What lands

**`AuthDomainImpl`** (all ACTIONs → `Promise`, lifted verbatim): sign in/up/guest/upgrade/OAuth-complete + sign-out/refresh/reset-password/change-password/begin-Google. Built over the OpenSecret client, the `SessionResolver` (enclave id → `wallet.users` row → domain `User`, emits `auth:*`), and `GuestAccountStorage`.

**`UserDomainImpl`**:
- `getCurrentUser(): Query<User | null>` — the **same** no-cache read body (`SessionResolver.getCurrentUser`: enclave id → DB row → `User`) wrapped in `toQuery(client, ['currentUser'], …)` and **memoised per key** (the `#q` map), so repeated calls return the **same stable `Query` ref**. The reactive runtime (`toQuery` + the SDK-internal `QueryClient`) is PR2's — TanStack stays hidden behind `Query<T>`.
- `updateUsername(...)` — a write → **stays `Promise`** (lifted verbatim).

**Internals** (re-housed framework-free): `SessionResolver`, `UserRepository` (+ `dbUserToUser` / `AgicashDbUser`), `GuestAccountStorage`, crypto helpers (`generateRandomPassword` / `computeSHA256`).

**Wiring**: `open-secret.ts` gains the auth wrappers + `hasSession` + `fetchUser` (the PR2 base only had `configure` + `generateThirdPartyToken`); `Sdk.create` now short-circuits the Supabase access token to `null` when signed out, and builds + wires the real auth/user domains (passing the internal `QueryClient` to the user domain). The auth/user stubs are removed.

## Reactive vs no-cache reconciliation (mechanical only)

- `StorageAdapter` imported from `../sdk` (reactive home) instead of `../types/dependencies`.
- `SdkEventMap` imported from `../types/events` instead of `../events`.
- `FullUser` / `GuestUser` exported from `types/user.ts` so the DB→domain mapper can `satisfies` them.

No interface conflicts between PR1 and the no-cache impl — signatures matched; only the `getCurrentUser` return type differs (Promise → Query), which is exactly PR1's reactive contract.

## Framework-free

No `react` / `@tanstack/react-query` imports in `packages/wallet-sdk`; `@tanstack/query-core` is reached **only** via `toQuery` in `query.ts`. The React layer is the separate `@agicash/react-wallet-sdk` (untouched here).

## Tests

Ported the no-cache PR3 suite verbatim (auth / session / user-repository / db-user / crypto). Adapted `user.test.ts` to assert `getCurrentUser` returns a `Query<User | null>` (subscribe fires with the user/null; `toPromise()` resolves to it; memoised same-ref), keeping the auth + `updateUsername` write tests `Promise`-shaped.

## Local CI gate — green

- `bun --filter='*' run test`: **wallet-sdk 66 pass · web-wallet 133 pass · react-wallet-sdk 5 pass** (0 fail)
- `tsc --noEmit`: clean across all packages
- `biome format:check` + `lint:check`: clean (the 2 pre-existing `vite-env.d.ts` warnings are untouched)
- `bun install --frozen-lockfile`: succeeds, **no new deps**

🤖 Generated with [Claude Code](https://claude.com/claude-code)