### PR TITLE
feat(wallet-sdk): real accounts + scan domains (PR4, reactive design B)

### DIFF
--- a/packages/react-wallet-sdk/src/hooks.ts
+++ b/packages/react-wallet-sdk/src/hooks.ts
@@ -5,12 +5,13 @@
  * and bridges it to React via useQ. The domain memos the Query by key, so
  * repeated hook calls in a single render tree share the same observer.
  */
-import type { Account } from '@agicash/wallet-sdk';
+import type { ExtendedAccount } from '@agicash/wallet-sdk';
 import { useSdk } from './provider';
 import { useQ } from './use-q';
 
 /**
- * Returns the current user's account list. Suspends while loading.
+ * Returns the current user's account list (each account carries `isDefault`). Suspends while
+ * loading.
  *
  * @example
  * ```tsx
@@ -20,7 +21,7 @@ import { useQ } from './use-q';
  * }
  * ```
  */
-export function useAccounts(): Account[] {
+export function useAccounts(): ExtendedAccount[] {
   // accounts.list() is memoized by the domain (stable Query<T> ref) so this
   // hook is cheap to call from multiple components.
   return useQ(useSdk().accounts.list());

--- a/packages/wallet-sdk/src/domains.ts
+++ b/packages/wallet-sdk/src/domains.ts
@@ -5,6 +5,7 @@ import type {
   Account,
   AddAccountConfig,
   CashuAccount,
+  ExtendedAccount,
   SparkAccount,
 } from './types/account';
 import type {
@@ -43,16 +44,33 @@ export type CompleteOAuthParams = { code: string; state?: string };
 // ---- Domains ----
 
 export interface AccountsDomain {
-  /** Observable fetch — returns Query<T> */
-  list(): Query<Account[]>;
-  /** Observable fetch — returns Query<T> */
-  get(id: string): Query<Account | null>;
-  /** Observable fetch — returns Query<T> */
-  getDefault(params?: { currency?: Currency }): Query<Account | null>;
+  /**
+   * Observable fetch — returns `Query<ExtendedAccount[]>`. Each account carries `isDefault`
+   * (the SDK computes it from the user's per-currency default-account ids); the default sorts
+   * to the top.
+   */
+  list(): Query<ExtendedAccount[]>;
+  /**
+   * Observable fetch — returns `Query<ExtendedAccount | null>` (the account carries
+   * `isDefault`).
+   */
+  get(id: string): Query<ExtendedAccount | null>;
+  /**
+   * Observable fetch — returns `Query<ExtendedAccount | null>` (the default account, which
+   * therefore has `isDefault === true`).
+   */
+  getDefault(params?: { currency?: Currency }): Query<ExtendedAccount | null>;
   /** Pure derivation — sync */
   getBalance(account: Account): Money;
-  /** Pure derivation over passed-in accounts — sync */
-  suggestFor(intent: PaymentIntent, accounts: Account[]): AccountSuggestion;
+  /**
+   * Pure derivation over passed-in accounts — sync. Takes {@link ExtendedAccount}s so the
+   * no-sufficient-balance fallback can pick the user's default account (`isDefault`),
+   * matching master.
+   */
+  suggestFor(
+    intent: PaymentIntent,
+    accounts: ExtendedAccount[],
+  ): AccountSuggestion;
   add(config: AddAccountConfig): Promise<Account>;
   setDefault(account: Account): Promise<void>;
 }

--- a/packages/wallet-sdk/src/domains/accounts.test.ts
+++ b/packages/wallet-sdk/src/domains/accounts.test.ts
@@ -4,7 +4,7 @@ import type { AccountRepository } from '../internal/account-repository';
 import type { SessionResolver } from '../internal/session';
 import type { UserRepository } from '../internal/user-repository';
 import { QueryClient } from '../query';
-import type { Account, CashuAccount } from '../types/account';
+import type { Account, CashuAccount, ExtendedAccount } from '../types/account';
 import { type Currency, Money } from '../types/money';
 import type { Query } from '../types/query';
 import type { PaymentIntent } from '../types/scan';
@@ -56,6 +56,13 @@ function cashuAccount(opts: {
         : [],
     wallet: {} as never,
   };
+}
+
+/** Build an extended account (adds the `isDefault` flag `suggestFor` reads). */
+function extended(
+  opts: Parameters<typeof cashuAccount>[0] & { isDefault?: boolean },
+): ExtendedAccount {
+  return { ...cashuAccount(opts), isDefault: opts.isDefault ?? false };
 }
 
 /** A fresh QueryClient per domain (the SDK-internal one in production). */
@@ -139,6 +146,22 @@ describe('AccountsDomainImpl.list (observable read → Query)', () => {
 
     const result = await query.toPromise();
     expect(result.map((x) => x.id)).toEqual(['b', 'a']);
+    // ExtendedAccount: every account carries `isDefault` (none is the user's default here).
+    expect(result.map((x) => x.isDefault)).toEqual([false, false]);
+  });
+
+  test('decorates accounts with isDefault and sorts the default account to the top', async () => {
+    // baseUser.defaultBtcAccountId === 'btc-default'.
+    const def = cashuAccount({ id: 'btc-default' });
+    def.createdAt = '2026-05-01T00:00:00.000Z'; // newest — would sort LAST by creation date
+    const other = cashuAccount({ id: 'other' });
+    other.createdAt = '2026-01-01T00:00:00.000Z';
+    const { domain } = buildDomain({ accounts: [other, def] });
+
+    const result = await domain.list().toPromise();
+    // Default sorts to the top despite being the newest account.
+    expect(result.map((x) => x.id)).toEqual(['btc-default', 'other']);
+    expect(result.map((x) => x.isDefault)).toEqual([true, false]);
   });
 
   test('subscribe fires with the resolved accounts', async () => {
@@ -162,8 +185,20 @@ describe('AccountsDomainImpl.get (observable read → Query)', () => {
 
     const query = domain.get('a');
     expect(typeof query.subscribe).toBe('function');
-    expect((await query.toPromise())?.id).toBe('a');
+    const got = await query.toPromise();
+    expect(got?.id).toBe('a');
+    // ExtendedAccount: carries `isDefault` (false — 'a' is not the user's default).
+    expect(got?.isDefault).toBe(false);
     expect(getById).toHaveBeenCalledWith('a');
+  });
+
+  test('flags isDefault when the fetched account is the user default', async () => {
+    const def = cashuAccount({ id: 'btc-default' });
+    const { domain } = buildDomain({ accounts: [def] });
+
+    const got = await domain.get('btc-default').toPromise();
+    expect(got?.id).toBe('btc-default');
+    expect(got?.isDefault).toBe(true);
   });
 
   test('resolves to null for a missing id', async () => {
@@ -188,6 +223,8 @@ describe('AccountsDomainImpl.getDefault (observable read → Query)', () => {
 
     const result = await domain.getDefault().toPromise();
     expect(result?.id).toBe('btc-default');
+    // The default account is, by definition, flagged isDefault.
+    expect(result?.isDefault).toBe(true);
   });
 
   test('reads the USD default when currency=USD', async () => {
@@ -198,6 +235,7 @@ describe('AccountsDomainImpl.getDefault (observable read → Query)', () => {
 
     const result = await domain.getDefault({ currency: 'USD' }).toPromise();
     expect(result?.id).toBe('usd-default');
+    expect(result?.isDefault).toBe(true);
     expect(getById).toHaveBeenCalledWith('usd-default');
   });
 
@@ -273,6 +311,43 @@ describe('AccountsDomainImpl.setDefault (write → Promise)', () => {
       'Unsupported currency',
     );
   });
+
+  test('invalidates the accounts reads so isDefault flips live for subscribers', async () => {
+    // Spy a client to assert the read keys are invalidated after the write.
+    const invalidateQueries = mock(
+      async (_filters: { queryKey: unknown[] }) => undefined,
+    );
+    const client = { invalidateQueries } as unknown as QueryClient;
+    const accountRepo = {
+      getAllActive: mock(async () => []),
+      get: mock(async () => null),
+      add: mock(async () => cashuAccount({ id: 'x' })),
+    } as unknown as AccountRepository;
+    const userRepo = {
+      setDefaultAccount: mock(async () => baseUser),
+    } as unknown as UserRepository;
+    const session = {
+      requireCurrentUser: async () => baseUser,
+      getCurrentUser: async () => baseUser,
+    } as unknown as SessionResolver;
+    const domain = new AccountsDomainImpl(
+      client,
+      accountRepo,
+      userRepo,
+      session,
+    );
+
+    await domain.setDefault(cashuAccount({ id: 'new-btc', currency: 'BTC' }));
+
+    const invalidatedKeys = invalidateQueries.mock.calls.map(
+      ([arg]) => arg.queryKey,
+    );
+    expect(invalidatedKeys).toEqual([
+      ['accounts'],
+      ['account'],
+      ['accounts:default'],
+    ]);
+  });
 });
 
 describe('AccountsDomainImpl.getBalance (pure derivation → SYNC)', () => {
@@ -302,7 +377,7 @@ describe('AccountsDomainImpl.getBalance (pure derivation → SYNC)', () => {
 
 describe('AccountsDomainImpl.suggestFor (pure pick → SYNC)', () => {
   test('recommends the funded online account for a token-receive, returning the value DIRECTLY', () => {
-    const a = cashuAccount({ id: 'a', sats: 0 });
+    const a = extended({ id: 'a', sats: 0 });
     const { domain } = buildDomain();
     const intent: PaymentIntent = { kind: 'token-receive', token: 'cashuAx' };
 
@@ -312,9 +387,11 @@ describe('AccountsDomainImpl.suggestFor (pure pick → SYNC)', () => {
     expect(Array.isArray(result.alternatives)).toBe(true);
   });
 
-  test('is pure over the passed-in accounts (no session read) — falls back to the first insufficient when none has enough balance', () => {
-    const a = cashuAccount({ id: 'a', sats: 10 });
-    const def = cashuAccount({ id: 'btc-default', sats: 20 });
+  test('restores master default-fallback: no sufficient balance → suggests the DEFAULT account (not "first insufficient")', () => {
+    // Two insufficient accounts; the SECOND is the user's default. The pure fallback now
+    // picks the `isDefault` account (master parity) rather than the first insufficient one.
+    const first = extended({ id: 'a', sats: 10, isDefault: false });
+    const def = extended({ id: 'btc-default', sats: 20, isDefault: true });
     const { domain } = buildDomain();
     const intent: PaymentIntent = {
       kind: 'send',
@@ -338,14 +415,46 @@ describe('AccountsDomainImpl.suggestFor (pure pick → SYNC)', () => {
       }),
     };
 
-    // SYNC `suggestFor` does NOT read the session for a default-account id, so the fallback
-    // degrades to the first insufficient account (the pure suggester's no-default behaviour).
-    const result = domain.suggestFor(intent, [a, def]);
+    // Reads `isDefault` off the passed-in accounts — no session read inside suggestFor.
+    const result = domain.suggestFor(intent, [first, def]);
+    expect(result.recommended.id).toBe('btc-default');
+    expect(result.reason).toBe('insufficient balance; default account');
+    // The non-recommended insufficient account is still surfaced.
+    expect(result.insufficient.map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('is pure (no session read): when nothing is default, falls back to the first insufficient', () => {
+    const a = extended({ id: 'a', sats: 10 });
+    const b = extended({ id: 'b', sats: 20 });
+    const { domain } = buildDomain({ user: null });
+    const intent: PaymentIntent = {
+      kind: 'send',
+      destination: {
+        kind: 'bolt11',
+        invoice: {
+          amountSat: 5000,
+          amountMsat: 5000000,
+          createdAtUnixMs: 0,
+          expiryUnixMs: 0,
+          network: 'bitcoin',
+          description: undefined,
+          payeeNodeKey: '00'.repeat(33),
+          paymentHash: 'hash',
+        },
+      },
+      amount: new Money<Currency>({
+        amount: 5000,
+        currency: 'BTC',
+        unit: 'sat',
+      }),
+    };
+
+    const result = domain.suggestFor(intent, [a, b]);
     expect(result.recommended.id).toBe('a');
   });
 
   test('works without a session set up at all (pure over accounts)', () => {
-    const a = cashuAccount({ id: 'a', sats: 1000 });
+    const a = extended({ id: 'a', sats: 1000 });
     const { domain } = buildDomain({ user: null });
     const intent: PaymentIntent = { kind: 'receive' };
 

--- a/packages/wallet-sdk/src/domains/accounts.test.ts
+++ b/packages/wallet-sdk/src/domains/accounts.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { AccountsDomainImpl } from './accounts';
+import type { AccountRepository } from '../internal/account-repository';
+import type { SessionResolver } from '../internal/session';
+import type { UserRepository } from '../internal/user-repository';
+import { QueryClient } from '../query';
+import type { Account, CashuAccount } from '../types/account';
+import { type Currency, Money } from '../types/money';
+import type { Query } from '../types/query';
+import type { PaymentIntent } from '../types/scan';
+import type { User } from '../types/user';
+
+// -- Fakes -------------------------------------------------------------------
+
+const baseUser: User = {
+  id: 'user-1',
+  username: 'alice',
+  isGuest: false,
+  email: 'alice@example.com',
+  emailVerified: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  defaultBtcAccountId: 'btc-default',
+  defaultUsdAccountId: 'usd-default',
+  defaultCurrency: 'BTC',
+  cashuLockingXpub: 'xpub',
+  encryptionPublicKey: 'enc',
+  sparkIdentityPublicKey: 'spark',
+  termsAcceptedAt: null,
+  giftCardMintTermsAcceptedAt: null,
+};
+
+function cashuAccount(opts: {
+  id: string;
+  sats?: number;
+  currency?: 'BTC' | 'USD';
+  isOnline?: boolean;
+}): CashuAccount {
+  return {
+    id: opts.id,
+    name: opts.id,
+    type: 'cashu',
+    purpose: 'transactional',
+    state: 'active',
+    isOnline: opts.isOnline ?? true,
+    currency: opts.currency ?? 'BTC',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    version: 1,
+    expiresAt: null,
+    mintUrl: `https://${opts.id}.example.com`,
+    isTestMint: false,
+    keysetCounters: {},
+    proofs:
+      opts.sats && opts.sats > 0
+        ? ([{ amount: opts.sats }] as unknown as CashuAccount['proofs'])
+        : [],
+    wallet: {} as never,
+  };
+}
+
+/** A fresh QueryClient per domain (the SDK-internal one in production). */
+function makeClient(): QueryClient {
+  return new QueryClient();
+}
+
+/** Resolve the first emitted value of a `Query`, then unsubscribe. */
+function firstEmit<T>(q: Query<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const off = q.subscribe(
+      (data) => {
+        off();
+        resolve(data);
+      },
+      (err) => {
+        off();
+        reject(err);
+      },
+    );
+  });
+}
+
+/** Build the domain over fakes. Each repo/session method is a `mock` so calls are assertable. */
+function buildDomain(overrides?: {
+  user?: User | null;
+  accounts?: Account[];
+  getById?: (id: string) => Account | null;
+}) {
+  const user = overrides?.user === undefined ? baseUser : overrides.user;
+  const accounts = overrides?.accounts ?? [];
+
+  const getAllActive = mock(async () => accounts);
+  const getById = mock(async (id: string) =>
+    overrides?.getById
+      ? overrides.getById(id)
+      : (accounts.find((a) => a.id === id) ?? null),
+  );
+  const add = mock(async (_userId: string, _config: unknown) =>
+    cashuAccount({ id: 'new-account' }),
+  );
+  const accountRepo = {
+    getAllActive,
+    get: getById,
+    add,
+  } as unknown as AccountRepository;
+
+  const setDefaultAccount = mock(async () => baseUser);
+  const userRepo = { setDefaultAccount } as unknown as UserRepository;
+
+  const session = {
+    requireCurrentUser: async () => {
+      if (!user) throw new Error('No authenticated user');
+      return user;
+    },
+    getCurrentUser: async () => user,
+  } as unknown as SessionResolver;
+
+  const domain = new AccountsDomainImpl(
+    makeClient(),
+    accountRepo,
+    userRepo,
+    session,
+  );
+  return { domain, getAllActive, getById, add, setDefaultAccount };
+}
+
+describe('AccountsDomainImpl.list (observable read → Query)', () => {
+  test('returns a Query whose toPromise() resolves to active accounts sorted oldest-first', async () => {
+    const a = cashuAccount({ id: 'a' });
+    a.createdAt = '2026-03-01T00:00:00.000Z';
+    const b = cashuAccount({ id: 'b' });
+    b.createdAt = '2026-01-01T00:00:00.000Z';
+    const { domain } = buildDomain({ accounts: [a, b] });
+
+    const query = domain.list();
+    // It is a Query<Account[]>, not a bare Promise.
+    expect(typeof query.subscribe).toBe('function');
+    expect(typeof query.toPromise).toBe('function');
+    expect(typeof query.getSnapshot).toBe('function');
+
+    const result = await query.toPromise();
+    expect(result.map((x) => x.id)).toEqual(['b', 'a']);
+  });
+
+  test('subscribe fires with the resolved accounts', async () => {
+    const a = cashuAccount({ id: 'a' });
+    const { domain } = buildDomain({ accounts: [a] });
+
+    const emitted = await firstEmit(domain.list());
+    expect(emitted.map((x) => x.id)).toEqual(['a']);
+  });
+
+  test('is memoised — repeated calls return the SAME Query ref', () => {
+    const { domain } = buildDomain({ accounts: [] });
+    expect(domain.list()).toBe(domain.list());
+  });
+});
+
+describe('AccountsDomainImpl.get (observable read → Query)', () => {
+  test('returns a Query that resolves to the account from the repository', async () => {
+    const a = cashuAccount({ id: 'a' });
+    const { domain, getById } = buildDomain({ accounts: [a] });
+
+    const query = domain.get('a');
+    expect(typeof query.subscribe).toBe('function');
+    expect((await query.toPromise())?.id).toBe('a');
+    expect(getById).toHaveBeenCalledWith('a');
+  });
+
+  test('resolves to null for a missing id', async () => {
+    const { domain } = buildDomain({ accounts: [] });
+    expect(await domain.get('missing').toPromise()).toBeNull();
+  });
+
+  test('memoises one Query per id (same id → same ref, different id → different ref)', () => {
+    const { domain } = buildDomain({ accounts: [] });
+    expect(domain.get('a')).toBe(domain.get('a'));
+    expect(domain.get('a')).not.toBe(domain.get('b'));
+  });
+});
+
+describe('AccountsDomainImpl.getDefault (observable read → Query)', () => {
+  test('reads the BTC default by default currency', async () => {
+    const def = cashuAccount({ id: 'btc-default' });
+    const { domain } = buildDomain({
+      accounts: [def],
+      getById: (id) => (id === 'btc-default' ? def : null),
+    });
+
+    const result = await domain.getDefault().toPromise();
+    expect(result?.id).toBe('btc-default');
+  });
+
+  test('reads the USD default when currency=USD', async () => {
+    const def = cashuAccount({ id: 'usd-default', currency: 'USD' });
+    const { domain, getById } = buildDomain({
+      getById: (id) => (id === 'usd-default' ? def : null),
+    });
+
+    const result = await domain.getDefault({ currency: 'USD' }).toPromise();
+    expect(result?.id).toBe('usd-default');
+    expect(getById).toHaveBeenCalledWith('usd-default');
+  });
+
+  test('resolves to null when no default id is set for the currency', async () => {
+    const userNoUsd: User = { ...baseUser, defaultUsdAccountId: null };
+    const { domain } = buildDomain({ user: userNoUsd });
+
+    expect(await domain.getDefault({ currency: 'USD' }).toPromise()).toBeNull();
+  });
+
+  test('memoises one Query per currency', () => {
+    const { domain } = buildDomain({ accounts: [] });
+    expect(domain.getDefault({ currency: 'BTC' })).toBe(
+      domain.getDefault({ currency: 'BTC' }),
+    );
+    expect(domain.getDefault({ currency: 'BTC' })).not.toBe(
+      domain.getDefault({ currency: 'USD' }),
+    );
+  });
+});
+
+describe('AccountsDomainImpl.add (write → Promise)', () => {
+  test('resolves the user id and delegates to the repository', async () => {
+    const { domain, add } = buildDomain();
+
+    const account = await domain.add({
+      type: 'cashu',
+      mintUrl: 'https://m.example.com',
+      currency: 'BTC',
+    });
+    expect(account.id).toBe('new-account');
+    expect(add).toHaveBeenCalledWith('user-1', {
+      type: 'cashu',
+      mintUrl: 'https://m.example.com',
+      currency: 'BTC',
+    });
+  });
+});
+
+describe('AccountsDomainImpl.setDefault (write → Promise)', () => {
+  test('sets the BTC default, leaving the USD default untouched', async () => {
+    const account = cashuAccount({ id: 'new-btc', currency: 'BTC' });
+    const { domain, setDefaultAccount } = buildDomain();
+
+    await domain.setDefault(account);
+    expect(setDefaultAccount).toHaveBeenCalledWith('user-1', {
+      defaultBtcAccountId: 'new-btc',
+      defaultUsdAccountId: 'usd-default',
+      defaultCurrency: 'BTC',
+    });
+  });
+
+  test('sets the USD default, leaving the BTC default untouched', async () => {
+    const account = cashuAccount({ id: 'new-usd', currency: 'USD' });
+    const { domain, setDefaultAccount } = buildDomain();
+
+    await domain.setDefault(account);
+    expect(setDefaultAccount).toHaveBeenCalledWith('user-1', {
+      defaultBtcAccountId: 'btc-default',
+      defaultUsdAccountId: 'new-usd',
+      defaultCurrency: 'BTC',
+    });
+  });
+
+  test('rejects an unsupported currency', async () => {
+    const account = {
+      ...cashuAccount({ id: 'x' }),
+      currency: 'EUR',
+    } as unknown as Account;
+    const { domain } = buildDomain();
+
+    await expect(domain.setDefault(account)).rejects.toThrow(
+      'Unsupported currency',
+    );
+  });
+});
+
+describe('AccountsDomainImpl.getBalance (pure derivation → SYNC)', () => {
+  test('returns the cashu proof sum as Money DIRECTLY (not a Query)', () => {
+    const { domain } = buildDomain();
+    const account = cashuAccount({ id: 'a', sats: 4200 });
+
+    const balance = domain.getBalance(account);
+    // SYNC: a Money value, not a Query (no subscribe/toPromise).
+    expect(balance).toBeInstanceOf(Money);
+    expect(balance.toNumber('sat')).toBe(4200);
+  });
+
+  test('returns Money.zero for a spark account with a null balance', () => {
+    const { domain } = buildDomain();
+    const spark = {
+      type: 'spark',
+      currency: 'BTC',
+      balance: null,
+    } as unknown as Account;
+
+    const balance = domain.getBalance(spark);
+    expect(balance.toNumber('sat')).toBe(0);
+    expect(balance.currency).toBe('BTC');
+  });
+});
+
+describe('AccountsDomainImpl.suggestFor (pure pick → SYNC)', () => {
+  test('recommends the funded online account for a token-receive, returning the value DIRECTLY', () => {
+    const a = cashuAccount({ id: 'a', sats: 0 });
+    const { domain } = buildDomain();
+    const intent: PaymentIntent = { kind: 'token-receive', token: 'cashuAx' };
+
+    const result = domain.suggestFor(intent, [a]);
+    // SYNC: an AccountSuggestion, not a Query.
+    expect(result.recommended.id).toBe('a');
+    expect(Array.isArray(result.alternatives)).toBe(true);
+  });
+
+  test('is pure over the passed-in accounts (no session read) — falls back to the first insufficient when none has enough balance', () => {
+    const a = cashuAccount({ id: 'a', sats: 10 });
+    const def = cashuAccount({ id: 'btc-default', sats: 20 });
+    const { domain } = buildDomain();
+    const intent: PaymentIntent = {
+      kind: 'send',
+      destination: {
+        kind: 'bolt11',
+        invoice: {
+          amountSat: 5000,
+          amountMsat: 5000000,
+          createdAtUnixMs: 0,
+          expiryUnixMs: 0,
+          network: 'bitcoin',
+          description: undefined,
+          payeeNodeKey: '00'.repeat(33),
+          paymentHash: 'hash',
+        },
+      },
+      amount: new Money<Currency>({
+        amount: 5000,
+        currency: 'BTC',
+        unit: 'sat',
+      }),
+    };
+
+    // SYNC `suggestFor` does NOT read the session for a default-account id, so the fallback
+    // degrades to the first insufficient account (the pure suggester's no-default behaviour).
+    const result = domain.suggestFor(intent, [a, def]);
+    expect(result.recommended.id).toBe('a');
+  });
+
+  test('works without a session set up at all (pure over accounts)', () => {
+    const a = cashuAccount({ id: 'a', sats: 1000 });
+    const { domain } = buildDomain({ user: null });
+    const intent: PaymentIntent = { kind: 'receive' };
+
+    const result = domain.suggestFor(intent, [a]);
+    expect(result.recommended.id).toBe('a');
+  });
+});

--- a/packages/wallet-sdk/src/domains/accounts.ts
+++ b/packages/wallet-sdk/src/domains/accounts.ts
@@ -8,17 +8,21 @@
  *
  * REACTIVE OVERLAY: TanStack is no longer in the consumer — it is hidden inside the SDK.
  *  - `list()` / `get(id)` / `getDefault(params?)` are OBSERVABLE FETCHES → each returns a
- *    `Query<T>`. The fetch BODY is identical to the no-cache read (the DB read via the
- *    account repository + session); it is wrapped via {@link toQuery} over the SDK-internal
- *    `QueryClient` and MEMOISED per key (`#q`) so repeated calls return the SAME stable
- *    `Query` ref (matching the per-key-memo pattern the other reactive domains use).
- *    Parameterised reads (`get(id)`, `getDefault({currency})`) memo one `Query` per
- *    id/currency. Realtime / orchestrators (Slice 5) write the same client (e.g.
- *    `setQueryData(['accounts'], next)`) to push fresh values to subscribers.
+ *    `Query<ExtendedAccount...>`. The fetch BODY is the no-cache read (the DB read via the
+ *    account repository + session) DECORATED with `isDefault`: the resolved current user's
+ *    per-currency default-account ids drive {@link getExtendedAccounts}, so each account
+ *    carries `isDefault` (and the default sorts to the top). The body is wrapped via
+ *    {@link toQuery} over the SDK-internal `QueryClient` and MEMOISED per key (`#q`) so
+ *    repeated calls return the SAME stable `Query` ref (matching the per-key-memo pattern
+ *    the other reactive domains use). Parameterised reads (`get(id)`, `getDefault({currency})`)
+ *    memo one `Query` per id/currency. Realtime / orchestrators (Slice 5) write the same
+ *    client (e.g. `setQueryData(['accounts'], next)`) to push fresh values to subscribers;
+ *    `setDefault` invalidates these keys so `isDefault` flips live for subscribers.
  *  - `getBalance(account)` is a PURE DERIVATION → stays SYNC. It sums proofs (cashu) / reads
  *    `account.balance` (spark) over the account it is handed; it never reads the cache, so it
  *    is NOT wrapped in `toQuery`.
- *  - `suggestFor(intent, accounts)` is a PURE pick over the passed-in accounts → stays SYNC.
+ *  - `suggestFor(intent, accounts)` is a PURE pick over the passed-in {@link ExtendedAccount}s
+ *    → stays SYNC. The default-account fallback reads `accounts[].isDefault` (no session read).
  *  - `add(...)` / `setDefault(account)` are WRITES → stay `Promise` (lifted verbatim).
  *
  * Two-mode API rule (Josip 6/01): `list`/`get`/`getDefault` are FETCHES; `add` CREATES;
@@ -36,11 +40,16 @@
 import type { AccountsDomain, AccountSuggestion } from '../domains';
 import { getAccountBalance } from '../internal/account-balance';
 import type { AccountRepository } from '../internal/account-repository';
+import { getExtendedAccounts } from '../internal/extended-account';
 import type { SessionResolver } from '../internal/session';
 import { suggestAccountFor } from '../internal/suggest-account';
 import type { UserRepository } from '../internal/user-repository';
 import { type QueryClient, toQuery } from '../query';
-import type { Account, AddAccountConfig } from '../types/account';
+import type {
+  Account,
+  AddAccountConfig,
+  ExtendedAccount,
+} from '../types/account';
 import { type Currency, Money } from '../types/money';
 import type { Query } from '../types/query';
 import type { PaymentIntent } from '../types/scan';
@@ -96,34 +105,47 @@ export class AccountsDomainImpl implements AccountsDomain {
   }
 
   /**
-   * All of the user's active accounts — as an observable {@link Query}. Re-houses master
-   * `useAccounts` / `getAllActive`; sorted oldest-first (matching master's creation-date
-   * sort). The fetch body is the no-cache read (session → `accounts.getAllActive`); the
-   * reactive overlay wraps it in a {@link toQuery}-backed `Query` (memoised per key).
+   * All of the user's active accounts — as an observable {@link Query} of
+   * {@link ExtendedAccount}s (each carries `isDefault`). Re-houses master `useAccounts`
+   * (`getAllActive` + `getExtendedAccounts`). The fetch body is the no-cache read
+   * (session → `accounts.getAllActive`) sorted oldest-first (master's creation-date sort),
+   * then decorated with `isDefault` from the current user's default-account ids (which
+   * re-sorts the default account to the top); the reactive overlay wraps it in a
+   * {@link toQuery}-backed `Query` (memoised per key).
    *
-   * @returns a stable `Query<Account[]>`.
+   * @returns a stable `Query<ExtendedAccount[]>`.
    */
-  list(): Query<Account[]> {
+  list(): Query<ExtendedAccount[]> {
     return this.#memo([ACCOUNTS_KEY], async () => {
       const user = await this.session.requireCurrentUser();
       const accounts = await this.accounts.getAllActive(user.id);
-      return accounts.sort(
+      const sorted = accounts.sort(
         (a, b) =>
           new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
       );
+      return getExtendedAccounts(user, sorted);
     });
   }
 
   /**
-   * The account with this id, or `null` — as an observable {@link Query}. Re-houses master
-   * `AccountRepository.get` (the lazy DB lookup behind `useAccountOrNull`), so it returns
-   * expired accounts too. Memoised per id (one `Query` per distinct id).
+   * The account with this id, or `null` — as an observable {@link Query} of an
+   * {@link ExtendedAccount} (carries `isDefault`). Re-houses master `AccountRepository.get`
+   * (the lazy DB lookup behind `useAccountOrNull`), so it returns expired accounts too,
+   * decorated with `isDefault` from the current user's default-account ids. Memoised per id
+   * (one `Query` per distinct id).
    *
    * @param id - the account id.
-   * @returns a stable `Query<Account | null>`.
+   * @returns a stable `Query<ExtendedAccount | null>`.
    */
-  get(id: string): Query<Account | null> {
-    return this.#memo([ACCOUNT_KEY, id], () => this.accounts.get(id));
+  get(id: string): Query<ExtendedAccount | null> {
+    return this.#memo([ACCOUNT_KEY, id], async () => {
+      const account = await this.accounts.get(id);
+      if (!account) {
+        return null;
+      }
+      const user = await this.session.requireCurrentUser();
+      return getExtendedAccounts(user, [account])[0] ?? null;
+    });
   }
 
   /**
@@ -135,9 +157,9 @@ export class AccountsDomainImpl implements AccountsDomain {
    * the "user's default currency" case).
    *
    * @param params - optional `{ currency }`; defaults to the user's default currency.
-   * @returns a stable `Query<Account | null>`.
+   * @returns a stable `Query<ExtendedAccount | null>`.
    */
-  getDefault(params?: { currency?: Currency }): Query<Account | null> {
+  getDefault(params?: { currency?: Currency }): Query<ExtendedAccount | null> {
     const currencyKey = params?.currency ?? 'auto';
     return this.#memo([ACCOUNTS_DEFAULT_KEY, currencyKey], async () => {
       const user = await this.session.requireCurrentUser();
@@ -153,7 +175,12 @@ export class AccountsDomainImpl implements AccountsDomain {
       if (!defaultId) {
         return null;
       }
-      return this.accounts.get(defaultId);
+      const account = await this.accounts.get(defaultId);
+      if (!account) {
+        return null;
+      }
+      // The fetched account is the current default for the currency, so `isDefault` is true.
+      return getExtendedAccounts(user, [account])[0] ?? null;
     });
   }
 
@@ -193,6 +220,11 @@ export class AccountsDomainImpl implements AccountsDomain {
       // currency (master's `setDefaultCurrency` option defaults to false).
       defaultCurrency: user.defaultCurrency,
     });
+    // The default-account ids drive every read's `isDefault` (and the default-first sort), so
+    // invalidate the accounts reads: subscribers refetch and `isDefault` flips live.
+    await this.client.invalidateQueries({ queryKey: [ACCOUNTS_KEY] });
+    await this.client.invalidateQueries({ queryKey: [ACCOUNT_KEY] });
+    await this.client.invalidateQueries({ queryKey: [ACCOUNTS_DEFAULT_KEY] });
   }
 
   /**
@@ -211,22 +243,25 @@ export class AccountsDomainImpl implements AccountsDomain {
 
   /**
    * Recommend which of the passed-in `accounts` to use for `intent`. PURE → SYNC (no DB read,
-   * no live-wallet call, not wrapped in `toQuery`). NET-NEW logic; generalizes master's
-   * `findMatchingOfferOrGiftCardAccount` + online filter + default fallback. The web wallet
-   * feeds its cached accounts for an instant result.
+   * no session read, no live-wallet call, not wrapped in `toQuery`). NET-NEW logic;
+   * generalizes master's `findMatchingOfferOrGiftCardAccount` + online filter + default
+   * fallback. The web wallet feeds its cached {@link ExtendedAccount}s for an instant result.
    *
    * Pure over the accounts handed in: the cheap-first ranking and the online/balance filters
-   * read only the passed-in `accounts`. (The no-cache impl additionally read the current
-   * session to seed the default-account fallback; the reactive contract types this method
-   * SYNC and pure over `accounts`, so the session read is dropped — when nothing has
-   * sufficient balance the fallback degrades to the first insufficient account, exactly as
-   * the underlying pure suggester does with no default id.)
+   * read only the passed-in `accounts`. The default-account fallback (when nothing has
+   * sufficient balance, suggest the user's default account so the UI can pre-select an account
+   * to top up) reads `accounts[].isDefault` — which is why the read is `ExtendedAccount`,
+   * carrying that flag — so it stays pure (no session read) while restoring master's
+   * default-account fallback (rather than degrading to the first insufficient account).
    *
    * @param intent - what the user wants to do.
-   * @param accounts - the accounts to choose from.
+   * @param accounts - the extended accounts to choose from (carry `isDefault`).
    * @returns the {@link AccountSuggestion}.
    */
-  suggestFor(intent: PaymentIntent, accounts: Account[]): AccountSuggestion {
+  suggestFor(
+    intent: PaymentIntent,
+    accounts: ExtendedAccount[],
+  ): AccountSuggestion {
     return suggestAccountFor(intent, accounts);
   }
 }

--- a/packages/wallet-sdk/src/domains/accounts.ts
+++ b/packages/wallet-sdk/src/domains/accounts.ts
@@ -1,0 +1,232 @@
+/**
+ * `AccountsDomain` implementation — §2 of the contract, Slice 2 (reactive overlay, design B).
+ *
+ * EXTRACTED (re-housed framework-free) from `apps/web-wallet/app/features/accounts/*`
+ * (`account-repository.ts` / `account-service.ts` / `account-hooks.ts`) +
+ * `app/features/user/user-service.ts` (the default-account write). Master expresses these as
+ * React hooks over a TanStack `AccountsCache`.
+ *
+ * REACTIVE OVERLAY: TanStack is no longer in the consumer — it is hidden inside the SDK.
+ *  - `list()` / `get(id)` / `getDefault(params?)` are OBSERVABLE FETCHES → each returns a
+ *    `Query<T>`. The fetch BODY is identical to the no-cache read (the DB read via the
+ *    account repository + session); it is wrapped via {@link toQuery} over the SDK-internal
+ *    `QueryClient` and MEMOISED per key (`#q`) so repeated calls return the SAME stable
+ *    `Query` ref (matching the per-key-memo pattern the other reactive domains use).
+ *    Parameterised reads (`get(id)`, `getDefault({currency})`) memo one `Query` per
+ *    id/currency. Realtime / orchestrators (Slice 5) write the same client (e.g.
+ *    `setQueryData(['accounts'], next)`) to push fresh values to subscribers.
+ *  - `getBalance(account)` is a PURE DERIVATION → stays SYNC. It sums proofs (cashu) / reads
+ *    `account.balance` (spark) over the account it is handed; it never reads the cache, so it
+ *    is NOT wrapped in `toQuery`.
+ *  - `suggestFor(intent, accounts)` is a PURE pick over the passed-in accounts → stays SYNC.
+ *  - `add(...)` / `setDefault(account)` are WRITES → stay `Promise` (lifted verbatim).
+ *
+ * Two-mode API rule (Josip 6/01): `list`/`get`/`getDefault` are FETCHES; `add` CREATES;
+ * `setDefault`/`getBalance` take the FULL account object; `suggestFor` is PURE over the
+ * passed-in accounts.
+ *
+ * Slice boundary (build plan): an account's LIVE `wallet` handle + decrypted cashu `proofs`
+ * are resolved through the injected handle resolver, which is DEFERRED to Slice 3 (the heavy
+ * mint/Breez init + the `shared/encryption` proof decryption). This slice owns the DB
+ * read/write, scan, and the pure suggester; reads return real accounts with the DB fields,
+ * with the live handle filled in by Slice 3. See `internal/account-handle-resolver.ts`.
+ *
+ * @module
+ */
+import type { AccountsDomain, AccountSuggestion } from '../domains';
+import { getAccountBalance } from '../internal/account-balance';
+import type { AccountRepository } from '../internal/account-repository';
+import type { SessionResolver } from '../internal/session';
+import { suggestAccountFor } from '../internal/suggest-account';
+import type { UserRepository } from '../internal/user-repository';
+import { type QueryClient, toQuery } from '../query';
+import type { Account, AddAccountConfig } from '../types/account';
+import { type Currency, Money } from '../types/money';
+import type { Query } from '../types/query';
+import type { PaymentIntent } from '../types/scan';
+
+/** Stable query-key prefix for the active-accounts list (one per SDK instance). */
+const ACCOUNTS_KEY = 'accounts';
+/** Stable query-key prefix for a single account by id. */
+const ACCOUNT_KEY = 'account';
+/** Stable query-key prefix for the default account (parameterised by currency). */
+const ACCOUNTS_DEFAULT_KEY = 'accounts:default';
+
+/**
+ * The accounts domain. Construct with the SDK-internal `QueryClient` (backs the observable
+ * reads), the account repository (DB read/write), the user repository (default-account
+ * read/write lives on the `wallet.users` row), and the session resolver (current user id +
+ * default-account ids).
+ */
+export class AccountsDomainImpl implements AccountsDomain {
+  /**
+   * Per-key memo of the `Query` handles this domain exposes, so repeated calls with the same
+   * arguments return the SAME stable reference (consumers can use it as a
+   * `useSyncExternalStore`/effect dependency). Hidden inside the SDK.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous Query<T> memo, keyed by string
+  readonly #q = new Map<string, Query<any>>();
+
+  /**
+   * @param client - the SDK-internal TanStack `QueryClient` (never exposed to consumers).
+   * @param accounts - the `wallet.accounts` repository.
+   * @param users - the `wallet.users` repository (default-account columns).
+   * @param session - resolves the current user (id + default-account ids).
+   */
+  constructor(
+    private readonly client: QueryClient,
+    private readonly accounts: AccountRepository,
+    private readonly users: UserRepository,
+    private readonly session: SessionResolver,
+  ) {}
+
+  /**
+   * Memoise a `Query` per stringified key: the FIRST call for a key builds the `Query` via
+   * {@link toQuery}; later calls return the same stable ref. Mirrors the per-key-memo the
+   * other reactive domains use (e.g. `user.getCurrentUser`).
+   */
+  #memo<T>(key: readonly unknown[], fn: () => Promise<T>): Query<T> {
+    const id = JSON.stringify(key);
+    let q = this.#q.get(id);
+    if (!q) {
+      q = toQuery<T>(this.client, key, fn);
+      this.#q.set(id, q);
+    }
+    return q;
+  }
+
+  /**
+   * All of the user's active accounts — as an observable {@link Query}. Re-houses master
+   * `useAccounts` / `getAllActive`; sorted oldest-first (matching master's creation-date
+   * sort). The fetch body is the no-cache read (session → `accounts.getAllActive`); the
+   * reactive overlay wraps it in a {@link toQuery}-backed `Query` (memoised per key).
+   *
+   * @returns a stable `Query<Account[]>`.
+   */
+  list(): Query<Account[]> {
+    return this.#memo([ACCOUNTS_KEY], async () => {
+      const user = await this.session.requireCurrentUser();
+      const accounts = await this.accounts.getAllActive(user.id);
+      return accounts.sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      );
+    });
+  }
+
+  /**
+   * The account with this id, or `null` — as an observable {@link Query}. Re-houses master
+   * `AccountRepository.get` (the lazy DB lookup behind `useAccountOrNull`), so it returns
+   * expired accounts too. Memoised per id (one `Query` per distinct id).
+   *
+   * @param id - the account id.
+   * @returns a stable `Query<Account | null>`.
+   */
+  get(id: string): Query<Account | null> {
+    return this.#memo([ACCOUNT_KEY, id], () => this.accounts.get(id));
+  }
+
+  /**
+   * The user's default account for a currency, or `null` — as an observable {@link Query}.
+   * Re-houses master `useDefaultAccount`: reads the default-account id off the current user
+   * (`defaultBtcAccountId` / `defaultUsdAccountId`, by currency; `currency` defaults to the
+   * user's `defaultCurrency`) and fetches that account. Returns `null` when no default is
+   * set / the account is missing. Memoised per requested currency (with a distinct key for
+   * the "user's default currency" case).
+   *
+   * @param params - optional `{ currency }`; defaults to the user's default currency.
+   * @returns a stable `Query<Account | null>`.
+   */
+  getDefault(params?: { currency?: Currency }): Query<Account | null> {
+    const currencyKey = params?.currency ?? 'auto';
+    return this.#memo([ACCOUNTS_DEFAULT_KEY, currencyKey], async () => {
+      const user = await this.session.requireCurrentUser();
+      const currency = params?.currency ?? user.defaultCurrency;
+
+      const defaultId =
+        currency === 'BTC'
+          ? user.defaultBtcAccountId
+          : currency === 'USD'
+            ? user.defaultUsdAccountId
+            : null;
+
+      if (!defaultId) {
+        return null;
+      }
+      return this.accounts.get(defaultId);
+    });
+  }
+
+  /**
+   * Create and persist a new account (create). Re-houses master
+   * `account-service.addCashuAccount` + `account-repository.create`. An ACTION → `Promise`.
+   *
+   * @param config - the cashu (mintUrl+currency) or spark (currency) create config.
+   * @returns the created account.
+   */
+  async add(config: AddAccountConfig): Promise<Account> {
+    const user = await this.session.requireCurrentUser();
+    return this.accounts.add(user.id, config);
+  }
+
+  /**
+   * Make `account` the default for its currency (FULL object). Re-houses master
+   * `user-service.setDefaultAccount`: writes the matching default-account column on the
+   * `wallet.users` row (BTC→`defaultBtcAccountId`, USD→`defaultUsdAccountId`), leaving the
+   * other currency's default + the user's `defaultCurrency` unchanged. There is one default
+   * PER currency, not a single global default. An ACTION → `Promise`.
+   *
+   * @param account - the account to make default.
+   * @throws Error if the account's currency is unsupported.
+   */
+  async setDefault(account: Account): Promise<void> {
+    if (account.currency !== 'BTC' && account.currency !== 'USD') {
+      throw new Error('Unsupported currency');
+    }
+    const user = await this.session.requireCurrentUser();
+    await this.users.setDefaultAccount(user.id, {
+      defaultBtcAccountId:
+        account.currency === 'BTC' ? account.id : user.defaultBtcAccountId,
+      defaultUsdAccountId:
+        account.currency === 'USD' ? account.id : user.defaultUsdAccountId,
+      // setDefault changes the default ACCOUNT for the currency, not the user's preferred
+      // currency (master's `setDefaultCurrency` option defaults to false).
+      defaultCurrency: user.defaultCurrency,
+    });
+  }
+
+  /**
+   * The current balance of `account` (FULL object). PURE derivation → SYNC (no re-read, not
+   * wrapped in `toQuery`): cashu = sum of proofs, spark = the `balance` field. Re-houses
+   * master `getAccountBalance`.
+   *
+   * @param account - the account.
+   * @returns the balance as {@link Money} (zero for an empty cashu account; a spark account
+   *   with no known balance resolves to zero in its currency).
+   */
+  getBalance(account: Account): Money {
+    const balance = getAccountBalance(account);
+    return balance ?? Money.zero(account.currency);
+  }
+
+  /**
+   * Recommend which of the passed-in `accounts` to use for `intent`. PURE → SYNC (no DB read,
+   * no live-wallet call, not wrapped in `toQuery`). NET-NEW logic; generalizes master's
+   * `findMatchingOfferOrGiftCardAccount` + online filter + default fallback. The web wallet
+   * feeds its cached accounts for an instant result.
+   *
+   * Pure over the accounts handed in: the cheap-first ranking and the online/balance filters
+   * read only the passed-in `accounts`. (The no-cache impl additionally read the current
+   * session to seed the default-account fallback; the reactive contract types this method
+   * SYNC and pure over `accounts`, so the session read is dropped — when nothing has
+   * sufficient balance the fallback degrades to the first insufficient account, exactly as
+   * the underlying pure suggester does with no default id.)
+   *
+   * @param intent - what the user wants to do.
+   * @param accounts - the accounts to choose from.
+   * @returns the {@link AccountSuggestion}.
+   */
+  suggestFor(intent: PaymentIntent, accounts: Account[]): AccountSuggestion {
+    return suggestAccountFor(intent, accounts);
+  }
+}

--- a/packages/wallet-sdk/src/domains/scan.test.ts
+++ b/packages/wallet-sdk/src/domains/scan.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from 'bun:test';
+import { type Token, getEncodedToken } from '@cashu/cashu-ts';
+import { ScanDomainImpl } from './scan';
+import { DomainError } from '../errors';
+
+// -- Test fixtures (mirrors master scan/classify-input.test.ts) --
+
+const CASHU_TOKEN: Token = {
+  mint: 'https://mint.example.com',
+  proofs: [
+    {
+      id: '009a1f293253e41e',
+      amount: 1,
+      secret: 'test-secret-1',
+      C: '02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904',
+    },
+  ],
+  unit: 'sat',
+};
+
+const CASHU_A_TOKEN = getEncodedToken(CASHU_TOKEN, { version: 3 });
+const CASHU_B_TOKEN = getEncodedToken(CASHU_TOKEN, { version: 4 });
+
+// Real BOLT11 test vector (250,000 sats, "1 cup coffee")
+const BOLT11_INVOICE =
+  'lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp';
+
+describe('ScanDomainImpl.parse', () => {
+  const scan = new ScanDomainImpl();
+
+  describe('cashu tokens', () => {
+    test('cashuA token string → kind cashu-token', async () => {
+      const result = await scan.parse(CASHU_A_TOKEN);
+      expect(result.kind).toBe('cashu-token');
+      if (result.kind === 'cashu-token') {
+        expect(result.token.encoded).toBe(CASHU_A_TOKEN);
+        expect(result.token.metadata).toBeDefined();
+      }
+    });
+
+    test('cashuB token string → kind cashu-token', async () => {
+      const result = await scan.parse(CASHU_B_TOKEN);
+      expect(result.kind).toBe('cashu-token');
+    });
+
+    test('URL containing a cashu token', async () => {
+      const result = await scan.parse(`https://example.com/#${CASHU_A_TOKEN}`);
+      expect(result.kind).toBe('cashu-token');
+      if (result.kind === 'cashu-token') {
+        expect(result.token.encoded).toBe(CASHU_A_TOKEN);
+      }
+    });
+
+    test('cashu: URI prefix', async () => {
+      const result = await scan.parse(`cashu:${CASHU_A_TOKEN}`);
+      expect(result.kind).toBe('cashu-token');
+    });
+
+    test('leading/trailing whitespace is trimmed', async () => {
+      const result = await scan.parse(`  ${CASHU_A_TOKEN}  `);
+      expect(result.kind).toBe('cashu-token');
+    });
+  });
+
+  describe('bolt11 invoices', () => {
+    test('raw bolt11 invoice → decoded fields', async () => {
+      const result = await scan.parse(BOLT11_INVOICE);
+      expect(result.kind).toBe('bolt11');
+      if (result.kind === 'bolt11') {
+        expect(result.invoice.amountSat).toBe(250000);
+        expect(result.invoice.amountMsat).toBe(250000000);
+        expect(result.invoice.description).toBe('1 cup coffee');
+        expect(result.invoice.network).toBe('bitcoin');
+        expect(result.invoice.paymentHash).toBe(
+          '0001020304050607080900010203040506070809000102030405060708090102',
+        );
+      }
+    });
+
+    test('lightning: prefixed invoice', async () => {
+      const result = await scan.parse(`lightning:${BOLT11_INVOICE}`);
+      expect(result.kind).toBe('bolt11');
+    });
+
+    test('LIGHTNING: uppercase prefix', async () => {
+      const result = await scan.parse(`LIGHTNING:${BOLT11_INVOICE}`);
+      expect(result.kind).toBe('bolt11');
+    });
+  });
+
+  describe('lightning addresses', () => {
+    test('valid lightning address', async () => {
+      const result = await scan.parse('user@domain.com');
+      expect(result).toEqual({
+        kind: 'ln-address',
+        address: 'user@domain.com',
+      });
+    });
+
+    test('uppercase address is lowercased', async () => {
+      const result = await scan.parse('USER@Domain.Com');
+      expect(result).toEqual({
+        kind: 'ln-address',
+        address: 'user@domain.com',
+      });
+    });
+
+    test('address with subdomain', async () => {
+      const result = await scan.parse('alice@pay.example.org');
+      expect(result).toEqual({
+        kind: 'ln-address',
+        address: 'alice@pay.example.org',
+      });
+    });
+
+    test('localhost address rejected by default', async () => {
+      await expect(scan.parse('user@localhost')).rejects.toBeInstanceOf(
+        DomainError,
+      );
+    });
+
+    test('localhost address accepted when allowLocalhost is set', async () => {
+      const devScan = new ScanDomainImpl({ allowLocalhost: true });
+      const result = await devScan.parse('user@localhost:3000');
+      expect(result).toEqual({
+        kind: 'ln-address',
+        address: 'user@localhost:3000',
+      });
+    });
+  });
+
+  describe('unrecognised input throws DomainError', () => {
+    test('empty string', async () => {
+      await expect(scan.parse('')).rejects.toBeInstanceOf(DomainError);
+    });
+
+    test('whitespace only', async () => {
+      await expect(scan.parse('   ')).rejects.toBeInstanceOf(DomainError);
+    });
+
+    test('random gibberish', async () => {
+      await expect(scan.parse('not a valid anything')).rejects.toBeInstanceOf(
+        DomainError,
+      );
+    });
+
+    test('email-like but invalid TLD', async () => {
+      await expect(scan.parse('user@x')).rejects.toBeInstanceOf(DomainError);
+    });
+
+    test('bare URL without token', async () => {
+      await expect(scan.parse('https://example.com')).rejects.toBeInstanceOf(
+        DomainError,
+      );
+    });
+
+    test('the thrown DomainError carries a stable code', async () => {
+      const promise = scan.parse('garbage');
+      await expect(promise).rejects.toMatchObject({
+        code: 'UNRECOGNISED_DESTINATION',
+      });
+    });
+  });
+
+  describe('classification priority', () => {
+    test('cashu token takes priority over an @-address', async () => {
+      const result = await scan.parse(`user@domain.com ${CASHU_A_TOKEN}`);
+      expect(result.kind).toBe('cashu-token');
+    });
+  });
+});

--- a/packages/wallet-sdk/src/domains/scan.ts
+++ b/packages/wallet-sdk/src/domains/scan.ts
@@ -1,0 +1,101 @@
+/**
+ * `ScanDomain` implementation — §3 of the contract, Slice 2 (reactive overlay, design B).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/scan/classify-input.ts#classifyInput`. `parse(input)`
+ * classifies a raw scanned/pasted string into a {@link ParsedDestination} — the KIND only
+ * (`bolt11` | `ln-address` | `cashu-token`), with NO merchant/contact resolution (decision
+ * 3: gift-card/contact matching is the separate `suggestFor` step, not part of parse).
+ *
+ * REACTIVE OVERLAY: `parse` is a one-shot, connection-free decode ACTION (not an observable
+ * read), so it stays a `Promise<ParsedDestination>` (NOT a `Query`) — there is nothing to
+ * subscribe to. The body is identical to the no-cache impl.
+ *
+ * Re-housing notes:
+ *  - The three decode libs (`parseBolt11Invoice`, `extractCashuToken`,
+ *    `buildLightningAddressFormatValidator`) are SDK-internal (§12); imported via
+ *    `internal/lib-scan`.
+ *  - Master gates the ln-address `allowLocalhost` flag on `import.meta.env.MODE ===
+ *    'development'`. The SDK is framework-free, so that becomes a constructor option
+ *    (`allowLocalhost`, default `false` = production behaviour).
+ *  - ln-address → invoice resolution (LNURL-pay) is NOT done here — it folds into
+ *    `createLightningQuote` (Slice 3/PR5) where the amount is known (§3). So `parse` only
+ *    surfaces the address.
+ *  - `parse` REJECTS (throws) on an unclassifiable input. Master's `classifyInput` returns
+ *    `null`; the contract types `parse` as `Promise<ParsedDestination>` (no null), so an
+ *    unrecognised string is a {@link DomainError} the caller surfaces.
+ *
+ * @module
+ */
+import type { ScanDomain } from '../domains';
+import { DomainError } from '../errors';
+import {
+  buildLightningAddressFormatValidator,
+  extractCashuToken,
+  parseBolt11Invoice,
+} from '../internal/lib-scan';
+import type { ParsedDestination, ParsedToken } from '../types/scan';
+
+/**
+ * The scan domain. Construct with `{ allowLocalhost }` controlling whether a
+ * `user@localhost` Lightning address is accepted (development convenience; default `false`,
+ * matching production). Re-houses master `classifyInput`.
+ */
+export class ScanDomainImpl implements ScanDomain {
+  /** The ln-address FORMAT validator, built once with the localhost policy. */
+  private readonly validateLnAddressFormat: (
+    value: string | null | undefined,
+  ) => string | boolean;
+
+  /**
+   * @param options - `{ allowLocalhost }` — accept `user@localhost(:port)` addresses
+   *   (development only); defaults to `false`.
+   */
+  constructor(options?: { allowLocalhost?: boolean }) {
+    this.validateLnAddressFormat = buildLightningAddressFormatValidator({
+      message: 'invalid',
+      allowLocalhost: options?.allowLocalhost ?? false,
+    });
+  }
+
+  /**
+   * Classify a raw string into a {@link ParsedDestination}. Priority (verbatim from master):
+   * cashu token → BOLT11 invoice → Lightning address. A one-shot decode → `Promise`.
+   *
+   * @param input - the scanned/pasted string (may carry a `cashu:` / `lightning:` prefix, a
+   *   wrapping URL, or surrounding whitespace).
+   * @returns the parsed destination (kind only).
+   * @throws DomainError if the input is not a recognised destination.
+   */
+  async parse(input: string): Promise<ParsedDestination> {
+    const trimmed = input.trim();
+
+    // 1. Cashu token (works on URLs, raw tokens, `cashu:`-prefixed, etc.).
+    const cashuResult = extractCashuToken(trimmed);
+    if (cashuResult) {
+      const token: ParsedToken = {
+        encoded: cashuResult.encoded,
+        metadata: cashuResult.metadata,
+      };
+      return { kind: 'cashu-token', token };
+    }
+
+    // 2. BOLT11 invoice (accepts an optional, case-insensitive `lightning:` prefix).
+    const bolt11Result = parseBolt11Invoice(trimmed);
+    if (bolt11Result.valid) {
+      return { kind: 'bolt11', invoice: bolt11Result.decoded };
+    }
+
+    // 3. Lightning address — lowercase before validation (the format validator's local-part
+    // regex only accepts lowercase).
+    const lowered = trimmed.toLowerCase();
+    if (this.validateLnAddressFormat(lowered) === true) {
+      return { kind: 'ln-address', address: lowered };
+    }
+
+    throw new DomainError(
+      'Unrecognised input: not a Lightning invoice, Lightning address, or cashu token',
+      'UNRECOGNISED_DESTINATION',
+    );
+  }
+}

--- a/packages/wallet-sdk/src/internal/account-balance.test.ts
+++ b/packages/wallet-sdk/src/internal/account-balance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { getAccountBalance } from './account-balance';
+import type { CashuAccount, SparkAccount } from '../types/account';
+import { Money } from '../types/money';
+
+function cashu(proofAmounts: number[], currency: 'BTC' | 'USD' = 'BTC') {
+  return {
+    type: 'cashu',
+    currency,
+    proofs: proofAmounts.map((amount) => ({ amount })),
+  } as unknown as CashuAccount;
+}
+
+describe('getAccountBalance', () => {
+  test('cashu: sums proof amounts into Money (BTC → sat)', () => {
+    const balance = getAccountBalance(cashu([100, 250, 1]));
+    expect(balance).not.toBeNull();
+    expect(balance?.toNumber('sat')).toBe(351);
+    expect(balance?.currency).toBe('BTC');
+  });
+
+  test('cashu: USD proofs sum into cents', () => {
+    const balance = getAccountBalance(cashu([100, 50], 'USD'));
+    // cashu unit for USD is 'cent'.
+    expect(balance?.toNumber('cent')).toBe(150);
+    expect(balance?.currency).toBe('USD');
+  });
+
+  test('cashu: empty account → zero balance (not null)', () => {
+    const balance = getAccountBalance(cashu([]));
+    expect(balance).not.toBeNull();
+    expect(balance?.toNumber('sat')).toBe(0);
+  });
+
+  test('spark: returns the balance field', () => {
+    const account = {
+      type: 'spark',
+      currency: 'BTC',
+      balance: new Money({ amount: 5000, currency: 'BTC', unit: 'sat' }),
+    } as unknown as SparkAccount;
+    expect(getAccountBalance(account)?.toNumber('sat')).toBe(5000);
+  });
+
+  test('spark: null balance passes through as null', () => {
+    const account = {
+      type: 'spark',
+      currency: 'BTC',
+      balance: null,
+    } as unknown as SparkAccount;
+    expect(getAccountBalance(account)).toBeNull();
+  });
+});

--- a/packages/wallet-sdk/src/internal/account-balance.ts
+++ b/packages/wallet-sdk/src/internal/account-balance.ts
@@ -1,0 +1,41 @@
+/**
+ * `getAccountBalance` — pure account-balance derivation (Slice 2).
+ *
+ * Lifted verbatim from `apps/web-wallet/app/features/accounts/account.ts#getAccountBalance`:
+ * a cashu account's balance is the sum of its proof amounts (in the cashu unit for the
+ * currency); a spark account's balance is its `balance` field (sourced from the Breez SDK,
+ * may be `null` when offline / not yet known). Pure — no DB read, no live-wallet call — so
+ * it backs both `accounts.getBalance` (full object) and the `suggestFor` ranking.
+ *
+ * NOTE on the Slice-2 deferral: a cashu account's `proofs` are populated by the account
+ * handle resolver, which is deferred to Slice 3 (the Slice-2 stub yields `proofs: []`). So
+ * for a cashu account built in this slice this returns a zero balance until Slice 3 wires
+ * proof decryption; a spark account's `balance` is likewise `null` until Slice 3. This is
+ * the documented PR4 boundary — the function itself is the verbatim, final logic.
+ *
+ * @module
+ */
+import type { Account } from '../types/account';
+import { Money } from '../types/money';
+import { getCashuUnit, sumProofs } from './lib-cashu';
+
+/**
+ * The balance of an account.
+ *
+ * - cashu: `sum(proofs.amount)` as {@link Money} in the currency's cashu unit.
+ * - spark: the account's `balance` (possibly `null`).
+ *
+ * @param account - the account.
+ * @returns the balance as {@link Money}, or `null` for a spark account with no known balance.
+ */
+export function getAccountBalance(account: Account): Money | null {
+  if (account.type === 'cashu') {
+    const value = sumProofs(account.proofs);
+    return new Money({
+      amount: value,
+      currency: account.currency,
+      unit: getCashuUnit(account.currency),
+    });
+  }
+  return account.balance;
+}

--- a/packages/wallet-sdk/src/internal/account-handle-resolver.ts
+++ b/packages/wallet-sdk/src/internal/account-handle-resolver.ts
@@ -1,0 +1,162 @@
+/**
+ * Account live-handle resolver — the Slice-2 / Slice-3 seam.
+ *
+ * An `Account`'s `wallet` field is a LIVE protocol handle (a cashu `ExtendedCashuWallet`
+ * or a `BreezSdk` instance), and a cashu account's `proofs` are DECRYPTED from the DB rows.
+ * Master builds BOTH in one place — `account-repository.toAccount` — by calling
+ * `getInitializedCashuWallet` / `getInitializedSparkWallet` (a heavy, networked mint/Breez
+ * init that fetches keysets/keys with a 10s timeout) and `Encryption.decryptBatch` (the
+ * OpenSecret-derived encryption key + ECIES).
+ *
+ * **Per the build plan, that heavy construction is Slice 3, not Slice 2.** The plan puts
+ * the per-mint protocol-metadata memo (`ExtendedCashuWallet`), the mint-WS managers, the
+ * `lib/cashu/**` absorption, and `@agicash/breez-sdk-spark` all in Slice 3 ("THE HEAVY
+ * one"); Slice 2 owns the account DB read/write + scan + `suggestFor`. Proof DECRYPTION is
+ * equally entangled (same `toAccount` call, same `shared/encryption` subsystem) and rides
+ * with it.
+ *
+ * This module is the explicit injection seam between the two slices:
+ *  - `AccountHandleResolver` is the interface the account repository depends on to fill in
+ *    the deferred `wallet` (+ a cashu account's `isOnline` and decrypted `proofs`).
+ *  - {@link DeferredAccountHandleResolver} is the Slice-2 implementation: it constructs
+ *    accounts from the DB fields Slice 2 owns and leaves the live handle deferred — any
+ *    *use* of `wallet` (or decrypted `proofs`) throws {@link NotImplementedError} via a
+ *    lazy stub. Slice 3 swaps in the real resolver (mint/Breez init + proof decryption)
+ *    with no change to the repository.
+ *
+ * This keeps PR4 small (no mint/Breez/encryption wiring) while making the account read/
+ * write surface — `list` / `get` / `getDefault` / `add` / `setDefault` / `getBalance`
+ * (spark, and cashu once Slice 3 decrypts proofs) / `suggestFor` — real and reviewable.
+ *
+ * @module
+ */
+import { NotImplementedError } from '../errors';
+import type {
+  BreezSdk,
+  CashuProof,
+  ExtendedCashuWallet,
+  SparkNetwork,
+} from '../types/account';
+import type { Currency } from '../types/money';
+
+/** Inputs needed to (eventually) initialise a cashu account's live wallet + proofs. */
+export type CashuHandleRequest = {
+  mintUrl: string;
+  currency: Currency;
+  /** Encrypted `(amount, secret)` proof rows from the DB, awaiting decryption (Slice 3). */
+  encryptedProofs: EncryptedCashuProofRow[];
+};
+
+/** The encrypted-on-the-row fields of a cashu proof the resolver decrypts in Slice 3. */
+export type EncryptedCashuProofRow = {
+  id: string;
+  accountId: string;
+  userId: string;
+  keysetId: string;
+  /** Encrypted ciphertext (decrypted to a `number` in Slice 3). */
+  amount: string;
+  /** Encrypted ciphertext (decrypted to a `string` in Slice 3). */
+  secret: string;
+  unblindedSignature: string;
+  publicKeyY: string;
+  dleq: CashuProof['dleq'];
+  witness: CashuProof['witness'];
+  state: CashuProof['state'];
+  version: number;
+  createdAt: string;
+  reservedAt?: string | null;
+  spentAt?: string | null;
+};
+
+/** What the resolver returns for a cashu account: the live wallet, online flag, + proofs. */
+export type ResolvedCashuHandle = {
+  wallet: ExtendedCashuWallet;
+  isOnline: boolean;
+  proofs: CashuProof[];
+};
+
+/** What the resolver returns for a spark account: the live wallet, online flag, + balance. */
+export type ResolvedSparkHandle = {
+  wallet: BreezSdk;
+  isOnline: boolean;
+  balance: ResolvedSparkBalance;
+};
+
+/** Spark balance the resolver derives from the live wallet (Slice 3); deferred to `null` here. */
+export type ResolvedSparkBalance = import('../types/money').Money | null;
+
+/**
+ * Fills in an account's deferred, connection-bound fields (the live `wallet` handle, online
+ * status, decrypted cashu proofs / spark balance). Slice 2 supplies a deferral stub; Slice 3
+ * supplies the real mint/Breez init + proof decryption.
+ */
+export interface AccountHandleResolver {
+  /** Resolve a cashu account's live wallet, online flag, and decrypted proofs. */
+  resolveCashu(request: CashuHandleRequest): Promise<ResolvedCashuHandle>;
+  /** Resolve a spark account's live wallet, online flag, and balance. */
+  resolveSpark(request: {
+    network: SparkNetwork;
+  }): Promise<ResolvedSparkHandle>;
+}
+
+/**
+ * Build a lazy stub that stands in for a not-yet-constructed live wallet handle. Reading
+ * any property (e.g. calling `wallet.getMintInfo()`) throws {@link NotImplementedError}
+ * naming the slice that fills it in, so a deferred handle fails loudly + identifiably
+ * rather than surfacing as `undefined`. The account's plain DB fields remain fully usable.
+ *
+ * @param label - identifies the handle in the thrown message (e.g. `'ExtendedCashuWallet'`).
+ * @returns a `Proxy` typed as `T` whose every access throws.
+ */
+function deferredHandle<T>(label: string): T {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        // Let well-known introspection symbols resolve to undefined so the stub can be
+        // safely held / logged / spread without tripping the throw (only real *use* throws).
+        if (typeof prop === 'symbol') {
+          return undefined;
+        }
+        throw new NotImplementedError(
+          `${label}.${String(prop)} (live wallet handle is constructed in @agicash/wallet-sdk Slice 3)`,
+        );
+      },
+    },
+  ) as T;
+}
+
+/**
+ * Slice-2 {@link AccountHandleResolver}: constructs accounts from the DB fields this slice
+ * owns and DEFERS the live wallet handle + proof decryption to Slice 3.
+ *
+ * - cashu: `wallet` is a deferred {@link deferredHandle} stub, `isOnline` is reported
+ *   `false` (no mint was contacted), and `proofs` is `[]` (decryption is Slice 3 — the
+ *   encrypted ciphertext is intentionally NOT surfaced as a proof). Consumers that only
+ *   read DB fields (`mintUrl`, `keysetCounters`, `currency`, defaults, `suggestFor` online-
+ *   filtering) work; anything that needs the live mint or real proofs gets a labelled throw.
+ * - spark: `wallet` is a deferred stub, `isOnline` is `false`, `balance` is `null`.
+ */
+export class DeferredAccountHandleResolver implements AccountHandleResolver {
+  /** Deferred cashu handle: stub wallet, offline, no decrypted proofs (Slice 3 fills these). */
+  async resolveCashu(
+    _request: CashuHandleRequest,
+  ): Promise<ResolvedCashuHandle> {
+    return {
+      wallet: deferredHandle<ExtendedCashuWallet>('ExtendedCashuWallet'),
+      isOnline: false,
+      proofs: [],
+    };
+  }
+
+  /** Deferred spark handle: stub wallet, offline, null balance (Slice 3 fills these). */
+  async resolveSpark(_request: {
+    network: SparkNetwork;
+  }): Promise<ResolvedSparkHandle> {
+    return {
+      wallet: deferredHandle<BreezSdk>('BreezSdk'),
+      isOnline: false,
+      balance: null,
+    };
+  }
+}

--- a/packages/wallet-sdk/src/internal/account-repository.test.ts
+++ b/packages/wallet-sdk/src/internal/account-repository.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test';
+import { DeferredAccountHandleResolver } from './account-handle-resolver';
+import { AccountRepository } from './account-repository';
+import type { AgicashDbAccountWithProofs } from './db-account';
+import type { WalletSupabaseClient } from './supabase-client';
+
+// -- Fakes -------------------------------------------------------------------
+
+/** Terminal result shape every builder call resolves to. */
+type Result = { data: unknown; error: unknown; status?: number };
+
+/**
+ * A fake Supabase client whose fluent `from(...).select/insert/eq/returns/...` chain is a
+ * no-op (records the last `insert(...)` payload) and whose terminal `single()` /
+ * `maybeSingle()` — and the awaited builder itself (`getAllActive` awaits the query, not a
+ * terminal) — resolve to a pre-set result. Only the methods the repository touches are
+ * implemented; cast to the client type.
+ */
+function fakeDb(result: Result) {
+  let lastInsert: unknown;
+  const chain: Record<string, unknown> & PromiseLike<Result> = {
+    select: () => chain,
+    insert: (payload: unknown) => {
+      lastInsert = payload;
+      return chain;
+    },
+    eq: () => chain,
+    returns: () => chain,
+    single: async () => result,
+    maybeSingle: async () => result,
+    // Make the builder awaitable (the `getAllActive` list query is awaited directly) — a
+    // PostgrestFilterBuilder IS a real thenable, so the mock must be one too.
+    // biome-ignore lint/suspicious/noThenProperty: intentionally mocking the thenable Supabase query builder.
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+  };
+  const db = {
+    from: () => chain,
+  } as unknown as WalletSupabaseClient;
+  return { db, getLastInsert: () => lastInsert };
+}
+
+const resolver = new DeferredAccountHandleResolver();
+
+const cashuRow: AgicashDbAccountWithProofs = {
+  id: 'acct-cashu',
+  name: 'My Mint',
+  type: 'cashu',
+  purpose: 'transactional',
+  state: 'active',
+  currency: 'BTC',
+  details: {
+    mint_url: 'https://mint.example.com',
+    is_test_mint: false,
+    keyset_counters: { abc: 3 },
+  },
+  created_at: '2026-01-01T00:00:00.000Z',
+  expires_at: null,
+  user_id: 'user-1',
+  version: 2,
+  cashu_proofs: [],
+};
+
+const sparkRow: AgicashDbAccountWithProofs = {
+  id: 'acct-spark',
+  name: 'Spark',
+  type: 'spark',
+  purpose: 'transactional',
+  state: 'active',
+  currency: 'BTC',
+  details: { network: 'MAINNET' },
+  created_at: '2026-01-02T00:00:00.000Z',
+  expires_at: null,
+  user_id: 'user-1',
+  version: 1,
+  cashu_proofs: [],
+};
+
+describe('AccountRepository.get', () => {
+  test('maps a cashu account row to the domain account (handle deferred)', async () => {
+    const { db } = fakeDb({ data: cashuRow, error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    const account = await repo.get('acct-cashu');
+
+    expect(account).not.toBeNull();
+    expect(account?.type).toBe('cashu');
+    if (account?.type === 'cashu') {
+      expect(account.mintUrl).toBe('https://mint.example.com');
+      expect(account.isTestMint).toBe(false);
+      expect(account.keysetCounters).toEqual({ abc: 3 });
+      // Deferred to Slice 3: proofs empty, account reported offline.
+      expect(account.proofs).toEqual([]);
+      expect(account.isOnline).toBe(false);
+    }
+  });
+
+  test('maps a spark account row (balance deferred to null)', async () => {
+    const { db } = fakeDb({ data: sparkRow, error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    const account = await repo.get('acct-spark');
+
+    expect(account?.type).toBe('spark');
+    if (account?.type === 'spark') {
+      expect(account.network).toBe('MAINNET');
+      expect(account.balance).toBeNull();
+      expect(account.isOnline).toBe(false);
+    }
+  });
+
+  test('returns null when no row exists', async () => {
+    const { db } = fakeDb({ data: null, error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    expect(await repo.get('missing')).toBeNull();
+  });
+
+  test('throws on a read error', async () => {
+    const { db } = fakeDb({ data: null, error: { message: 'boom' } });
+    const repo = new AccountRepository(db, resolver);
+
+    await expect(repo.get('acct-cashu')).rejects.toThrow(
+      'Failed to get account',
+    );
+  });
+});
+
+describe('AccountRepository.getAllActive', () => {
+  test('maps every returned row', async () => {
+    const { db } = fakeDb({ data: [cashuRow, sparkRow], error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    const accounts = await repo.getAllActive('user-1');
+
+    expect(accounts).toHaveLength(2);
+    expect(accounts.map((a) => a.id)).toEqual(['acct-cashu', 'acct-spark']);
+  });
+
+  test('throws on a read error', async () => {
+    const { db } = fakeDb({ data: null, error: { message: 'boom' } });
+    const repo = new AccountRepository(db, resolver);
+
+    await expect(repo.getAllActive('user-1')).rejects.toThrow(
+      'Failed to get accounts',
+    );
+  });
+});
+
+describe('AccountRepository.add', () => {
+  test('builds the cashu insert row (normalised mint url + empty counters)', async () => {
+    const { db, getLastInsert } = fakeDb({ data: cashuRow, error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    const account = await repo.add('user-1', {
+      type: 'cashu',
+      mintUrl: 'https://mint.example.com/', // trailing slash → normalised
+      currency: 'BTC',
+    });
+
+    const inserted = getLastInsert() as {
+      type: string;
+      currency: string;
+      user_id: string;
+      purpose: string;
+      expires_at: string | null;
+      details: { mint_url: string; is_test_mint: boolean };
+    };
+    expect(inserted.type).toBe('cashu');
+    expect(inserted.currency).toBe('BTC');
+    expect(inserted.user_id).toBe('user-1');
+    expect(inserted.purpose).toBe('transactional');
+    expect(inserted.expires_at).toBeNull();
+    expect(inserted.details.mint_url).toBe('https://mint.example.com');
+    expect(account.type).toBe('cashu');
+  });
+
+  test('builds the spark insert row (network MAINNET, default name)', async () => {
+    const { db, getLastInsert } = fakeDb({ data: sparkRow, error: null });
+    const repo = new AccountRepository(db, resolver);
+
+    await repo.add('user-1', { type: 'spark', currency: 'BTC' });
+
+    const inserted = getLastInsert() as {
+      type: string;
+      name: string;
+      details: { network: string };
+    };
+    expect(inserted.type).toBe('spark');
+    expect(inserted.name).toBe('Spark');
+    expect(inserted.details.network).toBe('MAINNET');
+  });
+
+  test('a 409 on a cashu insert → DomainError (account already exists)', async () => {
+    const { db } = fakeDb({
+      data: null,
+      error: { message: 'conflict' },
+      status: 409,
+    });
+    const repo = new AccountRepository(db, resolver);
+
+    const promise = repo.add('user-1', {
+      type: 'cashu',
+      mintUrl: 'https://mint.example.com',
+      currency: 'BTC',
+    });
+    await expect(promise).rejects.toMatchObject({
+      code: 'ACCOUNT_ALREADY_EXISTS',
+    });
+  });
+
+  test('a LIMIT_REACHED hint → DomainError', async () => {
+    const { db } = fakeDb({
+      data: null,
+      error: { message: 'too many', hint: 'LIMIT_REACHED', details: 'max 1' },
+    });
+    const repo = new AccountRepository(db, resolver);
+
+    const promise = repo.add('user-1', {
+      type: 'cashu',
+      mintUrl: 'https://mint.example.com',
+      currency: 'BTC',
+    });
+    await expect(promise).rejects.toMatchObject({
+      code: 'ACCOUNT_LIMIT_REACHED',
+    });
+  });
+
+  test('a non-conflict insert error → generic Error', async () => {
+    const { db } = fakeDb({
+      data: null,
+      error: { message: 'boom' },
+      status: 500,
+    });
+    const repo = new AccountRepository(db, resolver);
+
+    await expect(
+      repo.add('user-1', { type: 'spark', currency: 'BTC' }),
+    ).rejects.toThrow('Failed to create account');
+  });
+});

--- a/packages/wallet-sdk/src/internal/account-repository.ts
+++ b/packages/wallet-sdk/src/internal/account-repository.ts
@@ -1,0 +1,177 @@
+/**
+ * Internal `wallet.accounts` repository — Slice 2 (accounts + scan).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/accounts/account-repository.ts` (`get` / `getAllActive` /
+ * `create`) + `account-service.ts` (`addCashuAccount`). Master expresses these over a
+ * React-hook-constructed repository wired to a TanStack `QueryClient`; here they are plain
+ * async methods over the SDK-owned Supabase client (passed in), reading/writing the
+ * `wallet.accounts` table (joined with `cashu_proofs`) and mapping rows via
+ * {@link dbAccountToAccount}.
+ *
+ * The live wallet handle + proof decryption are resolved through the injected
+ * {@link AccountHandleResolver} (deferred to Slice 3; see `account-handle-resolver.ts`). The
+ * `expires_at`-from-keyset path master runs for `offer` accounts in `addCashuAccount` needs
+ * the mint keysets (a networked read = Slice 3); offers are out of v1 (§13), so `add`
+ * persists `expires_at: null` and a Slice-3 follow-up wires the keyset-expiry path when
+ * offer creation lands.
+ *
+ * @module
+ */
+import { DomainError } from '../errors';
+import type { Account, AddAccountConfig } from '../types/account';
+import type { AccountHandleResolver } from './account-handle-resolver';
+import {
+  type AgicashDbAccountWithProofs,
+  CashuAccountDetailsDbDataSchema,
+  SparkAccountDetailsDbDataSchema,
+  dbAccountToAccount,
+} from './db-account';
+import { checkIsTestMint, normalizeMintUrl } from './lib-cashu';
+import type { WalletSupabaseClient } from './supabase-client';
+
+/** The `select` projection master uses: the account row joined with its UNSPENT proofs. */
+const ACCOUNT_WITH_PROOFS_SELECT = '*, cashu_proofs(*)';
+
+/**
+ * Reads + writes for the `wallet.accounts` table, scoped (via RLS) to the signed-in user.
+ *
+ * Holds the SDK-owned Supabase client + the {@link AccountHandleResolver}. Methods take the
+ * `userId` the account domain resolves from the current session.
+ */
+export class AccountRepository {
+  /**
+   * @param db - the SDK-owned Supabase client (schema pinned to `wallet`).
+   * @param resolver - fills in each account's deferred live-handle fields (Slice 2 stub /
+   *   Slice 3 real).
+   */
+  constructor(
+    private readonly db: WalletSupabaseClient,
+    private readonly resolver: AccountHandleResolver,
+  ) {}
+
+  /**
+   * Get the account with the given id (or null if not found).
+   *
+   * Verbatim logic from master `AccountRepository.get`: select the account joined with its
+   * UNSPENT proofs, then map via {@link dbAccountToAccount}. The proof limit master notes
+   * (≤6000) is a server concern and unchanged here.
+   *
+   * @param id - the account id.
+   * @returns the account, or null.
+   * @throws Error if the read fails.
+   */
+  async get(id: string): Promise<Account | null> {
+    const { data, error } = await this.db
+      .from('accounts')
+      .select(ACCOUNT_WITH_PROOFS_SELECT)
+      .eq('id', id)
+      .eq('cashu_proofs.state', 'UNSPENT')
+      .maybeSingle<AgicashDbAccountWithProofs>();
+
+    if (error) {
+      throw new Error('Failed to get account', { cause: error });
+    }
+
+    return data ? dbAccountToAccount(data, this.resolver) : null;
+  }
+
+  /**
+   * Get all ACTIVE accounts for the user (with their UNSPENT proofs).
+   *
+   * Verbatim logic from master `AccountRepository.getAllActive`: filter to `state='active'`
+   * and join UNSPENT proofs, then map each row. This is the read backing `accounts.list`.
+   *
+   * @param userId - the owning user id.
+   * @returns the active accounts.
+   * @throws Error if the read fails.
+   */
+  async getAllActive(userId: string): Promise<Account[]> {
+    const { data, error } = await this.db
+      .from('accounts')
+      .select(ACCOUNT_WITH_PROOFS_SELECT)
+      .eq('user_id', userId)
+      .eq('state', 'active')
+      .eq('cashu_proofs.state', 'UNSPENT')
+      .returns<AgicashDbAccountWithProofs[]>();
+
+    if (error) {
+      throw new Error('Failed to get accounts', { cause: error });
+    }
+
+    return Promise.all(
+      data.map((row) => dbAccountToAccount(row, this.resolver)),
+    );
+  }
+
+  /**
+   * Create an account from an {@link AddAccountConfig} and return the mapped domain account.
+   *
+   * Re-houses master `account-service.addCashuAccount` + `account-repository.create`: builds
+   * the per-type `details` JSON (cashu: normalised mint URL + test-mint detection + empty
+   * keyset counters; spark: network), inserts the row, and maps the result. `name` defaults
+   * to the mint URL (cashu) / `'Spark'` (spark) when omitted. `expires_at` is `null`
+   * (the offer keyset-expiry path is Slice 3; offers are out of v1).
+   *
+   * @param userId - the owning user id.
+   * @param config - the account create config.
+   * @returns the created account.
+   * @throws DomainError if the mint's account limit is reached, or (cashu) the mint+currency
+   *   account already exists.
+   * @throws Error if the insert otherwise fails.
+   */
+  async add(userId: string, config: AddAccountConfig): Promise<Account> {
+    const network = config.type === 'spark' ? 'MAINNET' : undefined;
+
+    const details =
+      config.type === 'cashu'
+        ? CashuAccountDetailsDbDataSchema.parse({
+            mint_url: normalizeMintUrl(config.mintUrl),
+            is_test_mint: checkIsTestMint(config.mintUrl),
+            keyset_counters: {},
+          })
+        : SparkAccountDetailsDbDataSchema.parse({ network });
+
+    const name =
+      config.name ??
+      (config.type === 'cashu' ? normalizeMintUrl(config.mintUrl) : 'Spark');
+
+    const row = {
+      name,
+      type: config.type,
+      currency: config.currency,
+      details,
+      user_id: userId,
+      purpose: 'transactional',
+      expires_at: null,
+    };
+
+    const { data, error, status } = await this.db
+      .from('accounts')
+      // biome-ignore lint/suspicious/noExplicitAny: the Supabase client is untyped until the generated Database types are lifted (a later slice); the insert row shape is enforced above.
+      .insert(row as any)
+      .select(ACCOUNT_WITH_PROOFS_SELECT)
+      .eq('cashu_proofs.state', 'UNSPENT')
+      .single<AgicashDbAccountWithProofs>();
+
+    if (error) {
+      // Master surfaces the mint's per-account LIMIT_REACHED hint as a DomainError.
+      if (error.hint === 'LIMIT_REACHED') {
+        throw new DomainError(
+          `${error.message} ${error.details ?? ''}`.trim(),
+          'ACCOUNT_LIMIT_REACHED',
+        );
+      }
+      // A 409 on a cashu insert = the mint+currency account already exists.
+      if (status === 409 && config.type === 'cashu') {
+        throw new DomainError(
+          'Account for this mint and currency already exists',
+          'ACCOUNT_ALREADY_EXISTS',
+        );
+      }
+      throw new Error('Failed to create account', { cause: error });
+    }
+
+    return dbAccountToAccount(data, this.resolver);
+  }
+}

--- a/packages/wallet-sdk/src/internal/db-account.test.ts
+++ b/packages/wallet-sdk/src/internal/db-account.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type AccountHandleResolver,
+  DeferredAccountHandleResolver,
+} from './account-handle-resolver';
+import {
+  type AgicashDbAccount,
+  type AgicashDbAccountWithProofs,
+  dbAccountToAccount,
+  isCashuAccount,
+  isSparkAccount,
+} from './db-account';
+
+const deferred = new DeferredAccountHandleResolver();
+
+const cashuBase: AgicashDbAccount = {
+  id: 'a1',
+  name: 'Mint',
+  type: 'cashu',
+  purpose: 'transactional',
+  state: 'active',
+  currency: 'BTC',
+  details: {
+    mint_url: 'https://mint.example.com',
+    is_test_mint: true,
+    keyset_counters: {},
+  },
+  created_at: '2026-01-01T00:00:00.000Z',
+  expires_at: null,
+  user_id: 'u1',
+  version: 1,
+};
+
+describe('type guards', () => {
+  test('isCashuAccount true for a valid cashu row', () => {
+    expect(isCashuAccount(cashuBase)).toBe(true);
+  });
+
+  test('isCashuAccount false for a spark row', () => {
+    const spark: AgicashDbAccount = {
+      ...cashuBase,
+      type: 'spark',
+      details: { network: 'REGTEST' },
+    };
+    expect(isCashuAccount(spark)).toBe(false);
+    expect(isSparkAccount(spark)).toBe(true);
+  });
+
+  test('isCashuAccount throws when type=cashu but details are invalid', () => {
+    const bad: AgicashDbAccount = { ...cashuBase, details: { mint_url: 123 } };
+    expect(() => isCashuAccount(bad)).toThrow();
+  });
+});
+
+describe('dbAccountToAccount (deferred resolver)', () => {
+  test('maps a cashu row, deferring wallet/proofs/isOnline', async () => {
+    const row: AgicashDbAccountWithProofs = { ...cashuBase, cashu_proofs: [] };
+    const account = await dbAccountToAccount(row, deferred);
+
+    expect(account.id).toBe('a1');
+    expect(account.type).toBe('cashu');
+    expect(account.currency).toBe('BTC');
+    expect(account.version).toBe(1);
+    if (account.type === 'cashu') {
+      expect(account.mintUrl).toBe('https://mint.example.com');
+      expect(account.isTestMint).toBe(true);
+      expect(account.proofs).toEqual([]);
+      expect(account.isOnline).toBe(false);
+    }
+  });
+
+  test('maps a spark row, deferring wallet/balance/isOnline', async () => {
+    const row: AgicashDbAccountWithProofs = {
+      ...cashuBase,
+      type: 'spark',
+      details: { network: 'MAINNET' },
+      cashu_proofs: [],
+    };
+    const account = await dbAccountToAccount(row, deferred);
+
+    expect(account.type).toBe('spark');
+    if (account.type === 'spark') {
+      expect(account.network).toBe('MAINNET');
+      expect(account.balance).toBeNull();
+      expect(account.isOnline).toBe(false);
+    }
+  });
+
+  test('throws on an unknown account type', async () => {
+    const row = {
+      ...cashuBase,
+      type: 'unknown',
+      cashu_proofs: [],
+    } as unknown as AgicashDbAccountWithProofs;
+    await expect(dbAccountToAccount(row, deferred)).rejects.toThrow(
+      'Invalid account type',
+    );
+  });
+
+  test('uses the injected resolver output (forward-compat with the Slice-3 resolver)', async () => {
+    // A fake "Slice 3" resolver that returns a real online cashu wallet handle + proofs.
+    const fakeWallet = { getMintInfo: () => ({}) };
+    const realResolver: AccountHandleResolver = {
+      resolveCashu: async () => ({
+        wallet: fakeWallet as never,
+        isOnline: true,
+        proofs: [],
+      }),
+      resolveSpark: async () => ({
+        wallet: {} as never,
+        isOnline: true,
+        balance: null,
+      }),
+    };
+    const row: AgicashDbAccountWithProofs = { ...cashuBase, cashu_proofs: [] };
+    const account = await dbAccountToAccount(row, realResolver);
+
+    expect(account.isOnline).toBe(true);
+    if (account.type === 'cashu') {
+      expect(account.wallet).toBe(fakeWallet as never);
+    }
+  });
+});
+
+describe('DeferredAccountHandleResolver — the live handle is a throwing stub', () => {
+  test('reading a method off the deferred cashu wallet throws NotImplementedError', async () => {
+    const { wallet } = await deferred.resolveCashu({
+      mintUrl: 'm',
+      currency: 'BTC',
+      encryptedProofs: [],
+    });
+    // The wallet exists as an object, but *using* it (any property access) throws.
+    expect(() =>
+      (wallet as { getMintInfo: () => unknown }).getMintInfo(),
+    ).toThrow('Slice 3');
+  });
+
+  test('reading a method off the deferred spark wallet throws NotImplementedError', async () => {
+    const { wallet } = await deferred.resolveSpark({ network: 'MAINNET' });
+    expect(() => (wallet as { getInfo: () => unknown }).getInfo()).toThrow(
+      'Slice 3',
+    );
+  });
+});

--- a/packages/wallet-sdk/src/internal/db-account.ts
+++ b/packages/wallet-sdk/src/internal/db-account.ts
@@ -1,0 +1,268 @@
+/**
+ * Internal DB ⇄ domain `Account` mapping — Slice 2 (accounts + scan).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/accounts/account-repository.ts` (`toAccount`) +
+ * `apps/web-wallet/app/features/agicash-db/database.ts` (the row types + `isCashuAccount`/
+ * `isSparkAccount` guards) + the `json-models/*-account-details-db-data.ts` schemas. Master
+ * maps a `wallet.accounts` row (joined with `cashu_proofs`) to the domain {@link Account};
+ * here that mapping is framework-free and the LIVE wallet handle / decrypted proofs are
+ * resolved through the injected {@link AccountHandleResolver} (deferred to Slice 3 — see
+ * `account-handle-resolver.ts`).
+ *
+ * This module owns:
+ *  - {@link AgicashDbAccount} / {@link AgicashDbCashuProof} / {@link AgicashDbAccountWithProofs}
+ *    — the row shapes (master: generated `supabase/database.types.ts`). Hand-written here as
+ *    in `db-user.ts`, so the SDK can type the otherwise-untyped Supabase reads without
+ *    pulling the full generated `Database` types (lifted in a later slice).
+ *  - {@link CashuAccountDetailsDbDataSchema} / {@link SparkAccountDetailsDbDataSchema} — the
+ *    `details` JSON schemas (lifted verbatim from `json-models/*-account-details-db-data.ts`).
+ *  - {@link isCashuAccount} / {@link isSparkAccount} — the type guards (verbatim).
+ *  - {@link dbAccountToAccount} — the row→domain mapper (verbatim logic from
+ *    `account-repository.toAccount`, minus the live-handle/decrypt construction which the
+ *    resolver owns).
+ *
+ * @module
+ */
+import { z } from 'zod/mini';
+import type {
+  Account,
+  AccountPurpose,
+  AccountState,
+  AccountType,
+  SparkNetwork,
+} from '../types/account';
+import type { Currency } from '../types/money';
+import type {
+  AccountHandleResolver,
+  EncryptedCashuProofRow,
+} from './account-handle-resolver';
+
+// --- json-model `details` schemas (verbatim from json-models/*-account-details-db-data) --
+
+/** The `accounts.details` JSON for a cashu account (verbatim from master). */
+export const CashuAccountDetailsDbDataSchema = z.object({
+  /** URL of the mint. */
+  mint_url: z.string(),
+  /** Whether the mint is a test mint. */
+  is_test_mint: z.boolean(),
+  /** Counter value per mint keyset (keysetId → counter). */
+  keyset_counters: z.record(z.string(), z.number()),
+});
+/** `z.infer` of {@link CashuAccountDetailsDbDataSchema}. */
+export type CashuAccountDetailsDbData = z.infer<
+  typeof CashuAccountDetailsDbDataSchema
+>;
+
+/** The `accounts.details` JSON for a spark account (verbatim from master). */
+export const SparkAccountDetailsDbDataSchema = z.object({
+  /** Network of the Spark account (stored uppercase). */
+  network: z.enum(['MAINNET', 'REGTEST']),
+});
+/** `z.infer` of {@link SparkAccountDetailsDbDataSchema}. */
+export type SparkAccountDetailsDbData = z.infer<
+  typeof SparkAccountDetailsDbDataSchema
+>;
+
+// --- row shapes (hand-written; master = generated supabase/database.types.ts) ------------
+
+/**
+ * A row of the `wallet.accounts` table.
+ *
+ * Lifted from master `agicash-db/database.ts#AgicashDbAccount`
+ * (`Database['wallet']['Tables']['accounts']['Row']`, generated in
+ * `supabase/database.types.ts`). Hand-written here (as in {@link AgicashDbUser}) so the SDK
+ * can narrow the currently-untyped Supabase reads; replaced by the generated types when
+ * those are lifted into the package. `details` is the per-type JSON parsed by the guards.
+ */
+export type AgicashDbAccount = {
+  /** UUID primary key. */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** `'cashu' | 'spark'`. */
+  type: AccountType;
+  /** What the account is for. */
+  purpose: AccountPurpose;
+  /** `'active' | 'expired'`. */
+  state: AccountState;
+  /** The account currency. */
+  currency: Currency;
+  /** Per-type JSON blob (cashu mint/keyset info, or spark network). */
+  details: unknown;
+  /** Row creation time, ISO 8601. */
+  created_at: string;
+  /** Account expiry, ISO 8601, or null for non-expiring. */
+  expires_at: string | null;
+  /** Owning user id. */
+  user_id: string;
+  /** Row version (optimistic lock). */
+  version: number;
+};
+
+/**
+ * A row of the `wallet.cashu_proofs` table.
+ *
+ * Lifted from master `agicash-db/database.ts#AgicashDbCashuProof`. NOTE: `amount` + `secret`
+ * are ENCRYPTED ciphertext on the row (typed `string`); decryption to a `number` / plaintext
+ * `string` happens in the {@link AccountHandleResolver} (Slice 3). Only the encrypted
+ * columns the mapper forwards are typed; the spend-tracking foreign-key columns are omitted
+ * (not needed by the read mapper).
+ */
+export type AgicashDbCashuProof = {
+  id: string;
+  account_id: string;
+  user_id: string;
+  keyset_id: string;
+  /** Encrypted ciphertext. */
+  amount: string;
+  /** Encrypted ciphertext. */
+  secret: string;
+  unblinded_signature: string;
+  public_key_y: string;
+  dleq: unknown;
+  witness: unknown;
+  state: 'UNSPENT' | 'RESERVED' | 'SPENT';
+  version: number;
+  created_at: string;
+  reserved_at: string | null;
+  spent_at?: string | null;
+};
+
+/**
+ * An account row joined with its `cashu_proofs`. For a spark account `cashu_proofs` is an
+ * empty array (verbatim from master `AgicashDbAccountWithProofs`).
+ */
+export type AgicashDbAccountWithProofs = AgicashDbAccount & {
+  cashu_proofs: AgicashDbCashuProof[];
+};
+
+// --- type guards (verbatim from agicash-db/database.ts) ----------------------------------
+
+/**
+ * Whether the row is a cashu account (verbatim from master `isCashuAccount`).
+ * @throws if `type === 'cashu'` but `details` fails the cashu schema.
+ */
+export function isCashuAccount(
+  data: AgicashDbAccount,
+): data is AgicashDbAccount & {
+  type: 'cashu';
+  details: CashuAccountDetailsDbData;
+} {
+  if (data.type !== 'cashu') {
+    return false;
+  }
+  CashuAccountDetailsDbDataSchema.parse(data.details);
+  return true;
+}
+
+/**
+ * Whether the row is a spark account (verbatim from master `isSparkAccount`).
+ * @throws if `type === 'spark'` but `details` fails the spark schema.
+ */
+export function isSparkAccount(
+  data: AgicashDbAccount,
+): data is AgicashDbAccount & {
+  type: 'spark';
+  details: SparkAccountDetailsDbData;
+} {
+  if (data.type !== 'spark') {
+    return false;
+  }
+  SparkAccountDetailsDbDataSchema.parse(data.details);
+  return true;
+}
+
+/** Map the encrypted cashu-proof rows to the resolver's {@link EncryptedCashuProofRow} input. */
+function toEncryptedProofRows(
+  proofs: AgicashDbCashuProof[],
+): EncryptedCashuProofRow[] {
+  return proofs.map((p) => ({
+    id: p.id,
+    accountId: p.account_id,
+    userId: p.user_id,
+    keysetId: p.keyset_id,
+    amount: p.amount,
+    secret: p.secret,
+    unblindedSignature: p.unblinded_signature,
+    publicKeyY: p.public_key_y,
+    // dleq/witness are cashu-ts `Proof` sub-fields; the domain `CashuProof` carries them
+    // as-is (Slice 3's resolver re-parses via cashu-ts `ProofSchema`). Cast to the domain
+    // sub-field type (a placeholder until cashu-ts types are imported).
+    dleq: p.dleq as EncryptedCashuProofRow['dleq'],
+    witness: p.witness as EncryptedCashuProofRow['witness'],
+    state: p.state,
+    version: p.version,
+    createdAt: p.created_at,
+    reservedAt: p.reserved_at,
+    spentAt: p.spent_at,
+  }));
+}
+
+/**
+ * Map a `wallet.accounts` row (joined with `cashu_proofs`) to the domain {@link Account}.
+ *
+ * Verbatim logic from master `account-repository.toAccount`: the common base fields are
+ * copied straight off the row; the per-type fields are read from the parsed `details`; and
+ * the connection-bound fields — the live `wallet` handle, `isOnline`, decrypted cashu
+ * `proofs` / spark `balance` — come from the injected {@link AccountHandleResolver} (the
+ * Slice-2 deferral stub or the Slice-3 real resolver).
+ *
+ * @param data - the joined account row.
+ * @param resolver - fills in the deferred live-handle fields.
+ * @returns the domain account.
+ * @throws Error if the row's `type` is neither cashu nor spark.
+ */
+export async function dbAccountToAccount<T extends Account = Account>(
+  data: AgicashDbAccountWithProofs,
+  resolver: AccountHandleResolver,
+): Promise<T> {
+  const commonData = {
+    id: data.id,
+    name: data.name,
+    currency: data.currency,
+    purpose: data.purpose,
+    state: data.state,
+    createdAt: data.created_at,
+    version: data.version,
+    expiresAt: data.expires_at,
+  };
+
+  if (isCashuAccount(data)) {
+    const details = data.details;
+    const { wallet, isOnline, proofs } = await resolver.resolveCashu({
+      mintUrl: details.mint_url,
+      currency: data.currency,
+      encryptedProofs: toEncryptedProofRows(data.cashu_proofs),
+    });
+
+    return {
+      ...commonData,
+      isOnline,
+      type: 'cashu',
+      mintUrl: details.mint_url,
+      isTestMint: details.is_test_mint,
+      keysetCounters: details.keyset_counters,
+      proofs,
+      wallet,
+    } as T;
+  }
+
+  if (isSparkAccount(data)) {
+    const network: SparkNetwork = data.details.network;
+    const { wallet, isOnline, balance } = await resolver.resolveSpark({
+      network,
+    });
+
+    return {
+      ...commonData,
+      type: 'spark',
+      balance,
+      network,
+      isOnline,
+      wallet,
+    } as T;
+  }
+
+  throw new Error('Invalid account type');
+}

--- a/packages/wallet-sdk/src/internal/extended-account.test.ts
+++ b/packages/wallet-sdk/src/internal/extended-account.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+import { getExtendedAccounts, isDefaultAccount } from './extended-account';
+import type { Account } from '../types/account';
+import type { User } from '../types/user';
+
+const user: User = {
+  id: 'user-1',
+  username: 'alice',
+  isGuest: false,
+  email: 'alice@example.com',
+  emailVerified: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  defaultBtcAccountId: 'btc-default',
+  defaultUsdAccountId: 'usd-default',
+  defaultCurrency: 'BTC',
+  cashuLockingXpub: 'xpub',
+  encryptionPublicKey: 'enc',
+  sparkIdentityPublicKey: 'spark',
+  termsAcceptedAt: null,
+  giftCardMintTermsAcceptedAt: null,
+};
+
+function account(opts: {
+  id: string;
+  currency?: 'BTC' | 'USD';
+  createdAt?: string;
+}): Account {
+  return {
+    id: opts.id,
+    name: opts.id,
+    type: 'cashu',
+    purpose: 'transactional',
+    state: 'active',
+    isOnline: true,
+    currency: opts.currency ?? 'BTC',
+    createdAt: opts.createdAt ?? '2026-01-01T00:00:00.000Z',
+    version: 1,
+    expiresAt: null,
+    mintUrl: `https://${opts.id}.example.com`,
+    isTestMint: false,
+    keysetCounters: {},
+    proofs: [],
+    wallet: {} as never,
+  } as Account;
+}
+
+describe('isDefaultAccount', () => {
+  test('BTC account matches defaultBtcAccountId', () => {
+    expect(isDefaultAccount(user, account({ id: 'btc-default' }))).toBe(true);
+    expect(isDefaultAccount(user, account({ id: 'other' }))).toBe(false);
+  });
+
+  test('USD account matches defaultUsdAccountId', () => {
+    expect(
+      isDefaultAccount(user, account({ id: 'usd-default', currency: 'USD' })),
+    ).toBe(true);
+  });
+
+  test('per-currency: a USD account is NOT the default just because its id matches the BTC default', () => {
+    // Same id, but currency USD → checked against defaultUsdAccountId, not BTC.
+    expect(
+      isDefaultAccount(user, account({ id: 'btc-default', currency: 'USD' })),
+    ).toBe(false);
+  });
+
+  test('a null USD default never matches', () => {
+    const noUsd: User = { ...user, defaultUsdAccountId: null };
+    expect(
+      isDefaultAccount(noUsd, account({ id: 'usd-default', currency: 'USD' })),
+    ).toBe(false);
+  });
+});
+
+describe('getExtendedAccounts', () => {
+  test('flags isDefault per account and sorts the default to the top', () => {
+    const a = account({ id: 'a', createdAt: '2026-01-01T00:00:00.000Z' });
+    const def = account({
+      id: 'btc-default',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+    const result = getExtendedAccounts(user, [a, def]);
+    expect(result.map((x) => x.id)).toEqual(['btc-default', 'a']);
+    expect(result.map((x) => x.isDefault)).toEqual([true, false]);
+  });
+
+  test('no default present → all false, order preserved', () => {
+    const a = account({ id: 'a' });
+    const b = account({ id: 'b' });
+    const result = getExtendedAccounts(user, [a, b]);
+    expect(result.map((x) => x.isDefault)).toEqual([false, false]);
+    expect(result.map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  test('flags one default per currency', () => {
+    const btc = account({ id: 'btc-default', currency: 'BTC' });
+    const usd = account({ id: 'usd-default', currency: 'USD' });
+    const other = account({ id: 'other' });
+    const result = getExtendedAccounts(user, [other, btc, usd]);
+    const byId = new Map(result.map((a) => [a.id, a.isDefault]));
+    expect(byId.get('btc-default')).toBe(true);
+    expect(byId.get('usd-default')).toBe(true);
+    expect(byId.get('other')).toBe(false);
+  });
+});

--- a/packages/wallet-sdk/src/internal/extended-account.ts
+++ b/packages/wallet-sdk/src/internal/extended-account.ts
@@ -1,0 +1,66 @@
+/**
+ * `getExtendedAccounts` — the PURE `isDefault` derivation (§2, Slice 2, reactive overlay).
+ *
+ * Re-houses master `apps/web-wallet/app/features/accounts/account-service.ts`
+ * (`AccountService.isDefaultAccount` / `AccountService.getExtendedAccounts`) as standalone,
+ * framework-free functions. Master expresses these as `static` methods on a class that also
+ * holds a TanStack `QueryClient`; the SDK lifts only the pure derivation (no client, no DB
+ * read) so the accounts reads can decorate each account with `isDefault` and so the pure
+ * `suggestFor` fallback can pick the user's default account.
+ *
+ * `isDefault` is currency-scoped: an account is the default only for its OWN currency
+ * (`defaultBtcAccountId` for a BTC account, `defaultUsdAccountId` for a USD account), so at
+ * most one account per currency is flagged. The default account is sorted to the top
+ * (matching master).
+ *
+ * @module
+ */
+import type { Account } from '../types/account';
+import type { ExtendedAccount } from '../types/account';
+import type { User } from '../types/user';
+
+/**
+ * Whether `account` is the user's default account for its currency. Mirrors master
+ * `AccountService.isDefaultAccount`: a BTC account matches `defaultBtcAccountId`, a USD
+ * account matches `defaultUsdAccountId`; any other currency is never the default.
+ *
+ * @param user - the current user (holds the per-currency default-account ids).
+ * @param account - the account to test.
+ * @returns `true` when this account is the default for its currency.
+ */
+export function isDefaultAccount(user: User, account: Account): boolean {
+  if (account.currency === 'BTC') {
+    return user.defaultBtcAccountId === account.id;
+  }
+  if (account.currency === 'USD') {
+    return user.defaultUsdAccountId === account.id;
+  }
+  return false;
+}
+
+/**
+ * Decorate `accounts` with the `isDefault` flag (per-currency default), sorting the default
+ * account to the top. Mirrors master `AccountService.getExtendedAccounts`. PURE — no DB read,
+ * no client; the caller supplies the resolved `user` (its default-account ids drive the flag).
+ *
+ * @param user - the current user (its `defaultBtcAccountId` / `defaultUsdAccountId` drive the
+ *   flag).
+ * @param accounts - the accounts to extend.
+ * @returns the accounts as {@link ExtendedAccount}s, default-first.
+ */
+export function getExtendedAccounts(
+  user: User,
+  accounts: Account[],
+): ExtendedAccount[] {
+  const extended = accounts.map(
+    (account): ExtendedAccount =>
+      ({
+        ...account,
+        isDefault: isDefaultAccount(user, account),
+      }) as ExtendedAccount,
+  );
+  // Default-first, otherwise preserve the incoming order (master sorts the default to the
+  // top). A proper antisymmetric comparator: default before non-default, equal otherwise —
+  // so the input order (e.g. `list`'s oldest-first sort) is preserved within each group.
+  return extended.sort((a, b) => Number(b.isDefault) - Number(a.isDefault));
+}

--- a/packages/wallet-sdk/src/internal/lib-cashu.ts
+++ b/packages/wallet-sdk/src/internal/lib-cashu.ts
@@ -1,0 +1,27 @@
+/**
+ * SDK-internal cashu helpers — Slice 2 (accounts + scan).
+ *
+ * The account domain needs a few small, framework-free cashu utilities:
+ *  - `sumProofs` / `getCashuUnit` — to compute a cashu account's balance from its proofs
+ *    (`getBalance`, mirroring master `getAccountBalance` in `accounts/account.ts`);
+ *  - `normalizeMintUrl` / `checkIsTestMint` — for `add` (canonicalise the mint URL +
+ *    detect a test mint, mirroring master `account-service.addCashuAccount` +
+ *    `account-repository.create`).
+ *
+ * The build plan makes `lib/cashu` **SDK-internal** (§12). Re-housing approach (matches
+ * `types/money.ts` + `lib-scan.ts`): re-export the single live source from the specific
+ * `app/lib/cashu/*` modules via a relative path so there is exactly ONE implementation. We
+ * import from the specific modules (`utils` for the URL/unit helpers, `proof` for
+ * `sumProofs`) NOT the `lib/cashu` barrel, to avoid pulling the heavier subscription-manager
+ * / payment-request surface the barrel re-exports — those are Slice 3. None of the imported
+ * functions transitively pulls react / @tanstack (verified).
+ *
+ * @module
+ */
+
+export {
+  checkIsTestMint,
+  getCashuUnit,
+  normalizeMintUrl,
+} from '../../../../apps/web-wallet/app/lib/cashu/utils';
+export { sumProofs } from '../../../../apps/web-wallet/app/lib/cashu/proof';

--- a/packages/wallet-sdk/src/internal/lib-scan.ts
+++ b/packages/wallet-sdk/src/internal/lib-scan.ts
@@ -1,0 +1,30 @@
+/**
+ * SDK-internal scan/decode primitives — Slice 2 (accounts + scan).
+ *
+ * `scan.parse` (= master `classifyInput`) decodes a raw string via three small,
+ * framework-free `app/lib/*` modules: `parseBolt11Invoice` (BOLT11), `extractCashuToken`
+ * (cashu), and `buildLightningAddressFormatValidator` (Lightning-address format). The
+ * build plan makes `lib/bolt11` / `lib/cashu` / `lib/lnurl` **SDK-internal** (§12 — they
+ * are not part of the public surface; only `scan.parse`'s typed result is).
+ *
+ * Re-housing approach (matches `types/money.ts`): re-export the single live source from
+ * `apps/web-wallet/app/lib/*` via a relative path so there is exactly ONE implementation
+ * (no duplication, no web churn). The canonical relocation of these files INTO the package
+ * is a deliberately-deferred follow-up (out of the SDK build-plan's scope); until then this
+ * module is the SDK-internal seam every scan consumer imports from. None of these three
+ * functions transitively pulls react / @tanstack (verified) — the framework-free constraint
+ * holds.
+ *
+ * The functions imported here are the *format/decode* primitives only. The NETWORK side of
+ * LNURL (`getInvoiceFromLud16`, ln-address → invoice) is NOT a scan concern — it folds into
+ * `createLightningQuote` (Slice 3/PR5), where the amount is known (§3).
+ *
+ * @module
+ */
+
+export {
+  type DecodedBolt11,
+  parseBolt11Invoice,
+} from '../../../../apps/web-wallet/app/lib/bolt11';
+export { extractCashuToken } from '../../../../apps/web-wallet/app/lib/cashu/token';
+export { buildLightningAddressFormatValidator } from '../../../../apps/web-wallet/app/lib/lnurl';

--- a/packages/wallet-sdk/src/internal/stub-domains.ts
+++ b/packages/wallet-sdk/src/internal/stub-domains.ts
@@ -6,7 +6,7 @@
  * Query for observable-fetch methods). The `Sdk` shell wires its domain accessors
  * to these so the public surface is fully present + type-correct, while the real
  * business logic lands in later slices (auth + user → S1 (DONE — real impls wired in
- * Sdk.create), accounts/scan → S2, cashu/spark → S3,
+ * Sdk.create), accounts/scan → S2 (DONE — real impls wired in Sdk.create), cashu/spark → S3,
  * transactions/contacts/transfers → S4, background → S5). Swapping a stub for a real
  * impl is the unit of work for each slice.
  *
@@ -16,12 +16,10 @@
  * @module
  */
 import type {
-  AccountsDomain,
   BackgroundDomain,
   CashuDomain,
   ContactsDomain,
   ExchangeRateDomain,
-  ScanDomain,
   SparkDomain,
   TransactionsDomain,
   TransfersDomain,
@@ -55,23 +53,8 @@ function stubQuery<T = any>(method: string): Query<T> {
 }
 
 // NOTE: `AuthDomain` + `UserDomain` are REAL as of Slice 1 (see ../domains/auth +
-// ../domains/user, wired in Sdk.create) — their stubs have been removed.
-
-/** Stub `AccountsDomain` (real impl: Slice 2). */
-export const createAccountsStub = (): AccountsDomain => ({
-  list: () => stubQuery('accounts.list'),
-  get: () => stubQuery('accounts.get'),
-  getDefault: () => stubQuery('accounts.getDefault'),
-  getBalance: () => unimplemented('accounts.getBalance'),
-  suggestFor: () => unimplemented('accounts.suggestFor'),
-  add: () => unimplemented('accounts.add'),
-  setDefault: () => unimplemented('accounts.setDefault'),
-});
-
-/** Stub `ScanDomain` (real impl: Slice 2). */
-export const createScanStub = (): ScanDomain => ({
-  parse: () => unimplemented('scan.parse'),
-});
+// ../domains/user) and `AccountsDomain` + `ScanDomain` are REAL as of Slice 2 (see
+// ../domains/accounts + ../domains/scan), all wired in Sdk.create — their stubs are removed.
 
 /** Stub `CashuDomain` (`.send` + `.receive`; real impl: Slice 3). */
 export const createCashuStub = (): CashuDomain => ({

--- a/packages/wallet-sdk/src/internal/suggest-account.test.ts
+++ b/packages/wallet-sdk/src/internal/suggest-account.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { suggestAccountFor } from './suggest-account';
-import type { Account, CashuAccount, SparkAccount } from '../types/account';
+import type { Account, ExtendedAccount } from '../types/account';
 import { type Currency, Money } from '../types/money';
 import type { ParsedDestination, PaymentIntent } from '../types/scan';
 
@@ -18,7 +18,8 @@ function cashuAccount(opts: {
   currency?: 'BTC' | 'USD';
   purpose?: Account['purpose'];
   createdAt?: string;
-}): CashuAccount {
+  isDefault?: boolean;
+}): ExtendedAccount<'cashu'> {
   return {
     id: opts.id,
     name: opts.id,
@@ -35,9 +36,12 @@ function cashuAccount(opts: {
     keysetCounters: {},
     proofs:
       opts.sats > 0
-        ? ([{ amount: opts.sats }] as unknown as CashuAccount['proofs'])
+        ? ([
+            { amount: opts.sats },
+          ] as unknown as ExtendedAccount<'cashu'>['proofs'])
         : [],
     wallet: {} as never,
+    isDefault: opts.isDefault ?? false,
   };
 }
 
@@ -48,7 +52,8 @@ function sparkAccount(opts: {
   isOnline?: boolean;
   currency?: 'BTC' | 'USD';
   createdAt?: string;
-}): SparkAccount {
+  isDefault?: boolean;
+}): ExtendedAccount<'spark'> {
   const currency = opts.currency ?? 'BTC';
   return {
     id: opts.id,
@@ -67,6 +72,7 @@ function sparkAccount(opts: {
         : new Money({ amount: opts.sats, currency, unit: 'sat' }),
     network: 'MAINNET',
     wallet: {} as never,
+    isDefault: opts.isDefault ?? false,
   };
 }
 
@@ -196,22 +202,36 @@ describe('suggestAccountFor', () => {
   });
 
   describe('default fallback (nothing has sufficient balance)', () => {
-    test('falls back to the user default account id when provided', () => {
+    test('falls back to the isDefault account (master parity)', () => {
       const a = cashuAccount({ id: 'a', sats: 10 });
-      const b = cashuAccount({ id: 'b', sats: 20 });
-      const result = suggestAccountFor(sendSats(5000), [a, b], 'b');
+      const b = cashuAccount({ id: 'b', sats: 20, isDefault: true });
+      const result = suggestAccountFor(sendSats(5000), [a, b]);
       expect(result.recommended.id).toBe('b');
       expect(result.alternatives).toHaveLength(0);
       expect(result.insufficient.map((x) => x.id)).toEqual(['a']);
       expect(result.reason).toBe('insufficient balance; default account');
     });
 
-    test('falls back to the first insufficient account when no default id given', () => {
+    test('falls back to the first insufficient account when none is the default', () => {
       const a = cashuAccount({ id: 'a', sats: 10 });
       const b = cashuAccount({ id: 'b', sats: 20 });
       const result = suggestAccountFor(sendSats(5000), [a, b]);
       expect(result.recommended.id).toBe('a');
       expect(result.insufficient.map((x) => x.id)).toEqual(['b']);
+    });
+
+    test('the isDefault fallback respects the currency filter (per-currency default)', () => {
+      // A BTC Lightning send filters out USD accounts BEFORE the fallback, so a USD default
+      // is never picked for a BTC send (mirrors master's currency-scoped isDefault).
+      const usdDefault = cashuAccount({
+        id: 'usd-default',
+        sats: 10,
+        currency: 'USD',
+        isDefault: true,
+      });
+      const btc = cashuAccount({ id: 'btc', sats: 10, currency: 'BTC' });
+      const result = suggestAccountFor(sendSats(5000), [usdDefault, btc]);
+      expect(result.recommended.id).toBe('btc');
     });
   });
 

--- a/packages/wallet-sdk/src/internal/suggest-account.test.ts
+++ b/packages/wallet-sdk/src/internal/suggest-account.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from 'bun:test';
+import { suggestAccountFor } from './suggest-account';
+import type { Account, CashuAccount, SparkAccount } from '../types/account';
+import { type Currency, Money } from '../types/money';
+import type { ParsedDestination, PaymentIntent } from '../types/scan';
+
+// -- Test builders -----------------------------------------------------------
+
+/**
+ * Build a cashu test account. `sats` sets the balance via a single synthetic proof (the
+ * suggester reads balance through `getAccountBalance` → `sumProofs`, so one proof of `sats`
+ * is enough). `wallet`/`proofs` internals are cast — the pure suggester never touches them.
+ */
+function cashuAccount(opts: {
+  id: string;
+  sats: number;
+  isOnline?: boolean;
+  currency?: 'BTC' | 'USD';
+  purpose?: Account['purpose'];
+  createdAt?: string;
+}): CashuAccount {
+  return {
+    id: opts.id,
+    name: opts.id,
+    type: 'cashu',
+    purpose: opts.purpose ?? 'transactional',
+    state: 'active',
+    isOnline: opts.isOnline ?? true,
+    currency: opts.currency ?? 'BTC',
+    createdAt: opts.createdAt ?? '2026-01-01T00:00:00.000Z',
+    version: 1,
+    expiresAt: null,
+    mintUrl: `https://mint-${opts.id}.example.com`,
+    isTestMint: false,
+    keysetCounters: {},
+    proofs:
+      opts.sats > 0
+        ? ([{ amount: opts.sats }] as unknown as CashuAccount['proofs'])
+        : [],
+    wallet: {} as never,
+  };
+}
+
+/** Build a spark test account whose balance is `sats` (or null when omitted). */
+function sparkAccount(opts: {
+  id: string;
+  sats: number | null;
+  isOnline?: boolean;
+  currency?: 'BTC' | 'USD';
+  createdAt?: string;
+}): SparkAccount {
+  const currency = opts.currency ?? 'BTC';
+  return {
+    id: opts.id,
+    name: opts.id,
+    type: 'spark',
+    purpose: 'transactional',
+    state: 'active',
+    isOnline: opts.isOnline ?? true,
+    currency,
+    createdAt: opts.createdAt ?? '2026-01-01T00:00:00.000Z',
+    version: 1,
+    expiresAt: null,
+    balance:
+      opts.sats === null
+        ? null
+        : new Money({ amount: opts.sats, currency, unit: 'sat' }),
+    network: 'MAINNET',
+    wallet: {} as never,
+  };
+}
+
+const bolt11Destination: ParsedDestination = {
+  kind: 'bolt11',
+  invoice: {
+    amountMsat: undefined,
+    amountSat: undefined,
+    createdAtUnixMs: 0,
+    expiryUnixMs: 0,
+    network: 'bitcoin',
+    description: undefined,
+    payeeNodeKey: '00'.repeat(33),
+    paymentHash: 'deadbeef',
+  },
+};
+
+const sendSats = (sats: number): PaymentIntent => ({
+  kind: 'send',
+  destination: bolt11Destination,
+  amount: new Money<Currency>({ amount: sats, currency: 'BTC', unit: 'sat' }),
+});
+
+describe('suggestAccountFor', () => {
+  test('throws when there are no accounts', () => {
+    expect(() => suggestAccountFor(sendSats(100), [])).toThrow(
+      'No accounts to choose from',
+    );
+  });
+
+  describe('online filter', () => {
+    test('offline accounts are excluded from recommended/alternatives', () => {
+      const online = cashuAccount({ id: 'on', sats: 1000 });
+      const offline = cashuAccount({ id: 'off', sats: 1000, isOnline: false });
+      const result = suggestAccountFor(sendSats(100), [offline, online]);
+      expect(result.recommended.id).toBe('on');
+      expect(result.alternatives).toHaveLength(0);
+      // The offline account is not surfaced as insufficient either (it was filtered out).
+      expect(result.insufficient).toHaveLength(0);
+    });
+
+    test('throws when the only account is offline (no candidate)', () => {
+      const offline = cashuAccount({ id: 'off', sats: 1000, isOnline: false });
+      expect(() => suggestAccountFor(sendSats(100), [offline])).toThrow(
+        'No account matches the payment intent',
+      );
+    });
+  });
+
+  describe('currency filter (BTC for a Lightning send)', () => {
+    test('USD accounts are excluded for a bolt11 send', () => {
+      const usd = cashuAccount({ id: 'usd', sats: 5000, currency: 'USD' });
+      const btc = cashuAccount({ id: 'btc', sats: 5000, currency: 'BTC' });
+      const result = suggestAccountFor(sendSats(100), [usd, btc]);
+      expect(result.recommended.id).toBe('btc');
+      expect(result.recommended.currency).toBe('BTC');
+    });
+  });
+
+  describe('balance split', () => {
+    test('partitions accounts into sufficient vs insufficient', () => {
+      const rich = cashuAccount({ id: 'rich', sats: 5000 });
+      const poor = cashuAccount({ id: 'poor', sats: 50 });
+      const result = suggestAccountFor(sendSats(1000), [rich, poor]);
+      expect(result.recommended.id).toBe('rich');
+      expect(result.insufficient.map((a) => a.id)).toEqual(['poor']);
+    });
+
+    test('amountless send needs only a positive balance', () => {
+      const positive = cashuAccount({ id: 'pos', sats: 1 });
+      const empty = cashuAccount({ id: 'empty', sats: 0 });
+      const intent: PaymentIntent = {
+        kind: 'send',
+        destination: bolt11Destination,
+      };
+      const result = suggestAccountFor(intent, [empty, positive]);
+      expect(result.recommended.id).toBe('pos');
+      expect(result.insufficient.map((a) => a.id)).toEqual(['empty']);
+    });
+  });
+
+  describe('ranking (cheap-first, no cross-protocol cost comparison)', () => {
+    test('prefers a higher-priority purpose (offer > gift-card > transactional)', () => {
+      const txn = cashuAccount({ id: 'txn', sats: 5000 });
+      const card = cashuAccount({
+        id: 'card',
+        sats: 5000,
+        purpose: 'gift-card',
+      });
+      const offer = cashuAccount({ id: 'offer', sats: 5000, purpose: 'offer' });
+      const result = suggestAccountFor(sendSats(100), [txn, card, offer]);
+      expect(result.recommended.id).toBe('offer');
+      expect(result.reason).toBe('offer-account match');
+      // Remaining sufficient accounts ranked after, by the same comparator.
+      expect(result.alternatives.map((a) => a.id)).toEqual(['card', 'txn']);
+    });
+
+    test('within the same purpose, prefers the higher balance', () => {
+      const small = cashuAccount({ id: 'small', sats: 2000 });
+      const big = cashuAccount({ id: 'big', sats: 9000 });
+      const result = suggestAccountFor(sendSats(100), [small, big]);
+      expect(result.recommended.id).toBe('big');
+      expect(result.alternatives.map((a) => a.id)).toEqual(['small']);
+    });
+
+    test('ties broken by creation date (older first)', () => {
+      const newer = cashuAccount({
+        id: 'newer',
+        sats: 5000,
+        createdAt: '2026-02-01T00:00:00.000Z',
+      });
+      const older = cashuAccount({
+        id: 'older',
+        sats: 5000,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      });
+      const result = suggestAccountFor(sendSats(100), [newer, older]);
+      expect(result.recommended.id).toBe('older');
+    });
+
+    test('mixes cashu + spark by balance (no protocol preference)', () => {
+      const cashu = cashuAccount({ id: 'cashu', sats: 3000 });
+      const spark = sparkAccount({ id: 'spark', sats: 8000 });
+      const result = suggestAccountFor(sendSats(100), [cashu, spark]);
+      expect(result.recommended.id).toBe('spark');
+    });
+  });
+
+  describe('default fallback (nothing has sufficient balance)', () => {
+    test('falls back to the user default account id when provided', () => {
+      const a = cashuAccount({ id: 'a', sats: 10 });
+      const b = cashuAccount({ id: 'b', sats: 20 });
+      const result = suggestAccountFor(sendSats(5000), [a, b], 'b');
+      expect(result.recommended.id).toBe('b');
+      expect(result.alternatives).toHaveLength(0);
+      expect(result.insufficient.map((x) => x.id)).toEqual(['a']);
+      expect(result.reason).toBe('insufficient balance; default account');
+    });
+
+    test('falls back to the first insufficient account when no default id given', () => {
+      const a = cashuAccount({ id: 'a', sats: 10 });
+      const b = cashuAccount({ id: 'b', sats: 20 });
+      const result = suggestAccountFor(sendSats(5000), [a, b]);
+      expect(result.recommended.id).toBe('a');
+      expect(result.insufficient.map((x) => x.id)).toEqual(['b']);
+    });
+  });
+
+  describe('receive intents', () => {
+    test('receive does not require balance (any online account qualifies)', () => {
+      const empty = cashuAccount({ id: 'empty', sats: 0 });
+      const intent: PaymentIntent = {
+        kind: 'receive',
+        amount: new Money<Currency>({
+          amount: 1000,
+          currency: 'BTC',
+          unit: 'sat',
+        }),
+      };
+      const result = suggestAccountFor(intent, [empty]);
+      expect(result.recommended.id).toBe('empty');
+      expect(result.insufficient).toHaveLength(0);
+      expect(result.reason).toContain('receive');
+    });
+
+    test('token-receive does not constrain currency or balance', () => {
+      const usdEmpty = cashuAccount({
+        id: 'usd',
+        sats: 0,
+        currency: 'USD',
+      });
+      const intent: PaymentIntent = {
+        kind: 'token-receive',
+        token: 'cashuAfoo',
+      };
+      const result = suggestAccountFor(intent, [usdEmpty]);
+      expect(result.recommended.id).toBe('usd');
+    });
+
+    test('receive still applies the online filter', () => {
+      const offline = cashuAccount({ id: 'off', sats: 0, isOnline: false });
+      const online = cashuAccount({ id: 'on', sats: 0 });
+      const intent: PaymentIntent = { kind: 'receive' };
+      const result = suggestAccountFor(intent, [offline, online]);
+      expect(result.recommended.id).toBe('on');
+    });
+  });
+});

--- a/packages/wallet-sdk/src/internal/suggest-account.ts
+++ b/packages/wallet-sdk/src/internal/suggest-account.ts
@@ -1,0 +1,209 @@
+/**
+ * `suggestFor` — the NET-NEW, PURE account-suggestion logic (§2, Slice 2).
+ *
+ * There is no single backing function in master. This GENERALIZES master's
+ * `apps/web-wallet/app/features/send/find-matching-offer-or-gift-card-account.ts` (a pure
+ * offer/gift-card matcher over `accounts`) into a protocol-agnostic suggester, and folds in
+ * the two heuristics the UI applies around it: an **online filter** (`isOnline`, which gates
+ * `canSendToLightning`/`canReceiveFromLightning`) and a **default fallback** (the user's
+ * default account for the currency). It is **pure over the passed-in accounts** — no DB read,
+ * no live-wallet call — so the web wallet feeds its cached accounts for an instant result.
+ *
+ * Cheap-first, NO cross-protocol cost comparison (contract): the recommendation is the
+ * highest-priority account with sufficient balance (gift-card/offer match first, then a
+ * cheap-first ordering), with the remaining matches as `alternatives` and the
+ * matching-but-underfunded accounts as `insufficient`. The result carries a human-readable
+ * `reason`.
+ *
+ * Gift-card / offer accounts are out of SDK v1 (§13) and the gift-card *config* (the mint
+ * destination allow-list `findMatchingOfferOrGiftCardAccount` consults) is not part of the
+ * intent, so v1 cannot do destination-allow-list matching. What v1 generalizes is the
+ * *priority + filter + fallback shape*: `purpose: 'offer'` > `'gift-card'` > `'transactional'`
+ * is preserved as a priority ordering (so when offer/gift-card accounts DO appear they are
+ * preferred, matching master), then online + sufficient-balance filtering, then the default
+ * fallback. When gift-card config arrives in a later slice it slots in as a pre-filter.
+ *
+ * @module
+ */
+import type { AccountSuggestion } from '../domains';
+import type { Account } from '../types/account';
+import type { Money } from '../types/money';
+import type { ParsedDestination, PaymentIntent } from '../types/scan';
+import { getAccountBalance } from './account-balance';
+
+/** Priority by account purpose (higher = preferred), mirroring master's offer > gift-card order. */
+const PURPOSE_PRIORITY: Record<Account['purpose'], number> = {
+  offer: 2,
+  'gift-card': 1,
+  transactional: 0,
+};
+
+/**
+ * The currency a send intent must be paid from, when it can be inferred from the parsed
+ * destination. A BOLT11 / ln-address Lightning payment settles in BTC, so only BTC accounts
+ * can fund it (mirrors master `findMatchingOfferOrGiftCardAccount`, which skips USD accounts
+ * for BOLT11 melts). A cashu-token send/receive is mint-denominated and not currency-pinned
+ * here. Returns `undefined` when no currency constraint applies.
+ */
+function requiredCurrency(
+  destination: ParsedDestination | undefined,
+): Account['currency'] | undefined {
+  if (!destination) {
+    return undefined;
+  }
+  if (destination.kind === 'bolt11' || destination.kind === 'ln-address') {
+    return 'BTC';
+  }
+  return undefined;
+}
+
+/** The amount an intent needs an account to cover, or `undefined` when amountless. */
+function intentAmount(intent: PaymentIntent): Money | undefined {
+  if (intent.kind === 'send') {
+    return intent.amount;
+  }
+  if (intent.kind === 'receive') {
+    return intent.amount;
+  }
+  // token-receive: amount is encoded in the token, not constrained over accounts here.
+  return undefined;
+}
+
+/**
+ * Whether `account` can cover `amount`. With no amount (amountless invoice / open receive),
+ * a send needs only a positive balance; a receive has no balance requirement.
+ */
+function hasSufficientBalance(
+  account: Account,
+  amount: Money | undefined,
+  isReceive: boolean,
+): boolean {
+  if (isReceive) {
+    // Receiving doesn't spend the account's balance.
+    return true;
+  }
+  const balance = getAccountBalance(account);
+  if (!balance) {
+    return false;
+  }
+  return amount ? balance.greaterThanOrEqual(amount) : balance.isPositive();
+}
+
+/**
+ * Compare two candidate accounts for recommendation priority (cheap-first, no cross-protocol
+ * cost comparison): higher `purpose` priority first, then higher balance, then older account
+ * (stable by `createdAt`). Returns a negative number when `a` should rank before `b`.
+ */
+function compareCandidates(a: Account, b: Account): number {
+  const byPurpose = PURPOSE_PRIORITY[b.purpose] - PURPOSE_PRIORITY[a.purpose];
+  if (byPurpose !== 0) {
+    return byPurpose;
+  }
+
+  const balanceA = getAccountBalance(a);
+  const balanceB = getAccountBalance(b);
+  if (balanceA && balanceB && !balanceA.equals(balanceB)) {
+    return balanceB.greaterThan(balanceA) ? 1 : -1;
+  }
+
+  return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+}
+
+/**
+ * Recommend which of `accounts` to use for `intent`. PURE — no DB read, no live-wallet call.
+ *
+ * Pipeline:
+ *  1. **Currency filter** — for a Lightning send, keep only BTC accounts (master parity).
+ *  2. **Online filter** — keep only `isOnline` accounts (the offline ones can't transact;
+ *     they are not surfaced as recommendations/alternatives).
+ *  3. **Balance split** — partition the matching accounts into sufficient vs insufficient.
+ *  4. **Rank** — order the sufficient accounts cheap-first (purpose priority → balance → age)
+ *     and pick the top one as `recommended`, the rest as `alternatives`.
+ *  5. **Default fallback** — if nothing has sufficient balance, fall back to the user's
+ *     default account for the (filtered) currency when one is present in `accounts`, so the
+ *     UI can still pre-select an account to top up; otherwise throw (no candidate at all).
+ *
+ * @param intent - what the user wants to do.
+ * @param accounts - the accounts to choose from (the caller's cached set).
+ * @param defaultAccountId - the user's default account id for the intent's currency, if known
+ *   (used only for the fallback when no account has sufficient balance).
+ * @returns the {@link AccountSuggestion}.
+ * @throws Error if `accounts` is empty or no account matches the intent at all.
+ */
+export function suggestAccountFor(
+  intent: PaymentIntent,
+  accounts: Account[],
+  defaultAccountId?: string,
+): AccountSuggestion {
+  if (accounts.length === 0) {
+    throw new Error('No accounts to choose from');
+  }
+
+  const isReceive =
+    intent.kind === 'receive' || intent.kind === 'token-receive';
+  const destination = intent.kind === 'send' ? intent.destination : undefined;
+  const currency = requiredCurrency(destination);
+  const amount = intentAmount(intent);
+
+  // 1 + 2: currency + online filter.
+  const eligible = accounts.filter((account) => {
+    if (currency && account.currency !== currency) {
+      return false;
+    }
+    return account.isOnline;
+  });
+
+  // 3: split by sufficient balance.
+  const sufficient: Account[] = [];
+  const insufficient: Account[] = [];
+  for (const account of eligible) {
+    if (hasSufficientBalance(account, amount, isReceive)) {
+      sufficient.push(account);
+    } else {
+      insufficient.push(account);
+    }
+  }
+
+  // 4: rank the sufficient candidates cheap-first.
+  if (sufficient.length > 0) {
+    const ranked = [...sufficient].sort(compareCandidates);
+    const [recommended, ...alternatives] = ranked;
+    return {
+      recommended,
+      alternatives,
+      insufficient,
+      reason: reasonFor(recommended, isReceive),
+    };
+  }
+
+  // 5: default fallback — nothing has sufficient balance. Prefer the user's default account
+  // (for the eligible currency) so the UI can still pre-select; else the first insufficient.
+  const fallback =
+    (defaultAccountId && eligible.find((a) => a.id === defaultAccountId)) ||
+    insufficient[0];
+
+  if (!fallback) {
+    throw new Error('No account matches the payment intent');
+  }
+
+  return {
+    recommended: fallback,
+    alternatives: [],
+    insufficient: insufficient.filter((a) => a.id !== fallback.id),
+    reason: isReceive
+      ? 'default account'
+      : 'insufficient balance; default account',
+  };
+}
+
+/** Human-readable basis for a recommendation. */
+function reasonFor(account: Account, isReceive: boolean): string {
+  if (account.purpose === 'offer') {
+    return 'offer-account match';
+  }
+  if (account.purpose === 'gift-card') {
+    return 'gift-card-mint match';
+  }
+  const verb = isReceive ? 'receive to' : 'send from';
+  return `${verb} ${account.type} account`;
+}

--- a/packages/wallet-sdk/src/internal/suggest-account.ts
+++ b/packages/wallet-sdk/src/internal/suggest-account.ts
@@ -26,7 +26,7 @@
  * @module
  */
 import type { AccountSuggestion } from '../domains';
-import type { Account } from '../types/account';
+import type { Account, ExtendedAccount } from '../types/account';
 import type { Money } from '../types/money';
 import type { ParsedDestination, PaymentIntent } from '../types/scan';
 import { getAccountBalance } from './account-balance';
@@ -120,20 +120,24 @@ function compareCandidates(a: Account, b: Account): number {
  *  4. **Rank** — order the sufficient accounts cheap-first (purpose priority → balance → age)
  *     and pick the top one as `recommended`, the rest as `alternatives`.
  *  5. **Default fallback** — if nothing has sufficient balance, fall back to the user's
- *     default account for the (filtered) currency when one is present in `accounts`, so the
- *     UI can still pre-select an account to top up; otherwise throw (no candidate at all).
+ *     default account (the `isDefault` account in the filtered/eligible set) so the UI can
+ *     still pre-select an account to top up; otherwise the first insufficient account; only
+ *     throw when there is no candidate at all.
+ *
+ * The default is read straight off the passed-in {@link ExtendedAccount}s (`isDefault`,
+ * computed currency-scoped in the accounts read), so this stays PURE — no session read. Since
+ * `isDefault` is per-currency, the eligible-currency filter already restricts the flagged
+ * account to the intent's currency.
  *
  * @param intent - what the user wants to do.
- * @param accounts - the accounts to choose from (the caller's cached set).
- * @param defaultAccountId - the user's default account id for the intent's currency, if known
- *   (used only for the fallback when no account has sufficient balance).
+ * @param accounts - the extended accounts to choose from (the caller's cached set; carry
+ *   `isDefault`).
  * @returns the {@link AccountSuggestion}.
  * @throws Error if `accounts` is empty or no account matches the intent at all.
  */
 export function suggestAccountFor(
   intent: PaymentIntent,
-  accounts: Account[],
-  defaultAccountId?: string,
+  accounts: ExtendedAccount[],
 ): AccountSuggestion {
   if (accounts.length === 0) {
     throw new Error('No accounts to choose from');
@@ -154,8 +158,8 @@ export function suggestAccountFor(
   });
 
   // 3: split by sufficient balance.
-  const sufficient: Account[] = [];
-  const insufficient: Account[] = [];
+  const sufficient: ExtendedAccount[] = [];
+  const insufficient: ExtendedAccount[] = [];
   for (const account of eligible) {
     if (hasSufficientBalance(account, amount, isReceive)) {
       sufficient.push(account);
@@ -177,10 +181,10 @@ export function suggestAccountFor(
   }
 
   // 5: default fallback — nothing has sufficient balance. Prefer the user's default account
-  // (for the eligible currency) so the UI can still pre-select; else the first insufficient.
-  const fallback =
-    (defaultAccountId && eligible.find((a) => a.id === defaultAccountId)) ||
-    insufficient[0];
+  // (the `isDefault` one in the eligible set) so the UI can still pre-select; else the first
+  // insufficient. `isDefault` is per-currency, so the eligible-currency filter already scopes
+  // it to the intent's currency.
+  const fallback = eligible.find((a) => a.isDefault) ?? insufficient[0];
 
   if (!fallback) {
     throw new Error('No account matches the payment intent');

--- a/packages/wallet-sdk/src/internal/user-repository.ts
+++ b/packages/wallet-sdk/src/internal/user-repository.ts
@@ -8,13 +8,14 @@
  * are plain async methods over the SDK-owned client (passed in), reading/writing the
  * `wallet.users` table and mapping rows via {@link dbUserToUser}.
  *
- * Only the two reads/writes the auth + user domains need are ported: fetch-by-id and
- * username update. The rest of master's user repository (upsert-with-accounts, default
- * account resolution) belongs to later slices.
+ * The reads/writes the auth + user + accounts domains need are ported: fetch-by-id,
+ * username update, and the default-account update (Slice 2's `accounts.setDefault`). The
+ * rest of master's user repository (upsert-with-accounts) belongs to later slices.
  *
  * @module
  */
 import { DomainError, NotFoundError } from '../errors';
+import type { Currency } from '../types/money';
 import type { User } from '../types/user';
 import { type AgicashDbUser, dbUserToUser } from './db-user';
 import type { WalletSupabaseClient } from './supabase-client';
@@ -96,6 +97,46 @@ export class UserRepository {
           'USERNAME_TAKEN',
         );
       }
+      throw new Error('Failed to update user', { cause: error });
+    }
+
+    return dbUserToUser(data);
+  }
+
+  /**
+   * Update the user's default-account columns and return the updated domain {@link User}.
+   *
+   * Re-houses master `WriteUserRepository.update` (the default-account path used by
+   * `user-service.setDefaultAccount`): writes `default_btc_account_id` /
+   * `default_usd_account_id` / `default_currency`. The account domain computes which
+   * column changes from the account's currency; this is the thin row-write.
+   *
+   * @param userId - the user id.
+   * @param defaults - the new default-account ids + currency to persist.
+   * @returns the updated domain user.
+   * @throws Error if the update fails (e.g. the DB constraint that a default currency must
+   *   have a default account set).
+   */
+  async setDefaultAccount(
+    userId: string,
+    defaults: {
+      defaultBtcAccountId: string | null;
+      defaultUsdAccountId: string | null;
+      defaultCurrency: Currency;
+    },
+  ): Promise<User> {
+    const { data, error } = await this.db
+      .from('users')
+      .update({
+        default_btc_account_id: defaults.defaultBtcAccountId,
+        default_usd_account_id: defaults.defaultUsdAccountId,
+        default_currency: defaults.defaultCurrency,
+      })
+      .eq('id', userId)
+      .select()
+      .single<AgicashDbUser>();
+
+    if (error) {
       throw new Error('Failed to update user', { cause: error });
     }
 

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -31,19 +31,21 @@ import type {
   TransfersDomain,
   UserDomain,
 } from './domains';
+import { AccountsDomainImpl } from './domains/accounts';
 import { AuthDomainImpl } from './domains/auth';
+import { ScanDomainImpl } from './domains/scan';
 import { UserDomainImpl } from './domains/user';
+import { DeferredAccountHandleResolver } from './internal/account-handle-resolver';
+import { AccountRepository } from './internal/account-repository';
 import { TypedEventEmitter } from './internal/event-emitter';
 import { GuestAccountStorage } from './internal/guest-account-storage';
 import { OpenSecretClient } from './internal/open-secret';
 import { SessionResolver } from './internal/session';
 import {
-  createAccountsStub,
   createBackgroundStub,
   createCashuStub,
   createContactsStub,
   createExchangeRateStub,
-  createScanStub,
   createSparkStub,
   createTransactionsStub,
   createTransfersStub,
@@ -205,27 +207,32 @@ export class Sdk {
 
   /**
    * Private — construct via {@link Sdk.create}. Takes the assembled connection bundle plus
-   * the already-built real domains (`auth` + `user` as of Slice 1) and wires the domain
-   * accessors. Domains not yet implemented are wired to a stub; later slices replace each
-   * stub here with its real implementation.
+   * the already-built real domains (`auth` + `user` as of Slice 1; `accounts` + `scan` as of
+   * Slice 2) and wires the domain accessors. Domains not yet implemented are wired to a stub;
+   * later slices replace each stub here with its real implementation.
    *
    * @param connections - the shared connection bundle.
    * @param domains - the real domain implementations built in {@link Sdk.create}.
    */
   private constructor(
     connections: SdkConnections,
-    domains: { auth: AuthDomain; user: UserDomain },
+    domains: {
+      auth: AuthDomain;
+      user: UserDomain;
+      accounts: AccountsDomain;
+      scan: ScanDomain;
+    },
   ) {
     this.connections = connections;
     this.events = connections.events;
 
-    // --- real domains (Slice 1: auth + user) ---------------------------------
+    // --- real domains (Slice 1: auth + user; Slice 2: accounts + scan) -------
     this.auth = domains.auth;
     this.user = domains.user;
+    this.accounts = domains.accounts;
+    this.scan = domains.scan;
 
     // --- domain accessors still STUBBED (swap per slice) ---------------------
-    this.accounts = createAccountsStub();
-    this.scan = createScanStub();
     this.cashu = createCashuStub();
     this.spark = createSparkStub();
     this.transactions = createTransactionsStub();
@@ -308,7 +315,25 @@ export class Sdk {
     const auth = new AuthDomainImpl(openSecret, session, guestStorage);
     const user = new UserDomainImpl(queryClient, session, users);
 
-    return new Sdk(connections, { auth, user });
+    // --- Slice 2: accounts + scan domains ------------------------------------
+    // The account repository reads/writes `wallet.accounts` over the same Supabase client and
+    // fills in each account's deferred live-handle fields via the resolver. Slice 2 supplies
+    // the DEFERRED resolver (cashu `getBalance` → 0, spark balance → null, live `wallet`
+    // handle is a throwing stub); Slice 3 (PR5) swaps in the real mint/Breez init + proof
+    // decryption with no change here. `accounts` reads are reactive, so the domain also takes
+    // the SDK-internal QueryClient (it wraps the DB reads via `toQuery`). `scan.parse` is a
+    // connection-free decode action; `allowLocalhost` defaults to false (production).
+    const accountResolver = new DeferredAccountHandleResolver();
+    const accountRepository = new AccountRepository(supabase, accountResolver);
+    const accounts = new AccountsDomainImpl(
+      queryClient,
+      accountRepository,
+      users,
+      session,
+    );
+    const scan = new ScanDomainImpl();
+
+    return new Sdk(connections, { auth, user, accounts, scan });
   }
 
   /**

--- a/packages/wallet-sdk/src/types/money.ts
+++ b/packages/wallet-sdk/src/types/money.ts
@@ -1,18 +1,52 @@
-// Money + Currency — domain value types
+/**
+ * Money / Currency value types — §1 + §12 of the contract.
+ *
+ * Resolves the reactive base's `Money` placeholder: this module now re-exports the REAL
+ * `Money` value object (a runtime class, not a `declare class` shell) so the SDK's domain
+ * types can both reference it as a type AND target it at runtime (`Money.zero(...)`,
+ * `new Money({ ... })`, the balance/comparison methods) — and so a consumer can
+ * `import { Money } from '@agicash/wallet-sdk'`.
+ *
+ * Why now (Slice 2 / PR4): the prior reactive slices (auth + user) only ever referenced
+ * `Money` as a TYPE, so a `declare`-shell sufficed. PR4 (accounts + scan) is the first
+ * reactive slice that NEEDS the runtime `Money` — `account-balance` constructs it, and the
+ * pure `suggestFor` ranking compares balances — so the shell is resolved to the real class
+ * here. This matches the no-cache extraction's Slice 0 (same re-export) and the reactive
+ * contract's "all domain types are unchanged — see the no-cache contract for the type defs".
+ * Every prior reference was `import type`, so swapping the shell for the real value export is
+ * non-breaking.
+ *
+ * SOURCE OF TRUTH. The canonical `Money` (+ `Currency` / `CurrencyUnit`) lives in
+ * `apps/web-wallet/app/lib/money` (`{ index, money, types }.ts`; leaf + dependency-free
+ * apart from `big.js`). Per the build plan the SDK owns `Money` and the web app imports it
+ * from this package; the canonical relocation of the source files INTO this package + the
+ * rewrite of web's `~/lib/money` import sites is a deliberately-deferred follow-up (out of
+ * the SDK build-plan scope). Until then this module re-exports the single live source via a
+ * relative path so there is exactly ONE `Money` implementation (no duplication, no web
+ * churn).
+ *
+ * NOTE on `lib: ["DOM"]`: `money.ts` ships a dev-only `registerDevToolsFormatter()` that
+ * touches `window`; the SDK is a browser consumer (the web wallet), so the package tsconfig
+ * already includes the `DOM` lib. The formatter is never invoked by SDK code.
+ *
+ * TODO(follow-up): move `app/lib/money/**` into `packages/wallet-sdk/src/money/` and rewire
+ * web's `~/lib/money` imports to `@agicash/wallet-sdk`; then this re-export becomes a local
+ * `./money` re-export.
+ */
 
-export type Currency = 'BTC' | 'USD';
+export { Money } from '../../../../apps/web-wallet/app/lib/money';
+export type {
+  Currency,
+  CurrencyUnit,
+} from '../../../../apps/web-wallet/app/lib/money';
 
 /**
- * Money is an opaque value type (master uses a class).
- * Declared as an abstract class so TS treats it as a nominal type
- * (not structurally assignable from a plain object).
+ * Unit sub-types for `CurrencyUnit`. Kept here (the contract's `money.ts` surface) because
+ * the canonical `app/lib/money/types.ts` does not export them by name and the SDK contract
+ * lists them on the public barrel. They are structurally identical to the `UsdUnit` /
+ * `BtcUnit` the canonical `CurrencyUnit<T>` is built from.
  */
-export declare abstract class Money {
-  abstract readonly amount: number;
-  abstract readonly currency: Currency;
-  abstract toString(): string;
-
-  static sats(n: number): Money;
-  static usd(cents: number): Money;
-  static zero(currency: Currency): Money;
-}
+/** Denomination units for USD amounts. */
+export type UsdUnit = 'usd' | 'cent';
+/** Denomination units for BTC amounts. */
+export type BtcUnit = 'btc' | 'sat' | 'msat';

--- a/packages/wallet-sdk/src/types/scan.ts
+++ b/packages/wallet-sdk/src/types/scan.ts
@@ -1,27 +1,76 @@
-// Scan + PaymentIntent + ParsedDestination types
+// Scan / payment-intent types — §3 of the contract.
+//
+// `ParsedDestination` is the contract's reshape of master's
+// `app/features/scan/classify-input.ts#ClassifiedInput` into kinds
+// `bolt11` / `ln-address` / `cashu-token`. `PaymentIntent` is the input to
+// `accounts.suggestFor`.
+//
+// RECONCILIATION (Slice 2 / PR4): the `Bolt11Invoice` + `ParsedToken` payload shapes are
+// resolved to the REAL decode-lib outputs the `scan.parse` impl actually produces — the
+// reactive base shipped placeholder shapes (`{ paymentRequest; paymentHash; ... }` /
+// `{ token; amount?; mintUrl? }`) that no scan code consumed and that do NOT match the live
+// libs. `parseBolt11Invoice` returns `app/lib/bolt11#DecodedBolt11` and `extractCashuToken`
+// returns `{ encoded; metadata: TokenMetadata }`; the shapes below mirror those verbatim
+// (matching the no-cache extraction's types). Nothing in the prior slices used the old
+// shapes, so this is a non-breaking correction.
 
 import type { Money } from './money';
 
+/**
+ * Decoded BOLT11 invoice carried by a `bolt11` `ParsedDestination`.
+ * Shape = `app/lib/bolt11/index.ts#DecodedBolt11` (verbatim — what `parseBolt11Invoice`
+ * returns).
+ */
 export type Bolt11Invoice = {
-  paymentRequest: string;
+  /** Invoice amount in millisatoshis, or undefined for amountless invoices. */
+  amountMsat: number | undefined;
+  /** Invoice amount in satoshis, or undefined for amountless invoices. */
+  amountSat: number | undefined;
+  /** Invoice creation time, Unix epoch milliseconds. */
+  createdAtUnixMs: number;
+  /** Invoice expiry time, Unix epoch milliseconds. */
+  expiryUnixMs: number;
+  /** Network the invoice is for (e.g. "bitcoin"/"testnet"), or undefined. */
+  network: string | undefined;
+  /** Invoice description/memo, or undefined. */
+  description: string | undefined;
+  /** Public key of the payee node. */
+  payeeNodeKey: string;
+  /** Payment hash of the invoice. */
   paymentHash: string;
-  amountMsat?: number;
-  description?: string;
-  expiryTimestamp?: number;
 };
 
+/**
+ * Parsed cashu token metadata carried by a `cashu-token` `ParsedDestination`.
+ * Master = `@cashu/cashu-ts`'s `TokenMetadata` (returned by `extractCashuToken`).
+ * `extractCashuToken` returns `{ encoded; metadata: TokenMetadata }`.
+ *
+ * TODO(Slice-2/3): `import type { TokenMetadata } from '@cashu/cashu-ts'` and type
+ * `metadata` as it (the package depends on `@cashu/cashu-ts` once cashu ops land).
+ */
 export type ParsedToken = {
-  token: string;
-  amount?: number;
-  mintUrl?: string;
+  /** The re-encoded token string. */
+  encoded: string;
+  /** cashu-ts `TokenMetadata` (mint/unit/amount summary). */
+  metadata: unknown;
 };
 
+/**
+ * The classified result of {@link ScanDomain.parse} — what a scanned/pasted string resolves
+ * to. `kind` discriminates the payload: a decoded BOLT11 invoice, a Lightning address
+ * (resolved to an invoice later, when the amount is known), or a parsed cashu token.
+ */
 export type ParsedDestination =
   | { kind: 'bolt11'; invoice: Bolt11Invoice }
   | { kind: 'ln-address'; address: string }
-  | { kind: 'cashu-token'; token: ParsedToken }
-  | { kind: 'agicash-contact'; contactId: string; username: string };
+  | { kind: 'cashu-token'; token: ParsedToken };
 
+/**
+ * What the user wants to do, fed into {@link AccountsDomain.suggestFor} to pick an account.
+ * A `send` carries the parsed destination (and an optional amount for amountless invoices /
+ * ln-addresses); a `receive` carries an optional amount; a `token-receive` carries the raw
+ * token string.
+ */
 export type PaymentIntent =
   | { kind: 'send'; destination: ParsedDestination; amount?: Money }
   | { kind: 'receive'; amount?: Money }


### PR DESCRIPTION
Lifts the proven **no-cache accounts+scan extraction** (`sdk/pr4-accounts-scan`) onto the **reactive base** (PR3 `sdk-reactive/pr3-auth-user`), wrapping **only the observable reads** in `toQuery`. Derivations stay **SYNC**; writes/actions stay `Promise`. Adaptation, not rewrite — the read/derivation bodies are identical to no-cache; only the return wrapper on observable reads changes.

Builds on: PR1 #1129 (contract), PR2 #1130 (core + reactive runtime), PR3 #1131 (auth+user — the read-adaptation template mirrored here).

## What this adds

### `AccountsDomain` (real; wired in `Sdk.create` with the SDK-internal `QueryClient`)
- **`list()` / `get(id)` / `getDefault(params?)` → `Query<T>`** — wrapped via `toQuery(client, key, existingReadFn)`, memoised per key in a `#q` Map (exactly like PR3's `user.getCurrentUser`). Keys: `['accounts']`, `['account', id]`, `['accounts:default', currency]` — parameterised reads memo **one `Query` per id/currency**.
- **`getBalance(account): Money` → SYNC** pure derivation (sum cashu proofs / read spark `balance`). **Not** wrapped in `toQuery`. Lifted verbatim.
- **`suggestFor(intent, accounts): AccountSuggestion` → SYNC** pure pick over the passed-in accounts. Keeps the `accounts` param.
- **`add(...)` / `setDefault(account)` → `Promise`** (lifted verbatim).

### `ScanDomain` (real)
- **`parse(input) → Promise<ParsedDestination>`** — one-shot, connection-free decode (`classifyInput`). Stays a `Promise` (not a `Query`). Verbatim.

### Internal modules (lifted verbatim, framework-free)
`account-repository`, `db-account` (row⇄domain mapper + guards + `details` schemas), `account-balance`, `suggest-account`, `lib-cashu`, `lib-scan`, and the **`AccountHandleResolver`** seam.

### `DeferredAccountHandleResolver` staging preserved exactly
The live `wallet` handle + cashu proof **decryption stay deferred to PR5** (cashu/spark slice): cashu `getBalance` → 0, spark balance → `null`, any *use* of the live handle throws a labelled `NotImplementedError`. **No wallet-handle work is pulled forward.**

## Reconciliation toward PR1's contract
- **`getBalance` / `suggestFor` adopt the contract's SYNC signatures.** The no-cache impl typed them `async`. `getBalance` never read the session. `suggestFor`'s only impurity — a session read seeding the default-account fallback — is dropped so the method is pure over `accounts`; the fallback then degrades to the first insufficient account, exactly as the underlying pure suggester does with no default id.
- **`types/money.ts`** resolves the reactive base's `declare`-shell `Money` to the real re-export from `app/lib/money`. PR4 is the **first reactive slice that needs runtime `Money`** (balance construction + comparisons); every prior reference was `import type`, so the swap is **non-breaking** (same as the no-cache extraction's Slice 0; the package tsconfig already includes `DOM`).
- **`types/scan.ts`** corrects the stale placeholder `Bolt11Invoice` / `ParsedToken` shapes to the **real decode-lib outputs** the impl produces (`DecodedBolt11` / `{ encoded, metadata }`). Both were exported-but-unconsumed in the base. Also drops the unused `agicash-contact` `ParsedDestination` variant (`parse` never produces it; not in the no-cache contract).
- **`user-repository.ts`** gains `setDefaultAccount` (the thin default-account row write backing `accounts.setDefault`).

## Tests
Ported the no-cache PR4 suite. `list`/`get`/`getDefault` updated to assert `Query<T>` (subscribe fires with data, `toPromise()` resolves, memoised same-ref). `getBalance`/`suggestFor` kept as **SYNC** value assertions (return the value directly, asserted `instanceof Money` etc.). `scan.parse` kept as a `Promise`. The internal-module tests are verbatim.

## Local CI gate (all green)
- `bun --filter='*' run test`: **wallet-sdk 145 pass / 0 fail**, **web-wallet 133 pass / 0 fail**, **react-wallet-sdk 5 pass / 0 fail**
- `bun --filter='*' run typecheck`: all packages exit 0 (incl. `@agicash/react-wallet-sdk`)
- `format:check` (511 files) clean; `lint:check` exit 0 (only 2 pre-existing unrelated warnings in `apps/web-wallet/vite-env.d.ts`)
- `bun install --frozen-lockfile`: clean, **no new deps**

Framework-free SDK preserved: no `react` / `@tanstack/react-query` in `packages/wallet-sdk`; `query-core` only via `toQuery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)