### PR TITLE
feat(wallet-sdk): executeQuote orchestrator + receiveToken claim flow (PR5d, reactive design B)

### DIFF
--- a/packages/wallet-sdk/src/domains/cashu.test.ts
+++ b/packages/wallet-sdk/src/domains/cashu.test.ts
@@ -21,7 +21,7 @@ import type { Currency, Money as MoneyType } from '../types/money';
 import type { Query } from '../types/query';
 
 const { CashuSendOpsImpl, CashuReceiveOpsImpl } = await import('./cashu');
-const { NotImplementedError, DomainError } = await import('../errors');
+const { DomainError } = await import('../errors');
 const { Money } = await import('../types/money');
 
 // -- Fakes ----------------------------------------------------------------------------------
@@ -95,13 +95,14 @@ function makeSendOps(
 ) {
   const ops = new CashuSendOpsImpl(
     makeClient(),
-    // biome-ignore lint/suspicious/noExplicitAny: minimal service/repo stubs for the fold + stub tests.
+    // biome-ignore lint/suspicious/noExplicitAny: minimal service/repo stubs for the fold tests.
     sendQuoteService as any,
     {} as never,
     sendQuoteRepository,
     sendSwapRepository,
     {} as never,
     session,
+    {} as never,
   );
   return { ops, sendQuoteService };
 }
@@ -178,24 +179,128 @@ describe('CashuSendOps.createLightningQuote — destination resolution', () => {
   });
 });
 
-describe('CashuSendOps.executeQuote — deferred to PR5d', () => {
-  test('throws NotImplementedError (orchestrator state machine deferred)', () => {
-    const { ops } = makeSendOps();
-    expect(() => ops.executeQuote({} as never)).toThrow(NotImplementedError);
+describe('CashuSendOps.executeQuote — wired to the orchestrator (PR5d)', () => {
+  test('delegates the full quote to orchestrator.executeCashuSendQuote', async () => {
+    const quote = { id: 'q1', state: 'UNPAID' } as never;
+    const executeCashuSendQuote = mock(async (q: unknown) => q);
+    const orchestrator = { executeCashuSendQuote } as never;
+    const ops = new CashuSendOpsImpl(
+      makeClient(),
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      session,
+      orchestrator,
+    );
+
+    const result = await ops.executeQuote(quote);
+
+    expect(executeCashuSendQuote).toHaveBeenCalledTimes(1);
+    expect(executeCashuSendQuote).toHaveBeenCalledWith(quote);
+    expect(result).toBe(quote);
   });
 });
 
-describe('CashuReceiveOps.receiveToken — deferred to PR5d', () => {
-  test('throws NotImplementedError with no side effects (the claim flow is deferred)', () => {
+describe('CashuReceiveOps.receiveToken — wired to the claim flow (PR5d)', () => {
+  test('a SAME-MINT claim returns { success:true, destinationAccount } (no throw)', async () => {
+    // The same-mint branch creates an internal CashuReceiveSwap + kicks the orchestrator; the flow
+    // reports kind:'same-mint' with the destination account projection (the swap stays internal).
+    const claim = mock(async () => ({
+      kind: 'same-mint' as const,
+      destinationAccount: { id: 'acc1', purpose: 'transactional' },
+    }));
     const ops = new CashuReceiveOpsImpl(
       makeClient(),
       {} as never,
       {} as never,
       session,
+      {
+        claim,
+      } as never,
     );
-    expect(() => ops.receiveToken({ token: 'cashuAabc' })).toThrow(
-      NotImplementedError,
+
+    const result = await ops.receiveToken({ token: 'cashuAabc' });
+
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      success: true,
+      destinationAccount: { id: 'acc1', purpose: 'transactional' },
+    });
+  });
+
+  test('a CROSS-account claim returns { success:true, destinationAccount }', async () => {
+    const claim = mock(async () => ({
+      kind: 'cross-account' as const,
+      destinationAccount: { id: 'spark1', purpose: 'transactional' },
+    }));
+    const ops = new CashuReceiveOpsImpl(
+      makeClient(),
+      {} as never,
+      {} as never,
+      session,
+      {
+        claim,
+      } as never,
     );
+
+    const result = await ops.receiveToken({
+      token: 'cashuAabc',
+      destinationAccount: { id: 'spark1', type: 'spark' } as never,
+    });
+
+    expect(claim).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      success: true,
+      destinationAccount: { id: 'spark1', purpose: 'transactional' },
+    });
+  });
+
+  test('a DomainError from the flow is swallowed to { success:false, message } (no throw)', async () => {
+    const claim = mock(async () => {
+      throw new DomainError(
+        'Claiming a token from a new mint is not supported yet',
+      );
+    });
+    const ops = new CashuReceiveOpsImpl(
+      makeClient(),
+      {} as never,
+      {} as never,
+      session,
+      {
+        claim,
+      } as never,
+    );
+
+    const result = await ops.receiveToken({ token: 'cashuAabc' });
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Claiming a token from a new mint is not supported yet',
+    });
+  });
+
+  test('an unexpected (non-Domain) error is swallowed to a generic { success:false } result', async () => {
+    const claim = mock(async () => {
+      throw new TypeError('boom');
+    });
+    const ops = new CashuReceiveOpsImpl(
+      makeClient(),
+      {} as never,
+      {} as never,
+      session,
+      {
+        claim,
+      } as never,
+    );
+
+    const result = await ops.receiveToken({ token: 'cashuAabc' });
+
+    expect(result).toEqual({
+      success: false,
+      message: 'Unexpected error while claiming the token',
+    });
   });
 });
 
@@ -274,6 +379,7 @@ describe('CashuReceiveOps.get — reactive Query<T>', () => {
       {} as never,
       receiveQuoteRepository,
       session,
+      {} as never,
     );
   }
 

--- a/packages/wallet-sdk/src/domains/cashu.ts
+++ b/packages/wallet-sdk/src/domains/cashu.ts
@@ -19,15 +19,14 @@
  * Every WRITE/ACTION (`createLightningQuote` / `createTokenQuote` / `failQuote` / `reverse` /
  * `executeQuote` / `receiveToken`) stays a `Promise` — lifted verbatim from the no-cache slice.
  *
- * **`executeQuote` — DEFERRED to the orchestrator sub-slice (PR5d).** Per the build plan, the
- * unified `executeQuote` orchestrator is the single biggest net-new construct — a framework-free
- * state machine that absorbs master's six React-resident `useProcess*Tasks` hooks (each a
- * TanStack mutation + retry/MintOperationError branch + a live mint-WS `*SubscriptionManager`)
- * and drives UNPAID→PENDING→PAID off DB state. The plan (§1 + §4) keeps that state-machine core
- * as its own reviewable unit and PR5b ships the IDEMPOTENT PRIMITIVES it will call
- * (`initiateSend`/`markSendQuoteAsPending`/`completeSendQuote`/`failSendQuote` + the swap/claim
- * services, with `wallet.restore` recovery + the DB reservation / CONCURRENCY_ERROR guards
- * preserved). `executeQuote` is therefore a documented stub here — see {@link CashuSendOpsImpl.executeQuote}.
+ * **`executeQuote` + `receiveToken` — wired through the orchestrator (PR5d).** `executeQuote` IS
+ * the orchestrator (the build plan's single biggest net-new construct) — it hands the full quote
+ * to the shared {@link Orchestrator}, which opens the mint melt-quote WS subscription and drives
+ * UNPAID→PENDING→PAID off FRESH DB state (no cache). `receiveToken` drives the full token-claim
+ * flow (same-mint receive swap + the cross-account melt-then-mint path) through the orchestrator and
+ * — mirroring master `claimToken` — keeps the created swap/quote INTERNAL, resolving to a
+ * lightweight `ReceiveTokenResult` (never throws; swallow-to-result).
+ * Both resolve on KICK-OFF; the terminal arrives via `send:*`/`receive:*` events + a later `.get`.
  *
  * @module
  */
@@ -39,9 +38,11 @@ import { getInvoiceFromLud16, isLNURLError } from '../internal/lib-lnurl';
 import type { CashuReceiveQuoteRepository } from '../internal/cashu-receive-quote-repository';
 import type { CashuSendQuoteRepository } from '../internal/cashu-send-quote-repository';
 import type { CashuSendSwapRepository } from '../internal/cashu-send-swap-repository';
+import type { Orchestrator } from '../internal/orchestrator';
+import type { ClaimCashuTokenFlow } from '../internal/claim-cashu-token-flow';
 import type { SessionResolver } from '../internal/session';
 import type { CashuDomain, CashuReceiveOps, CashuSendOps } from '../domains';
-import { DomainError, NotImplementedError } from '../errors';
+import { DomainError } from '../errors';
 import { type QueryClient, toQuery } from '../query';
 import type { Account, CashuAccount } from '../types/account';
 import type {
@@ -78,6 +79,7 @@ export class CashuSendOpsImpl implements CashuSendOps {
     private readonly sendSwapRepository: CashuSendSwapRepository,
     private readonly accounts: AccountRepository,
     private readonly session: SessionResolver,
+    private readonly orchestrator: Orchestrator,
   ) {}
 
   /**
@@ -151,28 +153,31 @@ export class CashuSendOpsImpl implements CashuSendOps {
     amount: Money;
   }): Promise<CashuSendSwap> {
     const user = await this.session.requireCurrentUser();
-    return this.sendSwapService.create({
+    const swap = await this.sendSwapService.create({
       userId: user.id,
       account: params.account,
       amount: params.amount,
       senderPaysFee: true,
     });
+    // A DRAFT swap needs the input proofs swapped for the exact proofs-to-send before a token can
+    // be encoded. Kick that off through the orchestrator (returns the swap in its now-PENDING
+    // state). A swap created PENDING (the account already held exact proofs) is returned as-is.
+    return this.orchestrator.executeCashuSendSwap(swap);
   }
 
   /**
-   * DEFERRED (orchestrator sub-slice, PR5d). `executeQuote` IS the orchestrator — the
-   * framework-free state machine that drives UNPAID → PENDING → PAID off DB state + the mint
-   * melt-quote WS subscription (master has only the React `TaskProcessor`). PR5b ships the
-   * idempotent primitives it sequences (`initiateSend` / `markSendQuoteAsPending` /
-   * `completeSendQuote` / `failSendQuote`, with `wallet.restore` recovery + the DB
-   * CONCURRENCY_ERROR guard) but NOT the drive loop. Throws {@link NotImplementedError}.
+   * Execute a cashu lightning send — THE orchestrator (not a thin kickoff). Hands the full quote
+   * to the shared {@link Orchestrator}, which opens the mint melt-quote WS subscription for the
+   * quote's mint and drives UNPAID → PENDING → PAID off FRESH DB state (re-reading the quote on
+   * each mint update, never a cache), preserving master's idempotency (`wallet.restore`) +
+   * recovery + the `MintOperationError`→fail branch. Resolves on KICK-OFF (returns the quote in
+   * its current state); the terminal arrives via `send:completed` / `send:failed` or `.get(id)`.
    *
-   * @param _quote - the quote to drive (full object on the kickoff path).
+   * @param quote - the FULL send quote (full object on the kickoff path).
+   * @returns the quote in its current state (does NOT block until terminal).
    */
-  executeQuote(_quote: CashuSendQuote): Promise<CashuSendQuote> {
-    throw new NotImplementedError(
-      'cashu.send.executeQuote (the orchestrator state machine lands in the PR5d orchestrator sub-slice; PR5b ships the idempotent send primitives it drives)',
-    );
+  executeQuote(quote: CashuSendQuote): Promise<CashuSendQuote> {
+    return this.orchestrator.executeCashuSendQuote(quote);
   }
 
   /**
@@ -285,6 +290,7 @@ export class CashuReceiveOpsImpl implements CashuReceiveOps {
     private readonly receiveQuoteService: CashuReceiveQuoteService,
     private readonly receiveQuoteRepository: CashuReceiveQuoteRepository,
     private readonly session: SessionResolver,
+    private readonly claimFlow: ClaimCashuTokenFlow,
   ) {}
 
   /**
@@ -303,30 +309,55 @@ export class CashuReceiveOpsImpl implements CashuReceiveOps {
   }
 
   /**
-   * Claim a cashu token. DEFERRED to the orchestrator sub-slice (PR5d) at the PUBLIC surface.
+   * Claim a received cashu token (PR5d). MIRRORS master `ClaimCashuTokenService.claimToken`: the
+   * receive-swap / receive-quote it creates is INTERNAL (DB-persisted, driven to completion by the
+   * background processor) and is NOT returned — this resolves to a lightweight
+   * {@link ReceiveTokenResult}. Completion surfaces via `receive:completed` / `receive:failed`.
    *
-   * The IDEMPOTENT PRIMITIVE is shipped + tested in PR5b — `CashuReceiveSwapService.create`
-   * (same-mint claim: create a receive swap + reserve, with `wallet.restore` double-claim
-   * recovery in `completeSwap`). What this public method additionally needs is the full claim
-   * FLOW master implements in `ClaimCashuTokenService`: destination-account resolution (add the
-   * mint if unknown, set-default UX), same-mint-vs-cross-account ROUTING, the cross-account
-   * melt-then-mint quote path (token → a different mint, or token → spark), and the
-   * result-surface reconciliation onto the contract's {@link ReceiveTokenResult} (master's
-   * `claimToken` SWALLOWS errors to a `{ success, ... }` result; the cross-account path drives a
-   * receive/spark quote under the hood). That flow is orchestrated over account/user services +
-   * exchange-rate fetches not yet in the SDK, and folds in with the orchestrator + transfers
-   * slices. Throws {@link NotImplementedError} (no side effects) rather than half-driving a claim.
+   * **NEVER throws — swallow-to-result** (master's outer try/catch). A user-facing `DomainError`
+   * becomes `{ success: false, message: error.message }`; any unexpected error is logged (with its
+   * cause) and becomes `{ success: false, message: 'Unexpected error while claiming the token' }`.
    *
-   * @param _params.token - the encoded cashu token string.
-   * @param _params.destinationAccount - the account to claim into.
+   * Decodes the token, resolves source/destination accounts, and routes the claim:
+   *  - **same-mint** (default — `destinationAccount` omitted → master's default resolution into the
+   *    token's own mint): creates a {@link CashuReceiveSwapService} swap and kicks the orchestrator;
+   *  - **cross-account, same-currency** (`destinationAccount` is a different cashu mint, or spark):
+   *    the melt-then-mint path (token → other-mint / token → spark).
+   * Both return `{ success: true, destinationAccount: { id, purpose } }` on kickoff.
+   *
+   * Build-DEFERRED internal branches (vs master, see {@link ClaimCashuTokenFlow}) surface through
+   * the result as `{ success: false, message }`, NOT a throw:
+   *  - **cross-currency** claims need the still-stubbed `exchangeRate` domain (Slice 4 / PR5e);
+   *  - claiming into a **mint the user has no account for** needs the auto-add + set-default UX
+   *    (`userService.setDefaultAccount`, Slice 4) — pass a full `destinationAccount` instead.
+   *
+   * @param params.token - the encoded cashu token string.
+   * @param params.destinationAccount - the account to claim into; omitted → master default
+   *   resolution (the token's own mint = same-mint claim).
+   * @returns a {@link ReceiveTokenResult} — started + destination, or failure + message.
    */
-  receiveToken(_params: {
+  async receiveToken(params: {
     token: string;
     destinationAccount?: Account;
   }): Promise<ReceiveTokenResult> {
-    throw new NotImplementedError(
-      'cashu.receive.receiveToken (the claim FLOW — account resolution + same/cross routing + the cross-account melt-then-mint quote — lands with the PR5d orchestrator + transfers; PR5b ships the same-mint receive-swap primitive it builds on)',
-    );
+    try {
+      const user = await this.session.requireCurrentUser();
+      const result = await this.claimFlow.claim({
+        userId: user.id,
+        encodedToken: params.token,
+        destinationAccount: params.destinationAccount,
+      });
+      return { success: true, destinationAccount: result.destinationAccount };
+    } catch (error) {
+      if (error instanceof DomainError) {
+        return { success: false, message: error.message };
+      }
+      // No Sentry/error-reporting seam in the framework-free SDK — master `captureException`s here;
+      // we log with the cause (best-effort, like the service primitives) + return a generic message.
+      const message = 'Unexpected error while claiming the token';
+      console.error(message, { cause: error });
+      return { success: false, message };
+    }
   }
 
   /**

--- a/packages/wallet-sdk/src/domains/spark.test.ts
+++ b/packages/wallet-sdk/src/domains/spark.test.ts
@@ -21,7 +21,7 @@ import type { Currency, Money as MoneyType } from '../types/money';
 import type { Query } from '../types/query';
 
 const { SparkSendOpsImpl, SparkReceiveOpsImpl } = await import('./spark');
-const { NotImplementedError, DomainError } = await import('../errors');
+const { DomainError } = await import('../errors');
 const { Money } = await import('../types/money');
 
 // -- Fakes ----------------------------------------------------------------------------------
@@ -93,12 +93,16 @@ function fakeSendQuoteService() {
   };
 }
 
-function makeSendOps(sendQuoteService = fakeSendQuoteService()) {
+function makeSendOps(
+  sendQuoteService = fakeSendQuoteService(),
+  orchestrator: unknown = {},
+) {
   const ops = new SparkSendOpsImpl(
     makeClient(),
-    // biome-ignore lint/suspicious/noExplicitAny: minimal service stub for the fold + stub tests.
+    // biome-ignore lint/suspicious/noExplicitAny: minimal service stub for the fold tests.
     sendQuoteService as any,
     session,
+    orchestrator as never,
   );
   return { ops, sendQuoteService };
 }
@@ -210,10 +214,19 @@ describe('SparkSendOps.createLightningQuote — destination resolution', () => {
   });
 });
 
-describe('SparkSendOps.executeQuote — deferred to PR5d', () => {
-  test('throws NotImplementedError (orchestrator state machine deferred, like cashu)', () => {
-    const { ops } = makeSendOps();
-    expect(() => ops.executeQuote({} as never)).toThrow(NotImplementedError);
+describe('SparkSendOps.executeQuote — wired to the orchestrator (PR5d)', () => {
+  test('delegates the full quote to orchestrator.executeSparkSendQuote', async () => {
+    const quote = { id: 'q1', state: 'UNPAID' } as never;
+    const executeSparkSendQuote = mock(async (q: unknown) => q);
+    const { ops } = makeSendOps(fakeSendQuoteService(), {
+      executeSparkSendQuote,
+    });
+
+    const result = await ops.executeQuote(quote);
+
+    expect(executeSparkSendQuote).toHaveBeenCalledTimes(1);
+    expect(executeSparkSendQuote).toHaveBeenCalledWith(quote);
+    expect(result).toBe(quote);
   });
 });
 
@@ -286,7 +299,12 @@ describe('SparkSendOps.get — reactive Query<T>', () => {
     // biome-ignore lint/suspicious/noExplicitAny: minimal service stub for the `get` read tests.
     sendQuoteService: any,
   ) {
-    return new SparkSendOpsImpl(makeClient(), sendQuoteService, session);
+    return new SparkSendOpsImpl(
+      makeClient(),
+      sendQuoteService,
+      session,
+      {} as never,
+    );
   }
 
   test('returns a Query (subscribe + toPromise) whose toPromise resolves the send quote (null when absent)', async () => {

--- a/packages/wallet-sdk/src/domains/spark.ts
+++ b/packages/wallet-sdk/src/domains/spark.ts
@@ -19,28 +19,25 @@
  * Every WRITE/ACTION (`createLightningQuote` / `failQuote` / `executeQuote`) stays a `Promise` —
  * lifted verbatim from the no-cache slice.
  *
- * **`executeQuote` — DEFERRED to the orchestrator sub-slice (PR5d).** This is the SAME decision
- * PR5b made for cashu's `executeQuote`, and for the same reason: the unified `executeQuote`
+ * **`executeQuote` — wired through the orchestrator (PR5d).** The unified `executeQuote`
  * orchestrator (the build plan's single biggest net-new construct) absorbs master's six
  * React-resident `useProcess*Tasks` hooks — INCLUDING `spark-send-quote-hooks.ts#useProcessSparkSendQuoteTasks`
- * — into one framework-free state machine, kept as its own reviewable unit (build plan §1 + §4 +
- * risk callout). For spark specifically: `initiateSend` (Breez `sendPayment`) moves a quote
- * UNPAID → PENDING, but the TERMINAL transition (→ COMPLETED / FAILED) is driven by the Breez
- * `paymentSucceeded` / `paymentFailed` event callback — the same event-listener substrate
- * `SparkBalanceTracker` uses and that the orchestrator owns (it also emits `send:completed` /
- * `send:failed`). Building only spark's drive loop here would duplicate that substrate and split
- * the orchestrator across two PRs. PR5c therefore ships the IDEMPOTENT PRIMITIVES the orchestrator
- * sequences (`initiateSend` with `idempotencyKey: quote.id` / `complete` / `fail`) + the balance
- * source, and leaves `executeQuote` a documented {@link NotImplementedError} stub — see
- * {@link SparkSendOpsImpl.executeQuote}.
+ * — into one framework-free state machine. For spark: `executeQuote` hands the full quote to the
+ * shared {@link Orchestrator}, which calls `initiateSend` (Breez `sendPayment`, UNPAID → PENDING)
+ * immediately; the TERMINAL transition (→ COMPLETED / FAILED) is driven by the Breez
+ * `paymentSucceeded` / `paymentFailed` event surfaced to the orchestrator's `stepSparkSend*` cores
+ * (the same event substrate `SparkBalanceTracker` uses, whose wiring lands with the S5 spark-event
+ * forwarder). PR5c ships the IDEMPOTENT PRIMITIVES the orchestrator sequences (`initiateSend` with
+ * `idempotencyKey: quote.id` / `complete` / `fail`). `executeQuote` resolves on KICK-OFF.
  *
  * @module
  */
 import { getInvoiceFromLud16, isLNURLError } from '../internal/lib-lnurl';
+import type { Orchestrator } from '../internal/orchestrator';
 import type { SparkReceiveQuoteService } from '../internal/spark-receive-quote-service';
 import type { SparkSendQuoteService } from '../internal/spark-send-quote-service';
 import type { SparkDomain, SparkReceiveOps, SparkSendOps } from '../domains';
-import { DomainError, NotImplementedError } from '../errors';
+import { DomainError } from '../errors';
 import { type QueryClient, toQuery } from '../query';
 import type { SparkAccount } from '../types/account';
 import type { SessionResolver } from '../internal/session';
@@ -69,6 +66,7 @@ export class SparkSendOpsImpl implements SparkSendOps {
     private readonly client: QueryClient,
     private readonly sendQuoteService: SparkSendQuoteService,
     private readonly session: SessionResolver,
+    private readonly orchestrator: Orchestrator,
   ) {}
 
   /**
@@ -122,19 +120,19 @@ export class SparkSendOpsImpl implements SparkSendOps {
   }
 
   /**
-   * DEFERRED (orchestrator sub-slice, PR5d). `executeQuote` IS the orchestrator — the
-   * framework-free state machine that drives UNPAID → PENDING → COMPLETED/FAILED off Breez
-   * `sendPayment` + its `paymentSucceeded` / `paymentFailed` event callback (master has only the
-   * React `TaskProcessor` + `useProcessSparkSendQuoteTasks`). PR5c ships the idempotent primitives
-   * it sequences (`initiateSend` with `idempotencyKey: quote.id`, `complete`, `fail`) but NOT the
-   * drive loop. Throws {@link NotImplementedError}. (Same placement as cashu's `executeQuote`.)
+   * Execute a spark lightning send — THE orchestrator. Hands the full quote to the shared
+   * {@link Orchestrator}, which calls Breez `sendPayment` (UNPAID → PENDING) immediately and emits
+   * `send:pending`; the terminal transition (→ COMPLETED / FAILED) arrives via the account's Breez
+   * `paymentSucceeded` / `paymentFailed` event (surfaced to `stepSparkSend*`, wired by the S5
+   * spark-event forwarder), emitting `send:completed` / `send:failed`. PR5c's `initiateSend`
+   * (`idempotencyKey: quote.id`) keeps a re-issue safe. Resolves on KICK-OFF (returns the quote in
+   * its now-PENDING state); the terminal arrives via events or `.get(id)`.
    *
-   * @param _quote - the quote to drive (full object on the kickoff path).
+   * @param quote - the FULL send quote (full object on the kickoff path).
+   * @returns the quote after initiation (PENDING), or unchanged if past UNPAID.
    */
-  executeQuote(_quote: SparkSendQuote): Promise<SparkSendQuote> {
-    throw new NotImplementedError(
-      'spark.send.executeQuote (the orchestrator state machine lands in the PR5d orchestrator sub-slice, with cashu.send.executeQuote; PR5c ships the idempotent spark send primitives it drives)',
-    );
+  executeQuote(quote: SparkSendQuote): Promise<SparkSendQuote> {
+    return this.orchestrator.executeSparkSendQuote(quote);
   }
 
   /**

--- a/packages/wallet-sdk/src/internal/claim-cashu-token-flow.test.ts
+++ b/packages/wallet-sdk/src/internal/claim-cashu-token-flow.test.ts
@@ -1,0 +1,173 @@
+import type { Token } from '@cashu/cashu-ts';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the decode layer so `claim()` can be driven without a real mint:
+//  - `extractCashuToken` (lib-scan) returns the raw token's encoded form + mint metadata;
+//  - `getDecodedToken` (cashu-ts) echoes the queued decoded token.
+// The same-mint route below resolves the SOURCE account from the user's existing accounts, so it
+// never touches `getInitializedCashuWallet` — only the decode needs mocking.
+let decodedToken: Token = {
+  mint: 'https://mint.example',
+  unit: 'sat',
+  proofs: [{ id: 'ks1', amount: 100, secret: 's', C: 'C' } as never],
+};
+const getDecodedToken = mock(() => decodedToken);
+// Override ONLY `getDecodedToken`; preserve every other cashu-ts export (other modules import
+// `MintInfo`, `OutputData`, etc. from it — a full replacement would break them).
+const actualCashuTs = await import('@cashu/cashu-ts');
+mock.module('@cashu/cashu-ts', () => ({ ...actualCashuTs, getDecodedToken }));
+const extractCashuToken = mock((_encoded: string) => ({
+  encoded: 'cashuAabc',
+  metadata: { mint: 'https://mint.example' },
+}));
+const actualLibScan = await import('./lib-scan');
+mock.module('./lib-scan', () => ({ ...actualLibScan, extractCashuToken }));
+
+// Mock the wallet-init so an UNKNOWN-mint source resolves to an (online) placeholder without a real
+// mint — lets the unknown-mint-destination deferral be exercised. Override only
+// `getInitializedCashuWallet`; preserve the rest of the module's exports.
+const getInitializedCashuWallet = mock(async () => ({
+  wallet: {} as never,
+  isOnline: true,
+}));
+const actualCashuWallet = await import('./cashu-wallet');
+mock.module('./cashu-wallet', () => ({
+  ...actualCashuWallet,
+  getInitializedCashuWallet,
+}));
+
+const { ClaimCashuTokenFlow } = await import('./claim-cashu-token-flow');
+const { DomainError } = await import('../errors');
+
+import type { CashuAccount } from '../types/account';
+
+// -- Fakes ----------------------------------------------------------------------------------
+
+const cashuAccount = (overrides: Partial<CashuAccount> = {}): CashuAccount =>
+  ({
+    id: 'acc1',
+    name: 'mint.example',
+    type: 'cashu',
+    purpose: 'transactional',
+    state: 'active',
+    isOnline: true,
+    currency: 'BTC',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    version: 0,
+    expiresAt: null,
+    mintUrl: 'https://mint.example',
+    isTestMint: false,
+    keysetCounters: {},
+    proofs: [],
+    wallet: {} as never,
+    ...overrides,
+  }) as CashuAccount;
+
+/** Build the flow + return handles on the two collaborators the same-mint wiring drives. */
+function makeFlow(opts: { accounts?: CashuAccount[] } = {}) {
+  const accounts = opts.accounts ?? [cashuAccount()];
+
+  const create = mock(async () => ({
+    swap: { tokenHash: 'hash-1', transactionId: 'tx-1', state: 'PENDING' },
+    account: accounts[0],
+  }));
+  const stepCashuReceiveSwap = mock(async () => undefined);
+
+  const mintCache = {
+    get: mock(async () => ({ allMintKeysets: { keysets: [{ id: 'ks1' }] } })),
+  };
+
+  const flow = new ClaimCashuTokenFlow({
+    accounts: { getAllActive: mock(async () => accounts) } as never,
+    cashuReceiveSwapService: { create } as never,
+    receiveCashuTokenQuoteService: {} as never,
+    orchestrator: { stepCashuReceiveSwap } as never,
+    mintCache: mintCache as never,
+  });
+
+  return { flow, create, stepCashuReceiveSwap, mintCache };
+}
+
+afterEach(() => {
+  getDecodedToken.mockClear();
+  extractCashuToken.mockClear();
+  decodedToken = {
+    mint: 'https://mint.example',
+    unit: 'sat',
+    proofs: [{ id: 'ks1', amount: 100, secret: 's', C: 'C' } as never],
+  };
+});
+
+// -- Tests ----------------------------------------------------------------------------------
+
+describe('ClaimCashuTokenFlow.claimSameMint — creates + kicks off the internal swap', () => {
+  test('calls the swap service then steps the orchestrator, returns the destination account', async () => {
+    const { flow, create, stepCashuReceiveSwap } = makeFlow();
+    const account = cashuAccount({ id: 'acc1', purpose: 'transactional' });
+
+    const result = await flow.claimSameMint('u1', decodedToken, account);
+
+    // The internal CashuReceiveSwap is created...
+    expect(create).toHaveBeenCalledTimes(1);
+    const createArgs = (create.mock.calls as unknown[][])[0][0];
+    expect(createArgs).toMatchObject({ userId: 'u1', account });
+    // ...and kicked off through the orchestrator (keyed by the swap's token hash + user).
+    expect(stepCashuReceiveSwap).toHaveBeenCalledTimes(1);
+    expect(stepCashuReceiveSwap).toHaveBeenCalledWith('hash-1', 'u1');
+    // ...and only the destination account projection is returned (the swap stays internal).
+    expect(result).toEqual({
+      kind: 'same-mint',
+      destinationAccount: { id: 'acc1', purpose: 'transactional' },
+    });
+  });
+});
+
+describe('ClaimCashuTokenFlow.claim — routes a same-mint token to the swap path', () => {
+  test('default destination (token own mint) → same-mint, creating the internal swap', async () => {
+    const { flow, create, stepCashuReceiveSwap } = makeFlow();
+
+    const result = await flow.claim({
+      userId: 'u1',
+      encodedToken: 'cashuAabc',
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(stepCashuReceiveSwap).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      kind: 'same-mint',
+      destinationAccount: { id: 'acc1', purpose: 'transactional' },
+    });
+  });
+
+  test('an undecodable token throws DomainError (caller swallows to a failure result)', async () => {
+    extractCashuToken.mockReturnValueOnce(
+      undefined as unknown as ReturnType<typeof extractCashuToken>,
+    );
+    const { flow, create } = makeFlow();
+
+    await expect(
+      flow.claim({ userId: 'u1', encodedToken: 'not-a-token' }),
+    ).rejects.toBeInstanceOf(DomainError);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test('a token from a mint the user has no account for throws DomainError (unknown-mint deferral)', async () => {
+    // No account for the token's mint → resolveDefaultDestination throws the deferral.
+    decodedToken = {
+      mint: 'https://other-mint.example',
+      unit: 'sat',
+      proofs: [{ id: 'ks1', amount: 100, secret: 's', C: 'C' } as never],
+    };
+    extractCashuToken.mockReturnValueOnce({
+      encoded: 'cashuAabc',
+      metadata: { mint: 'https://other-mint.example' },
+    } as ReturnType<typeof extractCashuToken>);
+    // No accounts → the source resolves to the mocked (online) placeholder wallet, then
+    // destination-resolution finds no own-mint account and raises the unknown-mint deferral.
+    const { flow } = makeFlow({ accounts: [] });
+
+    await expect(
+      flow.claim({ userId: 'u1', encodedToken: 'cashuAabc' }),
+    ).rejects.toBeInstanceOf(DomainError);
+  });
+});

--- a/packages/wallet-sdk/src/internal/claim-cashu-token-flow.ts
+++ b/packages/wallet-sdk/src/internal/claim-cashu-token-flow.ts
@@ -1,0 +1,332 @@
+/**
+ * Cashu token-claim FLOW — Slice 3 / PR5d. The orchestration behind `cashu.receive.receiveToken`.
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/receive/claim-cashu-token-service.ts#handleClaim`, narrowed to the
+ * pieces the current SDK surface supports. It decodes the token, resolves the SOURCE cashu account
+ * (building a placeholder wallet for a mint the user has no account for) and the DESTINATION
+ * account, then ROUTES:
+ *  - **same-mint** (destination mint+currency == source) → a {@link CashuReceiveSwapService} swap,
+ *    created + driven toward COMPLETED by the orchestrator (`stepCashuReceiveSwap`). The swap is
+ *    INTERNAL (DB-persisted, processor-driven); the flow returns only the destination account;
+ *  - **cross-account, same-currency** (a different cashu mint, or spark) → the cross-account
+ *    melt-then-mint via {@link ReceiveCashuTokenQuoteService}, driven by the orchestrator's
+ *    cross-account melt machine. The receive quote is INTERNAL too; the flow returns only the
+ *    destination account.
+ *
+ * Mirrors master's `handleClaim` shape: both branches resolve to the destination account
+ * projection (`{ id, purpose }`), never the created swap/quote object. This flow may THROW a
+ * `DomainError` (undecodable token, unsupported deferral); the outer `receiveToken` swallows it to
+ * a `{ success: false, message }` result (master's `claimToken` try/catch).
+ *
+ * DIVERGENCE / DEFERRED (vs master, documented for review — folds in with the Slice-4
+ * exchangeRate + user-service work):
+ *  - master's `handleClaim` ALSO adds an unknown destination mint as an account, sets it default,
+ *    and fetches a cross-CURRENCY exchange rate. The SDK's `account.add` exists, but
+ *    `userService.setDefaultAccount` (Slice 1/4) and the `exchangeRate` domain (still a stub) do
+ *    NOT. So this flow:
+ *      (a) requires the destination account to be one the SDK can resolve (the caller passes a full
+ *          `destinationAccount`, or it defaults to the token's own mint = same-mint claim); a token
+ *          from a mint the user has no account for (the unknown-mint auto-add UX) throws a
+ *          `DomainError`;
+ *      (b) supports cross-account only for the SAME currency (`exchangeRate = '1'`); a
+ *          cross-currency claim throws a `DomainError` pointing at the exchangeRate dependency.
+ *    The set-default UX is a consumer concern (web already owns it) and is not reproduced here.
+ *
+ * @module
+ */
+import { type Token, getDecodedToken } from '@cashu/cashu-ts';
+import type { AccountRepository } from './account-repository';
+import type { CashuReceiveSwapService } from './cashu-receive-swap-service';
+import type { MintMetadataCache } from './cashu-wallet';
+import { getInitializedCashuWallet } from './cashu-wallet';
+import type { ExtendedCashuWallet } from './lib-cashu-wallet';
+import { areMintUrlsEqual, tokenToMoney } from './lib-cashu-quotes';
+import { extractCashuToken } from './lib-scan';
+import type { Orchestrator } from './orchestrator';
+import type { ReceiveCashuTokenQuoteService } from './receive-cashu-token-quote-service';
+import { DomainError } from '../errors';
+import type { Account, CashuAccount } from '../types/account';
+import type { Currency } from '../types/money';
+import type { CashuReceiveQuote } from '../types/cashu';
+import type { SparkReceiveQuote } from '../types/spark';
+
+/** The SDK-internal collaborators the claim flow needs (a subset of the orchestrator's deps). */
+export type ClaimCashuTokenDeps = {
+  accounts: AccountRepository;
+  cashuReceiveSwapService: CashuReceiveSwapService;
+  receiveCashuTokenQuoteService: ReceiveCashuTokenQuoteService;
+  orchestrator: Orchestrator;
+  mintCache: MintMetadataCache;
+};
+
+/**
+ * The result of a claim kickoff — mirrors master `handleClaim`'s return shape. Both the same-mint
+ * (internal {@link CashuReceiveSwap}) and the cross-account (internal receive quote) paths resolve
+ * to the DESTINATION account projection only; the created swap/quote stays internal (DB-persisted,
+ * processor-driven). `kind` records which branch ran (for tests / observability), but carries no
+ * swap/quote object.
+ */
+export type ClaimResult = {
+  /** Which branch handled the claim. */
+  kind: 'same-mint' | 'cross-account';
+  /** The account the token is being claimed into (master `Pick<Account, 'id' | 'purpose'>`). */
+  destinationAccount: Pick<Account, 'id' | 'purpose'>;
+};
+
+/** Drives the token-claim flow behind `cashu.receive.receiveToken`. */
+export class ClaimCashuTokenFlow {
+  constructor(private readonly deps: ClaimCashuTokenDeps) {}
+
+  /**
+   * Decode + claim a token. Resolves source/destination, routes same-mint vs cross-account, kicks
+   * off the orchestrator for completion, and returns the destination account. Resolves on KICK-OFF
+   * (completion arrives via `receive:*` events). Mirrors master `handleClaim`.
+   *
+   * @param params.userId - the receiving user.
+   * @param params.encodedToken - the encoded cashu token string.
+   * @param params.destinationAccount - the account to claim into; defaults to the token's own mint
+   *   (a same-mint claim) when the user has an account for it.
+   * @returns the claim result (which branch ran + the destination account projection).
+   * @throws DomainError on an undecodable / unsupported token, an unknown-mint claim (auto-add
+   *   deferred), or an unsupported cross-currency claim.
+   */
+  async claim(params: {
+    userId: string;
+    encodedToken: string;
+    destinationAccount?: Account;
+  }): Promise<ClaimResult> {
+    const token = await this.decodeToken(params.encodedToken);
+    const tokenCurrency = tokenToMoney(token).currency;
+
+    const accounts = await this.deps.accounts.getAllActive(params.userId);
+    const sourceAccount = await this.resolveSourceAccount(
+      token,
+      tokenCurrency,
+      accounts,
+    );
+
+    const destinationAccount =
+      params.destinationAccount ??
+      this.resolveDefaultDestination(token, tokenCurrency, accounts);
+
+    if (this.isSameMintClaim(sourceAccount, destinationAccount)) {
+      // Same-mint claim (the common paste-and-claim path): create the internal receive swap and
+      // kick the orchestrator. The swap is DB-persisted + processor-driven — we return only the
+      // destination account, mirroring master `handleClaim`.
+      return this.claimSameMint(
+        params.userId,
+        token,
+        destinationAccount as CashuAccount,
+      );
+    }
+
+    return this.claimCrossAccount(
+      params.userId,
+      token,
+      sourceAccount,
+      destinationAccount,
+    );
+  }
+
+  /**
+   * Same-mint claim: create the receive swap (an INTERNAL {@link CashuReceiveSwap}) and kick it off
+   * through the orchestrator (`stepCashuReceiveSwap`), which drives it toward COMPLETED off fresh DB
+   * state and emits `receive:completed` / `receive:failed`. Returns only the destination account
+   * (the swap is internal — never surfaced), mirroring master `handleClaim`'s same-account branch.
+   *
+   * The orchestrator step is best-effort (it does not throw if completion fails — the background
+   * processor retries, exactly as master's `tryCompleteSwap`); a non-recoverable FAILED swap is
+   * reported via `receive:failed`, not by failing this kickoff.
+   *
+   * @param userId - the receiving user.
+   * @param token - the decoded token (mint == the destination account's mint).
+   * @param account - the destination (== source) cashu account.
+   * @returns the claim result (`same-mint` + the destination account projection).
+   */
+  async claimSameMint(
+    userId: string,
+    token: Token,
+    account: CashuAccount,
+  ): Promise<ClaimResult> {
+    const { swap } = await this.deps.cashuReceiveSwapService.create({
+      userId,
+      token,
+      account,
+    });
+    await this.deps.orchestrator.stepCashuReceiveSwap(swap.tokenHash, userId);
+    return {
+      kind: 'same-mint',
+      destinationAccount: { id: account.id, purpose: account.purpose },
+    };
+  }
+
+  /** Decode the encoded token, fetching the source mint's keyset ids to validate (master `decodeCashuToken`). */
+  private async decodeToken(encodedToken: string): Promise<Token> {
+    const extracted = extractCashuToken(encodedToken);
+    if (!extracted) {
+      throw new DomainError('Invalid cashu token');
+    }
+    try {
+      const metadata = await this.deps.mintCache.get(extracted.metadata.mint);
+      const keysetIds = metadata.allMintKeysets.keysets.map((k) => k.id);
+      return getDecodedToken(extracted.encoded, keysetIds);
+    } catch (error) {
+      const wrapped = new DomainError('Failed to decode cashu token');
+      wrapped.cause = error;
+      throw wrapped;
+    }
+  }
+
+  /**
+   * Resolve the SOURCE cashu account for the token's mint+currency: the user's existing account
+   * for it, else a placeholder built from a freshly-initialised wallet (the cross-account path
+   * melts from this even when the user has no account for the mint). Master
+   * `ReceiveCashuTokenService.getSourceAndDestinationAccounts` / `buildAccountForMint`, narrowed.
+   */
+  private async resolveSourceAccount(
+    token: Token,
+    tokenCurrency: Currency,
+    accounts: Account[],
+  ): Promise<CashuAccount> {
+    const existing = accounts.find(
+      (a): a is CashuAccount =>
+        a.type === 'cashu' &&
+        areMintUrlsEqual(a.mintUrl, token.mint) &&
+        a.currency === tokenCurrency,
+    );
+    if (existing) {
+      return existing;
+    }
+
+    const { wallet, isOnline } = await getInitializedCashuWallet({
+      cache: this.deps.mintCache,
+      mintUrl: token.mint,
+      currency: tokenCurrency,
+    });
+    if (!isOnline) {
+      throw new DomainError('Source mint is offline');
+    }
+    return this.buildPlaceholderSourceAccount(
+      token.mint,
+      tokenCurrency,
+      wallet,
+    );
+  }
+
+  /** Build a non-persisted source `CashuAccount` for a mint the user has no account for (placeholder id). */
+  private buildPlaceholderSourceAccount(
+    mintUrl: string,
+    currency: Currency,
+    wallet: ExtendedCashuWallet,
+  ): CashuAccount {
+    return {
+      id: 'cashu-account-placeholder-id',
+      name: mintUrl.replace('https://', '').replace('http://', ''),
+      type: 'cashu',
+      purpose: 'transactional',
+      state: 'active',
+      isOnline: true,
+      currency,
+      createdAt: new Date().toISOString(),
+      version: 0,
+      expiresAt: null,
+      mintUrl,
+      isTestMint: false,
+      keysetCounters: {},
+      proofs: [],
+      wallet,
+    };
+  }
+
+  /**
+   * Default the destination to the token's OWN mint (same-mint claim) when the user has an account
+   * for it, mirroring master's `getDefaultReceiveAccount` preference for the token's own mint.
+   *
+   * DEFERRED (Slice 4 / PR5e): when the user has NO account for the token's mint, master
+   * auto-adds the mint as an account + sets it default — that UX needs `userService.setDefaultAccount`
+   * (not yet wired), so this throws a `DomainError` (swallowed to `{ success: false, message }`).
+   * The caller can still claim by passing an explicit `destinationAccount`.
+   */
+  private resolveDefaultDestination(
+    token: Token,
+    tokenCurrency: Currency,
+    accounts: Account[],
+  ): Account {
+    const ownMintAccount = accounts.find(
+      (a): a is CashuAccount =>
+        a.type === 'cashu' &&
+        areMintUrlsEqual(a.mintUrl, token.mint) &&
+        a.currency === tokenCurrency,
+    );
+    if (ownMintAccount) {
+      return ownMintAccount;
+    }
+    throw new DomainError(
+      'Claiming a token from a new mint is not supported yet; choose an existing account to receive it.',
+    );
+  }
+
+  /** Whether the claim is same-mint (destination mint+currency equals the source). */
+  private isSameMintClaim(source: Account, destination: Account): boolean {
+    return (
+      source.type === 'cashu' &&
+      destination.type === 'cashu' &&
+      source.currency === destination.currency &&
+      areMintUrlsEqual(source.mintUrl, destination.mintUrl)
+    );
+  }
+
+  /**
+   * Cross-account claim (a different cashu mint, or spark): build the paired source-melt +
+   * destination-mint quotes, then kick off the orchestrator's cross-account melt machine. The
+   * destination receive quote is INTERNAL (processor-driven); returns only the destination account.
+   * Same-currency only (no exchangeRate domain yet).
+   *
+   * DEFERRED (Slice 4 / PR5e): a cross-CURRENCY claim needs the still-stubbed `exchangeRate`
+   * domain → it throws a `DomainError` (swallowed to `{ success: false, message }` by the caller).
+   */
+  private async claimCrossAccount(
+    userId: string,
+    token: Token,
+    sourceAccount: CashuAccount,
+    destinationAccount: Account,
+  ): Promise<ClaimResult> {
+    if (sourceAccount.currency !== destinationAccount.currency) {
+      throw new DomainError(
+        'Cross-currency token claims are not supported yet (they need the exchangeRate domain — Slice 4 / PR5e).',
+      );
+    }
+
+    const quotes =
+      await this.deps.receiveCashuTokenQuoteService.createCrossAccountReceiveQuotes(
+        {
+          userId,
+          token,
+          sourceAccount,
+          destinationAccount,
+          // Same-currency: a 1:1 conversion (the exchangeRate domain is required only cross-currency).
+          exchangeRate: '1',
+        },
+      );
+
+    if (quotes.destinationType === 'cashu') {
+      // Track the source melt + destination mint; the orchestrator drives both to completion.
+      await this.deps.orchestrator.startCashuTokenReceiveQuote(
+        quotes.cashuReceiveQuote as CashuReceiveQuote & { type: 'CASHU_TOKEN' },
+      );
+    } else {
+      await this.deps.orchestrator.startSparkTokenReceiveQuote(
+        quotes.sparkReceiveQuote as SparkReceiveQuote & { type: 'CASHU_TOKEN' },
+      );
+    }
+
+    return {
+      kind: 'cross-account',
+      destinationAccount: {
+        id: destinationAccount.id,
+        purpose: destinationAccount.purpose,
+      },
+    };
+  }
+}

--- a/packages/wallet-sdk/src/internal/lib-retry.ts
+++ b/packages/wallet-sdk/src/internal/lib-retry.ts
@@ -1,0 +1,20 @@
+/**
+ * SDK-internal retry helper — Slice 3 / PR5d (the orchestrator's drive loop).
+ *
+ * The orchestrator re-houses master's six React-resident `useProcess*Tasks` hooks off
+ * `@tanstack/react-query`. The TanStack mutations got retry/backoff "for free" from
+ * React Query (`useMutation({ retry, retryDelay })`); the framework-free orchestrator needs an
+ * equivalent. Master already ships exactly such a helper at `app/lib/with-retry.ts` — a pure,
+ * framework-free `withRetry({ fn, retry, retryDelay, signal })` with exponential backoff. Per the
+ * build plan (§3, "use `with-retry.ts` helper"), it is lifted here.
+ *
+ * Following the package's established single-source seam (see `./lib-cashu` / `./lib-scan`), this
+ * re-exports the SINGLE live source via a relative path rather than copying it — `with-retry.ts`
+ * (and its `delay` dependency) import nothing framework-coupled (verified: only a `setTimeout`
+ * delay + `AbortSignal`). The canonical relocation of `app/lib/**` INTO the package is a deferred
+ * follow-up (out of the build-plan's scope).
+ *
+ * @module
+ */
+
+export { withRetry } from '../../../../apps/web-wallet/app/lib/with-retry';

--- a/packages/wallet-sdk/src/internal/lib-timeout.ts
+++ b/packages/wallet-sdk/src/internal/lib-timeout.ts
@@ -1,0 +1,22 @@
+/**
+ * SDK-internal long-timeout + set helpers — Slice 3 / PR5d (the mint-WS subscription managers).
+ *
+ * The lifted mint-quote / melt-quote subscription managers (and the expiry timers the orchestrator
+ * schedules) need two framework-free utilities master keeps in `app/lib`:
+ *  - `setLongTimeout` / `clearLongTimeout` (`app/lib/timeout.ts`) — a `setTimeout` that supports
+ *    delays beyond the ~24.8-day platform cap (a quote can have a far-future expiry);
+ *  - `isSubset` (`app/lib/utils.ts`) — the subscription manager's "is this quote-id set already
+ *    covered?" check.
+ *
+ * Both are pure (no react / @tanstack), so per the package's single-source seam (see `./lib-cashu`)
+ * they are re-exported from the live app source rather than copied.
+ *
+ * @module
+ */
+
+export {
+  type LongTimeout,
+  clearLongTimeout,
+  setLongTimeout,
+} from '../../../../apps/web-wallet/app/lib/timeout';
+export { isSubset } from '../../../../apps/web-wallet/app/lib/utils';

--- a/packages/wallet-sdk/src/internal/melt-quote-subscription-manager.ts
+++ b/packages/wallet-sdk/src/internal/melt-quote-subscription-manager.ts
@@ -1,0 +1,174 @@
+/**
+ * Mint melt-quote WebSocket subscription manager — Slice 3 / PR5d.
+ *
+ * LIFTED near-verbatim (framework-free already) from
+ * `apps/web-wallet/app/lib/cashu/melt-quote-subscription-manager.ts`. This is the SDK's "live
+ * protocol connection" for cashu SEND quotes (§0 state kind 3): a per-mint-URL map of NUT-17
+ * `bolt11_melt_quote` subscriptions over each mint's WebSocket. The orchestrator's cashu
+ * send-quote + cross-account token-receive state machines drive their UNPAID → PENDING → PAID
+ * transitions off these updates.
+ *
+ * Re-housing vs master:
+ *  - master imported `getCashuWallet` from `~/lib/cashu` directly; here the wallet factory is
+ *    INJECTED (`getWallet(mintUrl)`) so the orchestrator can pass an account's live
+ *    `ExtendedCashuWallet` (already keyset-loaded) and fall back to a bare `getCashuWallet` for a
+ *    source mint the user has no account for (the cross-account token path). The injected factory
+ *    is the same `getCashuWallet` re-exported by `./lib-cashu-wallet`;
+ *  - `isSubset` comes from `./lib-timeout` (the single-source seam);
+ *  - no other change — the Map/subscription/onClose lifecycle is identical.
+ *
+ * @module
+ */
+import type { MeltQuoteBolt11Response } from '@cashu/cashu-ts';
+import type { ExtendedCashuWallet } from './lib-cashu-wallet';
+import { isSubset } from './lib-timeout';
+
+/** Per-mint subscription bookkeeping (master verbatim). */
+type SubscriptionData = {
+  ids: Set<string>;
+  subscriptionPromise: Promise<() => void>;
+  onUpdate: (meltQuoteResponse: MeltQuoteBolt11Response) => void;
+};
+
+/** A factory that returns a (cashu-ts) wallet for a mint URL — injected so the orchestrator can supply an account's live, keyset-loaded handle. */
+export type GetMeltSubscriptionWallet = (
+  mintUrl: string,
+) => ExtendedCashuWallet;
+
+/**
+ * Manages NUT-17 melt-quote WebSocket subscriptions, one per mint URL. Lifted from master's
+ * `MeltQuoteSubscriptionManager` (the in-flight working-set's live connection); framework-free.
+ */
+export class MeltQuoteSubscriptionManager {
+  private subscriptions: Map<string, SubscriptionData> = new Map();
+
+  /**
+   * @param getWallet - the wallet factory (defaults to none — the orchestrator always injects one).
+   */
+  constructor(private readonly getWallet: GetMeltSubscriptionWallet) {}
+
+  /**
+   * Subscribe to melt-quote updates for the given mint URL and quotes. If a subscription for the
+   * mint already covers these ids, the callback is swapped in place; otherwise the old one is
+   * torn down and a fresh subscription opened. Master verbatim (wallet factory injected).
+   *
+   * @param params.mintUrl - the mint URL to subscribe to.
+   * @param params.quoteIds - the melt-quote ids to subscribe to.
+   * @param params.onUpdate - callback invoked on each melt-quote update.
+   * @returns an unsubscribe function.
+   * @throws Error if the subscription fails.
+   */
+  async subscribe({
+    mintUrl,
+    quoteIds,
+    onUpdate,
+  }: {
+    mintUrl: string;
+    quoteIds: string[];
+    onUpdate: (meltQuoteResponse: MeltQuoteBolt11Response) => void;
+  }): Promise<() => void> {
+    const ids = new Set(quoteIds);
+    const mintSubscription = this.subscriptions.get(mintUrl);
+
+    if (mintSubscription) {
+      const unsubscribe = await mintSubscription.subscriptionPromise;
+
+      if (isSubset(ids, mintSubscription.ids)) {
+        this.subscriptions.set(mintUrl, {
+          ...mintSubscription,
+          onUpdate,
+        });
+        return () => {
+          unsubscribe();
+          this.subscriptions.delete(mintUrl);
+        };
+      }
+
+      unsubscribe();
+    }
+
+    const wallet = this.getWallet(mintUrl);
+
+    const subscriptionCallback = (meltQuote: MeltQuoteBolt11Response) => {
+      const currentSubscription = this.subscriptions.get(mintUrl);
+      if (currentSubscription) {
+        currentSubscription.onUpdate(meltQuote);
+      }
+    };
+
+    const subscriptionPromise = wallet.on.meltQuoteUpdates(
+      Array.from(ids),
+      subscriptionCallback,
+      (error) =>
+        console.error('Melt quote updates socket error', {
+          cause: error,
+        }),
+    );
+
+    this.subscriptions.set(mintUrl, {
+      ids,
+      subscriptionPromise,
+      onUpdate,
+    });
+
+    try {
+      const unsubscribe = await subscriptionPromise;
+
+      wallet.mint.webSocketConnection?.onClose(() => {
+        this.subscriptions.delete(mintUrl);
+      });
+
+      return () => {
+        unsubscribe();
+        this.subscriptions.delete(mintUrl);
+      };
+    } catch (error) {
+      this.subscriptions.delete(mintUrl);
+      throw error;
+    }
+  }
+
+  /**
+   * Remove a quote from a mint's subscription bookkeeping (does NOT unsubscribe the socket).
+   * No-op if the manager is not subscribed for that mint or quote. Master verbatim. Used after a
+   * send is failed-then-recreated with the same melt quote, so the new send re-triggers.
+   *
+   * @param params.mintUrl - the mint URL to remove the quote from.
+   * @param params.quoteId - the melt-quote id to remove.
+   */
+  removeQuoteFromSubscription({
+    mintUrl,
+    quoteId,
+  }: {
+    mintUrl: string;
+    quoteId: string;
+  }): void {
+    const mintSubscription = this.subscriptions.get(mintUrl);
+    if (!mintSubscription || !mintSubscription.ids.has(quoteId)) {
+      return;
+    }
+
+    const ids = new Set(mintSubscription.ids);
+    ids.delete(quoteId);
+    this.subscriptions.set(mintUrl, {
+      ...mintSubscription,
+      ids,
+    });
+  }
+
+  /** Tear down every open subscription (called when the orchestrator / SDK is destroyed). */
+  async closeAll(): Promise<void> {
+    const subscriptions = Array.from(this.subscriptions.values());
+    this.subscriptions.clear();
+    await Promise.all(
+      subscriptions.map(async (s) => {
+        try {
+          const unsubscribe = await s.subscriptionPromise;
+          unsubscribe();
+        } catch {
+          // The subscription never opened — nothing to tear down.
+        }
+      }),
+    );
+  }
+}

--- a/packages/wallet-sdk/src/internal/mint-quote-subscription-manager.ts
+++ b/packages/wallet-sdk/src/internal/mint-quote-subscription-manager.ts
@@ -1,0 +1,139 @@
+/**
+ * Mint mint-quote WebSocket subscription manager — Slice 3 / PR5d.
+ *
+ * LIFTED near-verbatim (framework-free already) from
+ * `apps/web-wallet/app/lib/cashu/mint-quote-subscription-manager.ts`. The SDK's "live protocol
+ * connection" for cashu lightning RECEIVE quotes (§0 state kind 3): a per-mint-URL map of NUT-17
+ * `bolt11_mint_quote` subscriptions over each mint's WebSocket. The orchestrator's cashu
+ * receive-quote state machine drives UNPAID → PAID → COMPLETED off these updates (for mints that
+ * advertise WebSocket support; the orchestrator polls the rest).
+ *
+ * Re-housing vs master: identical to {@link MeltQuoteSubscriptionManager} — the `getCashuWallet`
+ * factory is INJECTED rather than imported, and `isSubset` comes from the `./lib-timeout` seam.
+ *
+ * @module
+ */
+import type { MintQuoteBolt11Response } from '@cashu/cashu-ts';
+import type { ExtendedCashuWallet } from './lib-cashu-wallet';
+import { isSubset } from './lib-timeout';
+
+/** Per-mint subscription bookkeeping (master verbatim). */
+type SubscriptionData = {
+  ids: Set<string>;
+  subscriptionPromise: Promise<() => void>;
+  onUpdate: (mintQuoteResponse: MintQuoteBolt11Response) => void;
+};
+
+/** A factory that returns a (cashu-ts) wallet for a mint URL — injected so the orchestrator can supply an account's live, keyset-loaded handle. */
+export type GetMintSubscriptionWallet = (
+  mintUrl: string,
+) => ExtendedCashuWallet;
+
+/**
+ * Manages NUT-17 mint-quote WebSocket subscriptions, one per mint URL. Lifted from master's
+ * `MintQuoteSubscriptionManager`; framework-free.
+ */
+export class MintQuoteSubscriptionManager {
+  private subscriptions: Map<string, SubscriptionData> = new Map();
+
+  /**
+   * @param getWallet - the wallet factory (the orchestrator always injects one).
+   */
+  constructor(private readonly getWallet: GetMintSubscriptionWallet) {}
+
+  /**
+   * Subscribe to mint-quote updates for the given mint URL and quotes. Master verbatim (wallet
+   * factory injected).
+   *
+   * @param params.mintUrl - the mint URL to subscribe to.
+   * @param params.quoteIds - the mint-quote ids to subscribe to.
+   * @param params.onUpdate - callback invoked on each mint-quote update.
+   * @returns an unsubscribe function.
+   * @throws Error if the subscription fails.
+   */
+  async subscribe({
+    mintUrl,
+    quoteIds,
+    onUpdate,
+  }: {
+    mintUrl: string;
+    quoteIds: string[];
+    onUpdate: (mintQuoteResponse: MintQuoteBolt11Response) => void;
+  }): Promise<() => void> {
+    const ids = new Set(quoteIds);
+    const mintSubscription = this.subscriptions.get(mintUrl);
+
+    if (mintSubscription) {
+      const unsubscribe = await mintSubscription.subscriptionPromise;
+
+      if (isSubset(ids, mintSubscription.ids)) {
+        this.subscriptions.set(mintUrl, {
+          ...mintSubscription,
+          onUpdate,
+        });
+        return () => {
+          unsubscribe();
+          this.subscriptions.delete(mintUrl);
+        };
+      }
+
+      unsubscribe();
+    }
+
+    const wallet = this.getWallet(mintUrl);
+
+    const subscriptionCallback = (mintQuote: MintQuoteBolt11Response) => {
+      const currentSubscription = this.subscriptions.get(mintUrl);
+      if (currentSubscription) {
+        currentSubscription.onUpdate(mintQuote);
+      }
+    };
+
+    const subscriptionPromise = wallet.on.mintQuoteUpdates(
+      Array.from(ids),
+      subscriptionCallback,
+      (error) =>
+        console.error('Mint quote updates socket error', {
+          cause: error,
+        }),
+    );
+
+    this.subscriptions.set(mintUrl, {
+      ids,
+      subscriptionPromise,
+      onUpdate,
+    });
+
+    try {
+      const unsubscribe = await subscriptionPromise;
+
+      wallet.mint.webSocketConnection?.onClose(() => {
+        this.subscriptions.delete(mintUrl);
+      });
+
+      return () => {
+        unsubscribe();
+        this.subscriptions.delete(mintUrl);
+      };
+    } catch (error) {
+      this.subscriptions.delete(mintUrl);
+      throw error;
+    }
+  }
+
+  /** Tear down every open subscription (called when the orchestrator / SDK is destroyed). */
+  async closeAll(): Promise<void> {
+    const subscriptions = Array.from(this.subscriptions.values());
+    this.subscriptions.clear();
+    await Promise.all(
+      subscriptions.map(async (s) => {
+        try {
+          const unsubscribe = await s.subscriptionPromise;
+          unsubscribe();
+        } catch {
+          // The subscription never opened — nothing to tear down.
+        }
+      }),
+    );
+  }
+}

--- a/packages/wallet-sdk/src/internal/orchestrator-retry.test.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator-retry.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { MintOperationError, NetworkError } from '@cashu/cashu-ts';
+import { CashuErrorCodes } from './cashu-error-codes';
+import { mapVerdictToOutcome, runStep } from './orchestrator-retry';
+import { ConcurrencyError, DomainError } from '../errors';
+
+// A MintOperationError carrying a specific NUT code (the constructor takes the JSON error shape).
+const mintError = (code: number) =>
+  new MintOperationError(code, `mint error ${code}`);
+
+describe('runStep — verdict → error-model mapping (all 4 buckets)', () => {
+  test('a resolved step returns { kind: "resolved", value }', async () => {
+    const outcome = await runStep(async () => 42);
+    expect(outcome).toEqual({ kind: 'resolved', value: 42 });
+  });
+
+  test('TRANSIENT (cashu-ts NetworkError) retries, then surfaces a ConcurrencyError', async () => {
+    const fn = mock(async () => {
+      throw new NetworkError('offline');
+    });
+
+    await expect(runStep(fn, { maxRetries: 2 })).rejects.toBeInstanceOf(
+      ConcurrencyError,
+    );
+    // initial attempt + 2 retries = 3 calls.
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  test('TRANSIENT recovers if a retry succeeds (no error surfaced)', async () => {
+    let calls = 0;
+    const outcome = await runStep(
+      async () => {
+        calls++;
+        if (calls < 2) throw new NetworkError('flaky');
+        return 'ok';
+      },
+      { maxRetries: 3 },
+    );
+    expect(outcome).toEqual({ kind: 'resolved', value: 'ok' });
+    expect(calls).toBe(2);
+  });
+
+  test('PERMANENT (a deterministic mint rejection) does NOT retry, surfaces a DomainError', async () => {
+    const fn = mock(async () => {
+      throw mintError(CashuErrorCodes.TRANSACTION_NOT_BALANCED);
+    });
+
+    await expect(runStep(fn, { maxRetries: 3 })).rejects.toBeInstanceOf(
+      DomainError,
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('ALREADY-RESOLVED (token already spent) does NOT retry, resolves to a no-op', async () => {
+    const fn = mock(async () => {
+      throw mintError(CashuErrorCodes.TOKEN_ALREADY_SPENT);
+    });
+
+    const outcome = await runStep(fn, { maxRetries: 3 });
+
+    expect(outcome).toEqual({ kind: 'already-resolved' });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('UNHANDLED (an unknown error) does NOT retry, propagates the original error', async () => {
+    const original = new Error('mystery');
+    const fn = mock(async () => {
+      throw original;
+    });
+
+    await expect(runStep(fn, { maxRetries: 3 })).rejects.toBe(original);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('a DomainError thrown by a service is permanent (surfaced, not retried)', async () => {
+    const fn = mock(async () => {
+      throw new DomainError('insufficient balance');
+    });
+
+    await expect(runStep(fn)).rejects.toBeInstanceOf(DomainError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('mapVerdictToOutcome — the bare mapping (no retry loop)', () => {
+  test('already-resolved → { kind: "already-resolved" }', () => {
+    expect(
+      mapVerdictToOutcome(mintError(CashuErrorCodes.QUOTE_ALREADY_ISSUED)),
+    ).toEqual({ kind: 'already-resolved' });
+  });
+
+  test('transient → throws ConcurrencyError (preserving an existing one)', () => {
+    const existing = new ConcurrencyError('stale');
+    expect(() => mapVerdictToOutcome(existing)).toThrow(existing);
+  });
+
+  test('permanent → throws DomainError (wrapping, preserving the message)', () => {
+    let thrown: unknown;
+    try {
+      mapVerdictToOutcome(mintError(CashuErrorCodes.UNIT_MISMATCH));
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(DomainError);
+  });
+
+  test('unhandled → re-throws the original untouched', () => {
+    const original = { not: 'an error' };
+    expect(() => mapVerdictToOutcome(original)).toThrow();
+  });
+});

--- a/packages/wallet-sdk/src/internal/orchestrator-retry.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator-retry.ts
@@ -1,0 +1,142 @@
+/**
+ * Orchestrator retry + verdict→error-model wiring — Slice 3 / PR5d.
+ *
+ * This is the framework-free replacement for the retry/error branching master's
+ * `useProcess*Tasks` hooks got from React Query's `useMutation({ retry })`. It composes two
+ * already-built pieces:
+ *  - {@link classify} (§12, PR2) — the pure 4-bucket verdict (`transient` | `permanent` |
+ *    `already-resolved` | `unhandled`);
+ *  - {@link withRetry} (`app/lib/with-retry.ts`, lifted in `./lib-retry`) — exponential-backoff
+ *    retry.
+ *
+ * The mapping (build plan §3 / contract §12):
+ *
+ * | verdict            | orchestrator action                                              |
+ * | ------------------ | ---------------------------------------------------------------- |
+ * | `transient`        | retry (up to `maxRetries`); if still failing → `ConcurrencyError` |
+ * | `permanent`        | do NOT retry → surface as `DomainError`                           |
+ * | `already-resolved` | do NOT retry → treat as a no-op (the desired end-state is reached)|
+ * | `unhandled`        | do NOT retry → propagate the original error                      |
+ *
+ * GROUNDING. Master's hooks retry blindly up to 3× on most steps and gate ONLY on
+ * `error instanceof MintOperationError` (→ stop + fail). This refines that binary using
+ * `classify`: a mint rejection that is "already-spent / already-issued" is no longer a hard fail
+ * (it is the success end-state, reconciled by the services' `wallet.restore`), and a
+ * "proofs/outputs pending" rejection becomes retryable rather than fatal — matching the no-cache
+ * analyses. The `maxRetries` default of 3 preserves master's `retry: 3`.
+ *
+ * @module
+ */
+import { type ErrorClass, classify } from '../classify';
+import { ConcurrencyError, DomainError, SdkError } from '../errors';
+import { withRetry } from './lib-retry';
+
+/** The default retry budget for a transient step — matches master's hook `retry: 3`. */
+export const DEFAULT_MAX_RETRIES = 3;
+
+/**
+ * The resolved outcome of running an idempotent step through {@link runStep}: either the step's
+ * value, or a signal that the work was already done (so the caller treats it as a no-op).
+ */
+export type StepOutcome<T> =
+  | { kind: 'resolved'; value: T }
+  | { kind: 'already-resolved' };
+
+/**
+ * Run an idempotent orchestrator step with retry + the verdict→error-model mapping.
+ *
+ * Retries ONLY while the error classifies `transient` (and the budget remains). A `permanent`
+ * verdict is re-thrown as a {@link DomainError}; a `transient` budget-exhausted failure as a
+ * {@link ConcurrencyError}; an `already-resolved` verdict resolves to `{ kind: 'already-resolved' }`
+ * (the services' `wallet.restore` has reconciled local state); `unhandled` propagates the original
+ * error unchanged.
+ *
+ * Mirrors the idempotency of the services it wraps: re-running a step that has already taken
+ * effect is safe (the service no-ops on the terminal state, or the mint reports already-done →
+ * `already-resolved`).
+ *
+ * @param fn - the async step (a service-primitive call).
+ * @param options.maxRetries - transient-retry budget (default {@link DEFAULT_MAX_RETRIES}).
+ * @param options.signal - optional abort signal (cancels pending retry delays).
+ * @returns the step outcome.
+ * @throws ConcurrencyError on transient exhaustion, DomainError on a permanent verdict, or the
+ *   original error when `unhandled`.
+ */
+export async function runStep<T>(
+  fn: () => Promise<T>,
+  options: { maxRetries?: number; signal?: AbortSignal } = {},
+): Promise<StepOutcome<T>> {
+  const { maxRetries = DEFAULT_MAX_RETRIES, signal } = options;
+
+  try {
+    const value = await withRetry({
+      fn,
+      // Retry only while the verdict stays `transient` and the budget remains.
+      retry: (attemptIndex, error) =>
+        attemptIndex < maxRetries && classify(error) === 'transient',
+      signal,
+    });
+    return { kind: 'resolved', value };
+  } catch (error) {
+    return mapVerdictToOutcome<T>(error);
+  }
+}
+
+/**
+ * Map a thrown error's {@link classify} verdict onto the orchestrator's error model. Exposed
+ * separately so callers that don't need the retry loop (or that catch outside `withRetry`) reuse
+ * the SAME mapping.
+ *
+ * @param error - the thrown value from the failed step (post-retry).
+ * @returns `{ kind: 'already-resolved' }` for an already-resolved verdict.
+ * @throws ConcurrencyError (transient), DomainError (permanent), or the original error (unhandled).
+ */
+export function mapVerdictToOutcome<T>(error: unknown): StepOutcome<T> {
+  const verdict: ErrorClass = classify(error);
+
+  switch (verdict) {
+    case 'already-resolved':
+      // The desired end-state is already reached (e.g. proofs already spent / quote already
+      // issued); the service's `wallet.restore` reconciled local state. No-op.
+      return { kind: 'already-resolved' };
+    case 'transient':
+      // Survived the retry budget and is still transient — surface as the SDK's "stale, refetch +
+      // retry" signal so the next processor sweep / kickoff re-attempts.
+      throw asConcurrencyError(error);
+    case 'permanent':
+      // A deterministic rejection (the mint/peer will reject it identically) — surface to the user.
+      throw asDomainError(error);
+    default:
+      // `unhandled` — propagate untouched so nothing is silently swallowed.
+      throw error;
+  }
+}
+
+/** Wrap a transient failure as a {@link ConcurrencyError} (preserving an existing one + the cause). */
+function asConcurrencyError(error: unknown): ConcurrencyError {
+  if (error instanceof ConcurrencyError) {
+    return error;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  const wrapped = new ConcurrencyError(message);
+  if (error instanceof Error) {
+    wrapped.cause = error;
+  }
+  return wrapped;
+}
+
+/** Wrap a permanent failure as a {@link DomainError} (preserving an existing SDK error message). */
+function asDomainError(error: unknown): DomainError {
+  if (error instanceof SdkError) {
+    // A DomainError/NotFoundError is already user-facing — keep its message.
+    const wrapped = new DomainError(error.message);
+    wrapped.cause = error;
+    return wrapped;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  const wrapped = new DomainError(message);
+  if (error instanceof Error) {
+    wrapped.cause = error;
+  }
+  return wrapped;
+}

--- a/packages/wallet-sdk/src/internal/orchestrator-working-set.test.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator-working-set.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { OrchestratorWorkingSet } from './orchestrator-working-set';
+
+describe('OrchestratorWorkingSet', () => {
+  test('track + getByProtocolId resolves the agicash id and mint URL', () => {
+    const set = new OrchestratorWorkingSet();
+    set.track({
+      protocolId: 'melt-1',
+      agicashId: 'quote-1',
+      mintUrl: 'https://mint.test',
+    });
+
+    expect(set.getByProtocolId('melt-1')).toEqual({
+      agicashId: 'quote-1',
+      mintUrl: 'https://mint.test',
+    });
+    expect(set.hasAgicashId('quote-1')).toBe(true);
+  });
+
+  test('getByProtocolId returns undefined for an untracked protocol id', () => {
+    const set = new OrchestratorWorkingSet();
+    expect(set.getByProtocolId('nope')).toBeUndefined();
+    expect(set.hasAgicashId('nope')).toBe(false);
+  });
+
+  test('untrackByAgicashId removes BOTH the protocol-id and agicash-id mappings', () => {
+    const set = new OrchestratorWorkingSet();
+    set.track({ protocolId: 'melt-1', agicashId: 'quote-1' });
+
+    set.untrackByAgicashId('quote-1');
+
+    expect(set.getByProtocolId('melt-1')).toBeUndefined();
+    expect(set.hasAgicashId('quote-1')).toBe(false);
+  });
+
+  test('untrackByAgicashId is a no-op for an unknown id', () => {
+    const set = new OrchestratorWorkingSet();
+    expect(() => set.untrackByAgicashId('ghost')).not.toThrow();
+  });
+
+  test('track is idempotent — re-registering the same pair refreshes it', () => {
+    const set = new OrchestratorWorkingSet();
+    set.track({ protocolId: 'melt-1', agicashId: 'quote-1', mintUrl: 'a' });
+    set.track({ protocolId: 'melt-1', agicashId: 'quote-1', mintUrl: 'b' });
+
+    expect(set.getByProtocolId('melt-1')?.mintUrl).toBe('b');
+  });
+
+  test('clear drops everything', () => {
+    const set = new OrchestratorWorkingSet();
+    set.track({ protocolId: 'm1', agicashId: 'q1' });
+    set.track({ protocolId: 'm2', agicashId: 'q2' });
+
+    set.clear();
+
+    expect(set.getByProtocolId('m1')).toBeUndefined();
+    expect(set.getByProtocolId('m2')).toBeUndefined();
+    expect(set.hasAgicashId('q1')).toBe(false);
+  });
+});

--- a/packages/wallet-sdk/src/internal/orchestrator-working-set.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator-working-set.ts
@@ -1,0 +1,88 @@
+/**
+ * Orchestrator in-flight working-set — Slice 3 / PR5d.
+ *
+ * The framework-free replacement for the TanStack caches master's `useProcess*Tasks` hooks read
+ * (`unresolved*Cache.get(id)` / `getByMeltQuoteId` / `getByMintQuoteId`). It is the contract's
+ * §0 state kind 1 — "the quotes/swaps a running orchestrator is actively driving (a task queue,
+ * bounded)" — NOT a domain cache: it holds NO entity bodies, only the protocol-id → agicash-id
+ * INDEX a WebSocket/Breez update needs to find which agicash quote a mint event refers to.
+ *
+ * WHY this exists (the #1 correctness substitution). A mint melt/mint-quote WS update arrives keyed
+ * by the MINT's quote id, and a Breez event by the spark transfer/payment id — not by the agicash
+ * quote id. Master resolved that mapping by scanning a TanStack cache of full quotes. The SDK has
+ * no such cache, so on the WS/Breez signal it:
+ *   1. resolves `protocolId → agicashId` from THIS index (registered at `executeQuote` kickoff +
+ *      refreshed by a resume sweep), then
+ *   2. reads FRESH state from the DB via `repo.get(agicashId)` — never from a stale in-memory body.
+ * That two-step (index here, body from DB) is exactly the no-cache design: double-spend / stale-
+ * proof / missed-terminal cannot hide in a body this set never stores.
+ *
+ * Entries are removed when a quote reaches a terminal state (so the set stays bounded to in-flight
+ * work) and cleared on `destroy()`.
+ *
+ * @module
+ */
+
+/** A single tracked in-flight quote/swap: the protocol-id keys that map back to its agicash id. */
+type TrackedEntry = {
+  /** The agicash quote/swap id (the DB primary key the orchestrator reads state by). */
+  agicashId: string;
+  /** The mint URL the quote's mint WS subscription / source wallet uses (cashu only). */
+  mintUrl?: string;
+};
+
+/**
+ * A bounded index of the quotes/swaps a running orchestrator is actively driving, keyed by the
+ * protocol id carried on external signals. NOT a domain cache (holds no entity bodies).
+ */
+export class OrchestratorWorkingSet {
+  /** protocol-quote-id (mint melt/mint quote id, or spark transfer/payment id) → tracked entry. */
+  private readonly byProtocolId = new Map<string, TrackedEntry>();
+  /** agicash-id → the protocol id it was registered under (so terminal removal can clean both). */
+  private readonly protocolIdByAgicashId = new Map<string, string>();
+
+  /**
+   * Register an in-flight quote/swap. Idempotent — re-registering the same pair refreshes it.
+   *
+   * @param params.protocolId - the id external signals carry (mint quote id / spark id).
+   * @param params.agicashId - the agicash quote/swap id to read DB state by.
+   * @param params.mintUrl - the mint URL (cashu) for the WS subscription / source wallet.
+   */
+  track(params: {
+    protocolId: string;
+    agicashId: string;
+    mintUrl?: string;
+  }): void {
+    const { protocolId, agicashId, mintUrl } = params;
+    this.byProtocolId.set(protocolId, { agicashId, mintUrl });
+    this.protocolIdByAgicashId.set(agicashId, protocolId);
+  }
+
+  /** Resolve the agicash id (+ mint URL) for a protocol id, or undefined if not tracked. */
+  getByProtocolId(protocolId: string): TrackedEntry | undefined {
+    return this.byProtocolId.get(protocolId);
+  }
+
+  /** Whether an agicash quote/swap is currently being driven. */
+  hasAgicashId(agicashId: string): boolean {
+    return this.protocolIdByAgicashId.has(agicashId);
+  }
+
+  /**
+   * Stop tracking a quote/swap by its agicash id (called when it reaches a terminal state).
+   * No-op if not tracked.
+   */
+  untrackByAgicashId(agicashId: string): void {
+    const protocolId = this.protocolIdByAgicashId.get(agicashId);
+    if (protocolId !== undefined) {
+      this.byProtocolId.delete(protocolId);
+      this.protocolIdByAgicashId.delete(agicashId);
+    }
+  }
+
+  /** Drop everything (called on `Sdk.destroy()`). */
+  clear(): void {
+    this.byProtocolId.clear();
+    this.protocolIdByAgicashId.clear();
+  }
+}

--- a/packages/wallet-sdk/src/internal/orchestrator.test.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator.test.ts
@@ -1,0 +1,854 @@
+/**
+ * Orchestrator state-machine tests — Slice 3 / PR5d (the riskiest slice).
+ *
+ * Pumps each machine via its manually-pumpable `step*` core (NO live WS / Breez loop needed) with
+ * fake repos + services, asserting:
+ *  - each DB-state → service-call → event transition (the cache→DB substitution: every step reads
+ *    fresh repo state, never a cached body);
+ *  - idempotency (a step on an already-terminal / missing quote is a safe no-op — no service call,
+ *    no event);
+ *  - the classify-verdict → error-model handling threaded through `runStep`.
+ *
+ * The fakes implement only the methods each test path touches.
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import { MeltQuoteState, MintQuoteState } from '@cashu/cashu-ts';
+import { Orchestrator, type OrchestratorDeps } from './orchestrator';
+import { TypedEventEmitter } from './event-emitter';
+import { DomainError } from '../errors';
+import type { SdkEventMap } from '../types/events';
+import { type Currency, Money } from '../types/money';
+import type { CashuAccount, SparkAccount } from '../types/account';
+import type { CashuSendQuote } from '../types/cashu';
+import type { SparkSendQuote } from '../types/spark';
+
+// -- Helpers --------------------------------------------------------------------------------
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+/**
+ * Assert a captured event matches the expected name + payload. `Money` payload fields are compared
+ * by VALUE (`.toString()`), since two equal `Money` instances are distinct objects that bun's
+ * `toEqual` treats as unequal.
+ */
+function expectEvent(
+  captured: { event: keyof SdkEventMap; data: unknown }[],
+  index: number,
+  expected: { event: keyof SdkEventMap } & Record<string, unknown>,
+): void {
+  const actual = captured[index];
+  expect(actual).toBeDefined();
+  expect(actual?.event).toBe(expected.event);
+  const data = actual?.data as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    if (key === 'event') continue;
+    if (value instanceof Money) {
+      expect((data[key] as Money).toString()).toBe(value.toString());
+    } else {
+      expect(data[key]).toEqual(value);
+    }
+  }
+}
+
+/** A fake cashu account whose wallet methods the tested paths don't reach (only `.mintUrl`/`.id` used). */
+const cashuAccount = (id = 'acc-cashu'): CashuAccount =>
+  ({
+    id,
+    type: 'cashu',
+    mintUrl: 'https://mint.test',
+    currency: 'BTC',
+    proofs: [],
+    wallet: {},
+  }) as unknown as CashuAccount;
+
+const sparkAccount = (id = 'acc-spark'): SparkAccount =>
+  ({
+    id,
+    type: 'spark',
+    currency: 'BTC',
+    wallet: {},
+  }) as unknown as SparkAccount;
+
+/** A melt-quote update in a given state (only the fields the machines read). */
+const meltUpdate = (
+  quote: string,
+  state: MeltQuoteState,
+  overrides: { expiry?: number; amount?: number } = {},
+) =>
+  ({
+    quote,
+    state,
+    amount: overrides.amount ?? 100,
+    fee_reserve: 1,
+    expiry: overrides.expiry ?? Math.floor(Date.now() / 1000) + 3600,
+  }) as never;
+
+const mintUpdate = (quote: string, state: MintQuoteState) =>
+  ({ quote, state, request: 'lnbc1...', unit: 'sat' }) as never;
+
+/** Build an Orchestrator over a deps object whose unused members are inert. */
+function makeOrchestrator(overrides: Partial<OrchestratorDeps>): {
+  orchestrator: Orchestrator;
+  events: TypedEventEmitter<SdkEventMap>;
+  captured: { event: keyof SdkEventMap; data: unknown }[];
+} {
+  const events = new TypedEventEmitter<SdkEventMap>();
+  const captured: { event: keyof SdkEventMap; data: unknown }[] = [];
+  for (const name of [
+    'send:pending',
+    'send:completed',
+    'send:failed',
+    'receive:completed',
+    'receive:expired',
+    'receive:failed',
+  ] as (keyof SdkEventMap)[]) {
+    events.on(name, (data) => captured.push({ event: name, data }));
+  }
+
+  const deps = {
+    events,
+    accounts: { get: mock(async () => null) },
+    cashuSendQuoteService: {},
+    cashuSendQuoteRepository: {},
+    cashuSendSwapService: {},
+    cashuSendSwapRepository: {},
+    cashuReceiveQuoteService: {},
+    cashuReceiveQuoteRepository: {},
+    cashuReceiveSwapService: {},
+    cashuReceiveSwapRepository: {},
+    sparkSendQuoteService: {},
+    sparkSendQuoteRepository: {},
+    sparkReceiveQuoteService: {},
+    sparkReceiveQuoteRepository: {},
+    ...overrides,
+  } as unknown as OrchestratorDeps;
+
+  // Inject inert subscription managers so kickoff tests don't open real mint WebSockets (the live
+  // managers are lift-tested separately; the machine cores are pumped directly via `step*`).
+  const unsubscribe = () => {
+    /* no-op unsubscribe */
+  };
+  const noopSub = {
+    subscribe: mock(async () => unsubscribe),
+    removeQuoteFromSubscription: mock(() => {
+      /* no-op */
+    }),
+    closeAll: mock(async () => {
+      /* no-op */
+    }),
+  } as never;
+
+  const orchestrator = new Orchestrator(deps, {
+    melt: noopSub,
+    mint: noopSub,
+  });
+  return { orchestrator, events, captured };
+}
+
+const baseSendQuote = (
+  over: Partial<CashuSendQuote> & { state: CashuSendQuote['state'] },
+): CashuSendQuote =>
+  ({
+    id: 'sq1',
+    userId: 'u1',
+    accountId: 'acc-cashu',
+    transactionId: 'tx1',
+    quoteId: 'melt-1',
+    amountReceived: sats(100),
+    ...over,
+  }) as CashuSendQuote;
+
+const baseSparkQuote = (
+  over: Partial<SparkSendQuote> & { state: SparkSendQuote['state'] },
+): SparkSendQuote =>
+  ({
+    id: 'ssq1',
+    userId: 'u1',
+    accountId: 'acc-spark',
+    transactionId: 'tx1',
+    amount: sats(100),
+    ...over,
+  }) as SparkSendQuote;
+
+// -- CASHU lightning SEND ----------------------------------------------------------------------
+
+describe('Orchestrator — cashu lightning send machine', () => {
+  test('UNPAID melt update on an UNPAID quote initiates the send (DB-read, not cache)', async () => {
+    const quote = baseSendQuote({ state: 'UNPAID' });
+    const get = mock(async () => quote);
+    const initiateSend = mock(async () => undefined);
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { initiateSend } as never,
+    });
+
+    // Register the in-flight quote (what executeQuote does at kickoff) then pump the WS signal.
+    await orchestrator.executeCashuSendQuote(quote);
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('melt-1', MeltQuoteState.UNPAID),
+    );
+
+    // It re-read DB state (executeQuote's account fetch + the step's fetch) and initiated.
+    expect(get).toHaveBeenCalled();
+    expect(initiateSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('PAID melt update completes the send and emits send:completed', async () => {
+    const pending = baseSendQuote({ state: 'PENDING' });
+    const paid = baseSendQuote({
+      state: 'PAID',
+      paymentPreimage: 'pre',
+      lightningFee: sats(0),
+      amountSpent: sats(100),
+      totalFee: sats(0),
+    });
+    const get = mock(async () => pending);
+    const completeSendQuote = mock(async () => paid);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { completeSendQuote } as never,
+    });
+    await orchestrator.executeCashuSendQuote(pending);
+
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('melt-1', MeltQuoteState.PAID),
+    );
+
+    expect(completeSendQuote).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(1);
+    expectEvent(captured, 0, {
+      event: 'send:completed',
+      quoteId: 'sq1',
+      transactionId: 'tx1',
+      amount: paid.amountReceived,
+      protocol: 'cashu',
+    });
+  });
+
+  test('IDEMPOTENT: a melt update for an untracked quote is a no-op (no DB read, no service call)', async () => {
+    const get = mock(async () => null);
+    const completeSendQuote = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { completeSendQuote } as never,
+    });
+
+    // Never registered via executeQuote → not in the working set.
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('unknown-melt', MeltQuoteState.PAID),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(completeSendQuote).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+
+  test('IDEMPOTENT: a melt update on an already-PAID DB quote does not re-complete (untracks)', async () => {
+    const unpaid = baseSendQuote({ state: 'UNPAID' });
+    const paid = baseSendQuote({
+      state: 'PAID',
+      paymentPreimage: 'p',
+      lightningFee: sats(0),
+      amountSpent: sats(100),
+      totalFee: sats(0),
+    });
+    // executeQuote tracks the quote (reads only the account); the step then reads PAID (terminal)
+    // from the DB → no-op, no re-completion.
+    const get = mock(async () => paid);
+    const completeSendQuote = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { completeSendQuote } as never,
+    });
+    await orchestrator.executeCashuSendQuote(unpaid);
+
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('melt-1', MeltQuoteState.PAID),
+    );
+
+    expect(completeSendQuote).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+
+  test('a DomainError from initiateSend fails the quote and emits send:failed', async () => {
+    const quote = baseSendQuote({ state: 'UNPAID' });
+    const get = mock(async () => quote);
+    const initiateSend = mock(async () => {
+      throw new DomainError('mint rejected');
+    });
+    const failSendQuote = mock(async () => quote);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { initiateSend, failSendQuote } as never,
+    });
+    await orchestrator.executeCashuSendQuote(quote);
+
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('melt-1', MeltQuoteState.UNPAID),
+    );
+
+    expect(failSendQuote).toHaveBeenCalledTimes(1);
+    expect(captured[0]?.event).toBe('send:failed');
+  });
+});
+
+// -- SPARK lightning SEND ----------------------------------------------------------------------
+
+describe('Orchestrator — spark lightning send machine', () => {
+  test('executeQuote initiates an UNPAID quote (→ PENDING) and emits send:pending', async () => {
+    const pending = baseSparkQuote({
+      state: 'PENDING',
+      sparkId: 's',
+      sparkTransferId: 't',
+      fee: sats(1),
+    });
+    const initiateSend = mock(async () => pending);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => sparkAccount()) } as never,
+      sparkSendQuoteService: { initiateSend } as never,
+    });
+
+    const result = await orchestrator.executeSparkSendQuote(
+      baseSparkQuote({ state: 'UNPAID' }),
+    );
+
+    expect(initiateSend).toHaveBeenCalledTimes(1);
+    expect(result.state).toBe('PENDING');
+    expect(captured).toEqual([
+      {
+        event: 'send:pending',
+        data: { quoteId: 'ssq1', transactionId: 'tx1', protocol: 'spark' },
+      },
+    ]);
+  });
+
+  test('stepSparkSendCompleted completes a PENDING quote and emits send:completed', async () => {
+    const pending = baseSparkQuote({
+      state: 'PENDING',
+      sparkId: 's',
+      sparkTransferId: 't',
+      fee: sats(1),
+    });
+    const get = mock(async () => pending);
+    const complete = mock(async () => pending);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkSendQuoteRepository: { get } as never,
+      sparkSendQuoteService: { complete } as never,
+    });
+
+    await orchestrator.stepSparkSendCompleted({
+      quoteId: 'ssq1',
+      paymentPreimage: 'pre',
+    });
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expectEvent(captured, 0, {
+      event: 'send:completed',
+      quoteId: 'ssq1',
+      transactionId: 'tx1',
+      amount: pending.amount,
+      protocol: 'spark',
+    });
+  });
+
+  test('IDEMPOTENT: stepSparkSendCompleted on a non-PENDING quote is a no-op', async () => {
+    const completed = baseSparkQuote({
+      state: 'COMPLETED',
+      sparkId: 's',
+      sparkTransferId: 't',
+      fee: sats(1),
+      paymentPreimage: 'p',
+    });
+    const get = mock(async () => completed);
+    const complete = mock(async () => completed);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkSendQuoteRepository: { get } as never,
+      sparkSendQuoteService: { complete } as never,
+    });
+
+    await orchestrator.stepSparkSendCompleted({
+      quoteId: 'ssq1',
+      paymentPreimage: 'pre',
+    });
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+
+  test('stepSparkSendFailed fails a PENDING quote and emits send:failed', async () => {
+    const pending = baseSparkQuote({
+      state: 'PENDING',
+      sparkId: 's',
+      sparkTransferId: 't',
+      fee: sats(1),
+    });
+    const get = mock(async () => pending);
+    const fail = mock(async () => pending);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkSendQuoteRepository: { get } as never,
+      sparkSendQuoteService: { fail } as never,
+    });
+
+    await orchestrator.stepSparkSendFailed({
+      quoteId: 'ssq1',
+      reason: 'payment failed',
+    });
+
+    expect(fail).toHaveBeenCalledTimes(1);
+    expect(captured[0]?.event).toBe('send:failed');
+  });
+});
+
+// -- CASHU lightning RECEIVE -------------------------------------------------------------------
+
+describe('Orchestrator — cashu lightning receive machine', () => {
+  const receiveQuote = (state: string) =>
+    ({
+      id: 'rq1',
+      type: 'LIGHTNING',
+      state,
+      accountId: 'acc-cashu',
+      transactionId: 'tx1',
+      quoteId: 'mint-1',
+      amount: sats(100),
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    }) as never;
+
+  test('PAID mint update completes the receive and emits receive:completed', async () => {
+    const unpaid = receiveQuote('UNPAID');
+    const completed = receiveQuote('COMPLETED');
+    const get = mock(async () => unpaid);
+    const completeReceive = mock(async () => ({
+      quote: completed,
+      account: cashuAccount(),
+      addedProofs: [],
+    }));
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { completeReceive } as never,
+    });
+    await orchestrator.startCashuReceiveQuote(unpaid);
+
+    await orchestrator.stepCashuReceiveQuote(
+      mintUpdate('mint-1', MintQuoteState.PAID),
+    );
+
+    expect(completeReceive).toHaveBeenCalledTimes(1);
+    expect(captured).toHaveLength(1);
+    expectEvent(captured, 0, {
+      event: 'receive:completed',
+      quoteId: 'rq1',
+      transactionId: 'tx1',
+      amount: sats(100),
+      protocol: 'cashu',
+    });
+  });
+
+  test('ISSUED mint update re-runs complete (recovery after a killed completion)', async () => {
+    const unpaid = receiveQuote('UNPAID');
+    const completed = receiveQuote('COMPLETED');
+    const get = mock(async () => unpaid);
+    const completeReceive = mock(async () => ({
+      quote: completed,
+      account: cashuAccount(),
+      addedProofs: [],
+    }));
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { completeReceive } as never,
+    });
+    await orchestrator.startCashuReceiveQuote(unpaid);
+
+    await orchestrator.stepCashuReceiveQuote(
+      mintUpdate('mint-1', MintQuoteState.ISSUED),
+    );
+
+    expect(completeReceive).toHaveBeenCalledTimes(1);
+  });
+
+  test('UNPAID + past-expiry mint update expires the receive and emits receive:expired', async () => {
+    const expiredQuote = {
+      id: 'rq1',
+      type: 'LIGHTNING',
+      state: 'UNPAID',
+      accountId: 'acc-cashu',
+      transactionId: 'tx1',
+      quoteId: 'mint-1',
+      amount: sats(100),
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    } as never;
+    const get = mock(async () => expiredQuote);
+    const expire = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { expire } as never,
+    });
+    await orchestrator.startCashuReceiveQuote(expiredQuote);
+
+    await orchestrator.stepCashuReceiveQuote(
+      mintUpdate('mint-1', MintQuoteState.UNPAID),
+    );
+
+    expect(expire).toHaveBeenCalledTimes(1);
+    expect(captured[0]?.event).toBe('receive:expired');
+  });
+
+  test('IDEMPOTENT: a mint update on a COMPLETED DB quote does not re-complete', async () => {
+    const unpaid = receiveQuote('UNPAID');
+    const completed = receiveQuote('COMPLETED');
+    // startCashuReceiveQuote tracks the quote (reads only the account); the step then reads
+    // COMPLETED (terminal) from the DB → no-op.
+    const get = mock(async () => completed);
+    const completeReceive = mock(async () => ({
+      quote: completed,
+      account: cashuAccount(),
+      addedProofs: [],
+    }));
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { completeReceive } as never,
+    });
+    await orchestrator.startCashuReceiveQuote(unpaid);
+
+    await orchestrator.stepCashuReceiveQuote(
+      mintUpdate('mint-1', MintQuoteState.PAID),
+    );
+
+    expect(completeReceive).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+});
+
+// -- SPARK lightning RECEIVE -------------------------------------------------------------------
+
+describe('Orchestrator — spark lightning receive machine', () => {
+  const sparkReceive = (state: string) =>
+    ({
+      id: 'srq1',
+      state,
+      accountId: 'acc-spark',
+      transactionId: 'tx1',
+      amount: sats(100),
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    }) as never;
+
+  test('stepSparkReceiveCompleted completes an UNPAID quote and emits receive:completed', async () => {
+    const unpaid = sparkReceive('UNPAID');
+    const get = mock(async () => unpaid);
+    const complete = mock(async () => unpaid);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkReceiveQuoteRepository: { get } as never,
+      sparkReceiveQuoteService: { complete } as never,
+    });
+
+    await orchestrator.stepSparkReceiveCompleted({
+      quoteId: 'srq1',
+      paymentPreimage: 'pre',
+      sparkTransferId: 'st',
+    });
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expectEvent(captured, 0, {
+      event: 'receive:completed',
+      quoteId: 'srq1',
+      transactionId: 'tx1',
+      amount: sats(100),
+      protocol: 'spark',
+    });
+  });
+
+  test('IDEMPOTENT: stepSparkReceiveCompleted on a non-UNPAID quote is a no-op', async () => {
+    const paid = sparkReceive('PAID');
+    const get = mock(async () => paid);
+    const complete = mock(async () => paid);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkReceiveQuoteRepository: { get } as never,
+      sparkReceiveQuoteService: { complete } as never,
+    });
+
+    await orchestrator.stepSparkReceiveCompleted({
+      quoteId: 'srq1',
+      paymentPreimage: 'pre',
+      sparkTransferId: 'st',
+    });
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+
+  test('stepSparkReceiveExpired expires an UNPAID quote and emits receive:expired', async () => {
+    const unpaid = sparkReceive('UNPAID');
+    const get = mock(async () => unpaid);
+    const expire = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      sparkReceiveQuoteRepository: { get } as never,
+      sparkReceiveQuoteService: { expire } as never,
+    });
+
+    await orchestrator.stepSparkReceiveExpired('srq1');
+
+    expect(expire).toHaveBeenCalledTimes(1);
+    expect(captured[0]?.event).toBe('receive:expired');
+  });
+});
+
+// -- CASHU token SEND (swap) -------------------------------------------------------------------
+
+describe('Orchestrator — cashu token send swap machine', () => {
+  const swap = (state: string, over: Record<string, unknown> = {}) =>
+    ({
+      id: 'sw1',
+      accountId: 'acc-cashu',
+      transactionId: 'tx1',
+      amountReceived: sats(100),
+      state,
+      ...over,
+    }) as never;
+
+  test('executeCashuSendSwap swaps a DRAFT swap to PENDING via swapForProofsToSend', async () => {
+    const draft = swap('DRAFT', {
+      keysetId: 'ks',
+      keysetCounter: 0,
+      outputAmounts: { send: [], change: [] },
+    });
+    const pending = swap('PENDING', { tokenHash: 'th', proofsToSend: [] });
+    let call = 0;
+    const get = mock(async () => (call++ === 0 ? draft : pending));
+    const swapForProofsToSend = mock(async () => undefined);
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendSwapRepository: { get } as never,
+      cashuSendSwapService: { swapForProofsToSend } as never,
+    });
+
+    const result = await orchestrator.executeCashuSendSwap(draft);
+
+    expect(swapForProofsToSend).toHaveBeenCalledTimes(1);
+    expect(result.state).toBe('PENDING');
+  });
+
+  test('stepCashuSendSwapSpent completes a PENDING swap and emits send:completed', async () => {
+    const pending = swap('PENDING', { tokenHash: 'th', proofsToSend: [] });
+    const get = mock(async () => pending);
+    const complete = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      cashuSendSwapRepository: { get } as never,
+      cashuSendSwapService: { complete } as never,
+    });
+
+    await orchestrator.stepCashuSendSwapSpent('sw1');
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expectEvent(captured, 0, {
+      event: 'send:completed',
+      quoteId: 'sw1',
+      transactionId: 'tx1',
+      amount: sats(100),
+      protocol: 'cashu',
+    });
+  });
+
+  test('IDEMPOTENT: stepCashuSendSwapSpent on a non-PENDING swap is a no-op', async () => {
+    const completed = swap('COMPLETED', { tokenHash: 'th', proofsToSend: [] });
+    const get = mock(async () => completed);
+    const complete = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      cashuSendSwapRepository: { get } as never,
+      cashuSendSwapService: { complete } as never,
+    });
+
+    await orchestrator.stepCashuSendSwapSpent('sw1');
+
+    expect(complete).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+});
+
+// -- CASHU same-mint token RECEIVE (swap) ------------------------------------------------------
+
+describe('Orchestrator — cashu same-mint receive swap machine', () => {
+  test('stepCashuReceiveSwap completes a PENDING swap and emits receive:completed', async () => {
+    const pendingSwap = {
+      tokenHash: 'th1',
+      state: 'PENDING',
+      accountId: 'acc-cashu',
+      userId: 'u1',
+    } as never;
+    const completedSwap = {
+      tokenHash: 'th1',
+      state: 'COMPLETED',
+      transactionId: 'tx1',
+      amountReceived: sats(50),
+    };
+    const getPending = mock(async () => [pendingSwap]);
+    const completeSwap = mock(async () => ({
+      swap: completedSwap,
+      account: cashuAccount(),
+      addedProofs: [],
+    }));
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveSwapRepository: { getPending } as never,
+      cashuReceiveSwapService: { completeSwap } as never,
+    });
+
+    await orchestrator.stepCashuReceiveSwap('th1', 'u1');
+
+    expect(completeSwap).toHaveBeenCalledTimes(1);
+    expectEvent(captured, 0, {
+      event: 'receive:completed',
+      quoteId: 'tx1',
+      transactionId: 'tx1',
+      amount: sats(50),
+      protocol: 'cashu',
+    });
+  });
+
+  test('IDEMPOTENT: stepCashuReceiveSwap with no matching pending swap is a no-op', async () => {
+    const getPending = mock(async () => []);
+    const completeSwap = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      cashuReceiveSwapRepository: { getPending } as never,
+      cashuReceiveSwapService: { completeSwap } as never,
+    });
+
+    await orchestrator.stepCashuReceiveSwap('th-missing', 'u1');
+
+    expect(completeSwap).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+});
+
+// -- CROSS-ACCOUNT token RECEIVE (melt machine) -----------------------------------------------
+
+describe('Orchestrator — cross-account cashu-token melt machine', () => {
+  const tokenReceiveQuote = (
+    over: { meltInitiated?: boolean; expiresAt?: string } = {},
+  ) =>
+    ({
+      id: 'crq1',
+      type: 'CASHU_TOKEN',
+      state: 'UNPAID',
+      accountId: 'acc-cashu',
+      transactionId: 'tx1',
+      quoteId: 'mint-dest-1',
+      amount: sats(90),
+      expiresAt:
+        over.expiresAt ?? new Date(Date.now() + 3600_000).toISOString(),
+      tokenReceiveData: {
+        sourceMintUrl: 'https://source-mint.test',
+        meltQuoteId: 'src-melt-1',
+        tokenAmount: sats(100),
+        tokenProofs: [],
+        meltInitiated: over.meltInitiated ?? false,
+      },
+    }) as never;
+
+  test('PENDING source-melt update marks the melt initiated', async () => {
+    const quote = tokenReceiveQuote();
+    const get = mock(async () => quote);
+    const markMeltInitiated = mock(async () => quote);
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { markMeltInitiated } as never,
+    });
+    await orchestrator.startCashuTokenReceiveQuote(quote);
+
+    await orchestrator.stepCashuTokenReceiveMelt(
+      meltUpdate('src-melt-1', MeltQuoteState.PENDING),
+    );
+
+    expect(markMeltInitiated).toHaveBeenCalledTimes(1);
+  });
+
+  test('UNPAID-again after the melt was initiated FAILS the receive (the melt failed)', async () => {
+    const quote = tokenReceiveQuote({ meltInitiated: true });
+    const get = mock(async () => quote);
+    const fail = mock(async () => undefined);
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { fail } as never,
+    });
+    await orchestrator.startCashuTokenReceiveQuote(quote);
+
+    await orchestrator.stepCashuTokenReceiveMelt(
+      meltUpdate('src-melt-1', MeltQuoteState.UNPAID),
+    );
+
+    expect(fail).toHaveBeenCalledTimes(1);
+  });
+
+  test('a past-expiry UNPAID source-melt update expires the receive and emits receive:expired', async () => {
+    const quote = tokenReceiveQuote({
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    const get = mock(async () => quote);
+    const expire = mock(async () => undefined);
+    const { orchestrator, captured } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { expire } as never,
+    });
+    await orchestrator.startCashuTokenReceiveQuote(quote);
+
+    await orchestrator.stepCashuTokenReceiveMelt(
+      meltUpdate('src-melt-1', MeltQuoteState.UNPAID, {
+        expiry: Math.floor(Date.now() / 1000) - 10,
+      }),
+    );
+
+    expect(expire).toHaveBeenCalledTimes(1);
+    expect(captured[0]?.event).toBe('receive:expired');
+  });
+
+  test('IDEMPOTENT: a melt update for an untracked cross-account quote is a no-op', async () => {
+    const get = mock(async () => null);
+    const markMeltInitiated = mock(async () => undefined);
+    const { orchestrator } = makeOrchestrator({
+      cashuReceiveQuoteRepository: { get } as never,
+      cashuReceiveQuoteService: { markMeltInitiated } as never,
+    });
+
+    await orchestrator.stepCashuTokenReceiveMelt(
+      meltUpdate('not-tracked', MeltQuoteState.PENDING),
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(markMeltInitiated).not.toHaveBeenCalled();
+  });
+});
+
+// -- Lifecycle ----------------------------------------------------------------------------------
+
+describe('Orchestrator — destroy', () => {
+  test('destroy clears the in-flight indices (a later step for a tracked quote is a no-op)', async () => {
+    const quote = baseSendQuote({ state: 'UNPAID' });
+    const get = mock(async () => quote);
+    const initiateSend = mock(async () => undefined);
+    const { orchestrator } = makeOrchestrator({
+      accounts: { get: mock(async () => cashuAccount()) } as never,
+      cashuSendQuoteRepository: { get } as never,
+      cashuSendQuoteService: { initiateSend } as never,
+    });
+    await orchestrator.executeCashuSendQuote(quote);
+
+    await orchestrator.destroy();
+    // After destroy the working set is cleared, so the signal resolves nothing.
+    await orchestrator.stepCashuSendQuote(
+      meltUpdate('melt-1', MeltQuoteState.UNPAID),
+    );
+
+    expect(initiateSend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/wallet-sdk/src/internal/orchestrator.ts
+++ b/packages/wallet-sdk/src/internal/orchestrator.ts
@@ -1,0 +1,1049 @@
+/**
+ * The unified `executeQuote` ORCHESTRATOR — Slice 3 / PR5d. The build plan's single biggest
+ * net-new construct (master has NO `executeQuote`).
+ *
+ * This is a framework-free state machine that absorbs master's six React-resident
+ * `useProcess*Tasks` hooks (each a TanStack mutation + retry/`MintOperationError` branch + a live
+ * mint-WS `*SubscriptionManager` / Breez event listener) into plain async methods. It DRIVES the
+ * idempotent service primitives PR5b/5c already built (`initiateSend` / `markSendQuoteAsPending` /
+ * `completeSendQuote` / `failSendQuote`, the swap/claim/receive services, with their `wallet.restore`
+ * recovery + DB reservation / CONCURRENCY_ERROR guards) — it does NOT reimplement them.
+ *
+ * THE #1 CORRECTNESS SUBSTITUTION — DB-read, not cache. Master's hooks read
+ * `unresolved*Cache.get(id)` (a TanStack cache) on every WS/Breez signal. The SDK has NO cache:
+ * every such read is replaced by a FRESH DB read through the existing repos
+ * ({@link OrchestratorDeps}), resolved via the {@link OrchestratorWorkingSet} index
+ * (protocol-quote-id → agicash-id). Getting this right is where double-spend / stale-proof /
+ * missed-terminal would hide; each `step*` re-reads the DB and re-validates the current state
+ * before acting, exactly mirroring the master hook's branch but without the cache.
+ *
+ * TWO ENTRY POINTS, ONE MACHINE.
+ *  - The KICKOFF path (`executeCashuSendQuote` / `executeSparkSendQuote` / `start*Receive*`) takes
+ *    the FULL object the caller already has, opens the live subscription/listener for it, and
+ *    returns immediately (resolves on KICK-OFF). The terminal state arrives via `send:completed` /
+ *    `send:failed` (+ a later `.get(id)`).
+ *  - The `step*(signal)` methods are the manually-pumpable CORE: each takes a single external
+ *    signal (a mint melt/mint-quote update, or a spark payment outcome), reads DB state, and runs
+ *    the right service primitive through {@link runStep} (retry + verdict→error-model). They are
+ *    what the live subscriptions call AND what the unit tests pump directly (NO live loop needed).
+ *
+ * The leader-gated autonomous PROCESSOR (the resume sweep that finds in-flight work in the DB and
+ * pumps these same machines headless) is **Slice 5 / a later PR** — NOT built here. This slice
+ * builds the machine CORE so it is reviewable + testable via direct kickoff + `step*`.
+ *
+ * @module
+ */
+import {
+  type MeltQuoteBolt11Response,
+  MeltQuoteState,
+  type MintQuoteBolt11Response,
+  MintQuoteState,
+  type Proof,
+} from '@cashu/cashu-ts';
+import type { AccountRepository } from './account-repository';
+import type { CashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
+import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+import type {
+  CashuReceiveSwap,
+  CashuReceiveSwapRepository,
+} from './cashu-receive-swap-repository';
+import type { CashuReceiveSwapService } from './cashu-receive-swap-service';
+import type { CashuSendQuoteRepository } from './cashu-send-quote-repository';
+import type { CashuSendQuoteService } from './cashu-send-quote-service';
+import type { CashuSendSwapRepository } from './cashu-send-swap-repository';
+import type { CashuSendSwapService } from './cashu-send-swap-service';
+import { type ExtendedCashuWallet, getCashuWallet } from './lib-cashu-wallet';
+import { getCashuUnit } from './lib-cashu-quotes';
+import { MeltQuoteSubscriptionManager } from './melt-quote-subscription-manager';
+import { MintQuoteSubscriptionManager } from './mint-quote-subscription-manager';
+import { OrchestratorWorkingSet } from './orchestrator-working-set';
+import { runStep } from './orchestrator-retry';
+import type { SparkReceiveQuoteRepository } from './spark-receive-quote-repository';
+import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
+import type { SparkSendQuoteRepository } from './spark-send-quote-repository';
+import type { SparkSendQuoteService } from './spark-send-quote-service';
+import { ConcurrencyError, DomainError } from '../errors';
+import type { TypedEventEmitter } from './event-emitter';
+import type { SdkEventMap } from '../types/events';
+import type { Account, CashuAccount, SparkAccount } from '../types/account';
+import type { Currency, Money } from '../types/money';
+import type {
+  CashuReceiveQuote,
+  CashuSendQuote,
+  CashuSendSwap,
+} from '../types/cashu';
+import type { SparkReceiveQuote, SparkSendQuote } from '../types/spark';
+
+/**
+ * The SDK-internal collaborators the orchestrator drives. All are the SAME instances `Sdk.create`
+ * builds for the public domains — the orchestrator shares them so a kickoff and the (future)
+ * processor act on one source of truth (the DB + the live wallet handles).
+ */
+export type OrchestratorDeps = {
+  accounts: AccountRepository;
+  events: TypedEventEmitter<SdkEventMap>;
+  cashuSendQuoteService: CashuSendQuoteService;
+  cashuSendQuoteRepository: CashuSendQuoteRepository;
+  cashuSendSwapService: CashuSendSwapService;
+  cashuSendSwapRepository: CashuSendSwapRepository;
+  cashuReceiveQuoteService: CashuReceiveQuoteService;
+  cashuReceiveQuoteRepository: CashuReceiveQuoteRepository;
+  cashuReceiveSwapService: CashuReceiveSwapService;
+  cashuReceiveSwapRepository: CashuReceiveSwapRepository;
+  sparkSendQuoteService: SparkSendQuoteService;
+  sparkSendQuoteRepository: SparkSendQuoteRepository;
+  sparkReceiveQuoteService: SparkReceiveQuoteService;
+  sparkReceiveQuoteRepository: SparkReceiveQuoteRepository;
+};
+
+/**
+ * The orchestrator. Holds the in-flight working-sets + the live subscription managers, and exposes
+ * the kickoff methods (called by the public domains) + the manually-pumpable `step*` cores (called
+ * by the subscriptions and by tests).
+ */
+export class Orchestrator {
+  /** cashu SEND-quote in-flight index (melt-quote-id → agicash send-quote id). */
+  private readonly cashuSendSet = new OrchestratorWorkingSet();
+  /** cashu RECEIVE-quote in-flight index (mint-quote-id → agicash receive-quote id, LIGHTNING). */
+  private readonly cashuReceiveSet = new OrchestratorWorkingSet();
+  /** cashu cross-account token-receive in-flight index (melt-quote-id → agicash receive-quote id). */
+  private readonly cashuTokenReceiveSet = new OrchestratorWorkingSet();
+  /** spark cross-account token-receive in-flight index (melt-quote-id → agicash spark-receive id). */
+  private readonly sparkTokenReceiveSet = new OrchestratorWorkingSet();
+
+  /** Mint melt-quote WS manager (cashu sends + cross-account token receives), wallet factory injected. */
+  private readonly meltSubscriptions: MeltQuoteSubscriptionManager;
+  /** Mint mint-quote WS manager (cashu lightning receives), wallet factory injected. */
+  private readonly mintSubscriptions: MintQuoteSubscriptionManager;
+
+  /**
+   * @param deps - the SDK-internal collaborators to drive.
+   * @param subscriptions - the live mint-WS managers (injectable for tests). Default: real managers
+   *   over a bare `getCashuWallet(mintUrl)` factory — sufficient for the WS protocol (subscriptions
+   *   only need the mint socket, not loaded keysets); state-changing steps fetch the FULL account
+   *   (keyset-loaded `ExtendedCashuWallet`) from the DB before acting.
+   */
+  constructor(
+    private readonly deps: OrchestratorDeps,
+    subscriptions?: {
+      melt: MeltQuoteSubscriptionManager;
+      mint: MintQuoteSubscriptionManager;
+    },
+  ) {
+    this.meltSubscriptions =
+      subscriptions?.melt ??
+      new MeltQuoteSubscriptionManager((mintUrl) => getCashuWallet(mintUrl));
+    this.mintSubscriptions =
+      subscriptions?.mint ??
+      new MintQuoteSubscriptionManager((mintUrl) => getCashuWallet(mintUrl));
+  }
+
+  // ===========================================================================================
+  // CASHU lightning SEND — drives UNPAID → PENDING → PAID off the mint melt-quote WS.
+  // Source: send/cashu-send-quote-hooks.ts#useProcessCashuSendQuoteTasks (+ useOnMeltQuoteStateChange).
+  // ===========================================================================================
+
+  /**
+   * KICKOFF a cashu lightning send. Registers the quote in the in-flight index, opens the melt-quote
+   * WS subscription for its mint (which will pump {@link stepCashuSendQuote} on each update), and
+   * returns the quote in its current state. Terminal arrives via `send:completed` / `send:failed`.
+   *
+   * @param quote - the FULL send quote (UNPAID on kickoff).
+   * @returns the same quote (resolves on kick-off; does NOT block until terminal).
+   */
+  async executeCashuSendQuote(quote: CashuSendQuote): Promise<CashuSendQuote> {
+    if (quote.state !== 'UNPAID' && quote.state !== 'PENDING') {
+      // Nothing to drive — already terminal.
+      return quote;
+    }
+    const account = await this.requireCashuAccount(quote.accountId);
+    this.cashuSendSet.track({
+      protocolId: quote.quoteId,
+      agicashId: quote.id,
+      mintUrl: account.mintUrl,
+    });
+    await this.trySubscribeMelt({
+      mintUrl: account.mintUrl,
+      quoteIds: [quote.quoteId],
+      onUpdate: (meltQuote) => {
+        void this.stepCashuSendQuote(meltQuote);
+      },
+    });
+    return quote;
+  }
+
+  /**
+   * STEP the cashu send machine on a melt-quote update. Manually pumpable (the unit tests call this
+   * directly). Resolves the agicash send quote from the in-flight index → reads FRESH DB state →
+   * branches on the melt state exactly as master's `useOnMeltQuoteStateChange` does
+   * (`onUnpaid`→initiate, `onPending`→markPending, `onPaid`→complete, `onExpired`→expire), each
+   * through {@link runStep}.
+   *
+   * @param meltQuote - the mint's melt-quote update.
+   */
+  async stepCashuSendQuote(meltQuote: MeltQuoteBolt11Response): Promise<void> {
+    const tracked = this.cashuSendSet.getByProtocolId(meltQuote.quote);
+    if (!tracked) {
+      return;
+    }
+    // DB-READ (not cache): the authoritative current state of the send quote.
+    const sendQuote = await this.deps.cashuSendQuoteRepository.get(
+      tracked.agicashId,
+    );
+    if (!sendQuote || this.isCashuSendTerminal(sendQuote)) {
+      // Removed / completed / failed in the meantime — stop tracking.
+      this.cashuSendSet.untrackByAgicashId(tracked.agicashId);
+      return;
+    }
+    const account = await this.requireCashuAccount(sendQuote.accountId);
+
+    if (meltQuote.state === MeltQuoteState.UNPAID) {
+      // The mint flips the melt quote back to UNPAID on a failed payment; only (re-)initiate while
+      // OUR quote is also UNPAID (an already-initiated send must not be re-sent). Master verbatim.
+      if (sendQuote.state === 'UNPAID') {
+        await this.initiateCashuSend(account, sendQuote, meltQuote);
+      }
+    } else if (meltQuote.state === MeltQuoteState.PENDING) {
+      await runStep(() =>
+        this.deps.cashuSendQuoteService.markSendQuoteAsPending(sendQuote),
+      );
+    } else if (meltQuote.state === MeltQuoteState.PAID) {
+      await this.completeCashuSend(account, sendQuote, meltQuote);
+    }
+  }
+
+  /**
+   * Initiate the send (mint melt-proofs), failing the quote on a `MintOperationError` exactly as
+   * master's `initiateSend` mutation does (`onError` → `failSendQuote`). The `already-resolved`
+   * verdict (the melt already happened) is a no-op — the PENDING/PAID WS update will complete it.
+   */
+  private async initiateCashuSend(
+    account: CashuAccount,
+    sendQuote: CashuSendQuote,
+    meltQuote: MeltQuoteBolt11Response,
+  ): Promise<void> {
+    try {
+      const outcome = await runStep(() =>
+        this.deps.cashuSendQuoteService.initiateSend(
+          account,
+          sendQuote,
+          meltQuote,
+        ),
+      );
+      if (outcome.kind === 'already-resolved') {
+        // The melt already happened (idempotent re-issue) — the completion path picks it up.
+        return;
+      }
+    } catch (error) {
+      // A permanent rejection (→ DomainError) means the mint will never accept this send. Master
+      // fails the quote in that case so the user can retry; mirror that here. A transient failure
+      // (→ ConcurrencyError) is left for the next signal / resume sweep.
+      if (error instanceof DomainError) {
+        await this.failCashuSendQuote(account, sendQuote, error.message);
+        return;
+      }
+      // ConcurrencyError / anything else — surface so the caller (kickoff) or processor retries.
+      throw error;
+    }
+  }
+
+  /** Complete the send (derive + match NUT-08 change), emit `send:completed`, stop tracking. */
+  private async completeCashuSend(
+    account: CashuAccount,
+    sendQuote: CashuSendQuote,
+    meltQuote: MeltQuoteBolt11Response,
+  ): Promise<void> {
+    const outcome = await runStep(() =>
+      this.deps.cashuSendQuoteService.completeSendQuote(
+        account,
+        sendQuote,
+        meltQuote,
+      ),
+    );
+    // The completion is terminal either way (resolved OR already-resolved-by-restore).
+    const completed =
+      outcome.kind === 'resolved'
+        ? outcome.value
+        : await this.deps.cashuSendQuoteRepository.get(sendQuote.id);
+    this.cashuSendSet.untrackByAgicashId(sendQuote.id);
+    this.meltSubscriptions.removeQuoteFromSubscription({
+      mintUrl: account.mintUrl,
+      quoteId: sendQuote.quoteId,
+    });
+    if (completed && completed.state === 'PAID') {
+      this.deps.events.emit('send:completed', {
+        quoteId: completed.id,
+        transactionId: completed.transactionId,
+        amount: completed.amountReceived,
+        protocol: 'cashu',
+      });
+    }
+  }
+
+  /** Fail the send quote, emit `send:failed`, stop tracking + drop the WS subscription for it. */
+  private async failCashuSendQuote(
+    account: CashuAccount,
+    sendQuote: CashuSendQuote,
+    reason: string,
+  ): Promise<void> {
+    await runStep(() =>
+      this.deps.cashuSendQuoteService.failSendQuote(account, sendQuote, reason),
+    );
+    this.cashuSendSet.untrackByAgicashId(sendQuote.id);
+    this.meltSubscriptions.removeQuoteFromSubscription({
+      mintUrl: account.mintUrl,
+      quoteId: sendQuote.quoteId,
+    });
+    this.deps.events.emit('send:failed', {
+      quoteId: sendQuote.id,
+      error: new DomainError(reason),
+      protocol: 'cashu',
+    });
+  }
+
+  private isCashuSendTerminal(quote: CashuSendQuote): boolean {
+    return (
+      quote.state === 'PAID' ||
+      quote.state === 'FAILED' ||
+      quote.state === 'EXPIRED'
+    );
+  }
+
+  // ===========================================================================================
+  // CASHU token SEND (swap) — drives DRAFT → PENDING → COMPLETED.
+  // Source: send/cashu-send-swap-hooks.ts#useProcessCashuSendSwapTasks (proof-state sub + draft trigger).
+  // ===========================================================================================
+
+  /**
+   * KICKOFF / advance a cashu token send. A DRAFT swap is swapped for the exact proofs-to-send
+   * (→ PENDING); a PENDING swap is left for its proofs to be spent (the proof-state watcher /
+   * resume sweep completes it). Returns the swap in its current state. Master's hook does the DRAFT
+   * swap via a trigger query + completes on proof-spent.
+   *
+   * @param swap - the FULL token-send swap.
+   * @returns the swap (PENDING after a DRAFT swap, else unchanged).
+   */
+  async executeCashuSendSwap(swap: CashuSendSwap): Promise<CashuSendSwap> {
+    if (swap.state === 'DRAFT') {
+      return this.stepCashuSendSwapDraft(swap);
+    }
+    // PENDING swaps complete when their proofs are detected spent (proof-state subscription /
+    // resume sweep) — nothing to kick off here.
+    return swap;
+  }
+
+  /**
+   * STEP a DRAFT token-send swap → swap input proofs for proofs-to-send (→ PENDING). Reads FRESH
+   * DB state first. Manually pumpable.
+   *
+   * @param swap - the swap to advance (re-read from the DB).
+   * @returns the (re-read) swap after the step.
+   */
+  async stepCashuSendSwapDraft(swap: CashuSendSwap): Promise<CashuSendSwap> {
+    const fresh = await this.deps.cashuSendSwapRepository.get(swap.id);
+    if (!fresh || fresh.state !== 'DRAFT') {
+      return fresh ?? swap;
+    }
+    const account = await this.requireCashuAccount(fresh.accountId);
+    await runStep(() =>
+      this.deps.cashuSendSwapService.swapForProofsToSend({
+        account,
+        swap: fresh,
+      }),
+    );
+    return (await this.deps.cashuSendSwapRepository.get(swap.id)) ?? fresh;
+  }
+
+  /**
+   * STEP a PENDING token-send swap → mark COMPLETED (called when its proofs are detected spent).
+   * Reads FRESH DB state, emits `send:completed`. Manually pumpable.
+   *
+   * @param swapId - the agicash swap id whose proofs were spent.
+   */
+  async stepCashuSendSwapSpent(swapId: string): Promise<void> {
+    const swap = await this.deps.cashuSendSwapRepository.get(swapId);
+    if (!swap || swap.state !== 'PENDING') {
+      return;
+    }
+    const outcome = await runStep(() =>
+      this.deps.cashuSendSwapService.complete(swap),
+    );
+    if (outcome.kind === 'resolved' || outcome.kind === 'already-resolved') {
+      this.deps.events.emit('send:completed', {
+        quoteId: swap.id,
+        transactionId: swap.transactionId,
+        amount: swap.amountReceived,
+        protocol: 'cashu',
+      });
+    }
+  }
+
+  // ===========================================================================================
+  // SPARK lightning SEND — drives UNPAID → PENDING → COMPLETED/FAILED off Breez sendPayment + events.
+  // Source: send/spark-send-quote-hooks.ts#useProcessSparkSendQuoteTasks (+ useOnSparkSendStateChange).
+  // ===========================================================================================
+
+  /**
+   * KICKOFF a spark lightning send. An UNPAID quote is initiated immediately (Breez `sendPayment`,
+   * UNPAID → PENDING). The TERMINAL transition (→ COMPLETED / FAILED) is driven by the account's
+   * Breez `paymentSucceeded` / `paymentFailed` event — surfaced to the orchestrator via
+   * {@link stepSparkSendCompleted} / {@link stepSparkSendFailed} (the S5 spark-event substrate +
+   * the balance tracker share this listener). Returns the quote in its (possibly now PENDING) state.
+   *
+   * @param quote - the FULL spark send quote (UNPAID on kickoff).
+   * @returns the quote after initiation (PENDING) or unchanged if already past UNPAID.
+   */
+  async executeSparkSendQuote(quote: SparkSendQuote): Promise<SparkSendQuote> {
+    if (quote.state !== 'UNPAID') {
+      return quote;
+    }
+    const account = await this.requireSparkAccount(quote.accountId);
+    try {
+      const outcome = await runStep(() =>
+        this.deps.sparkSendQuoteService.initiateSend({
+          account,
+          sendQuote: quote,
+        }),
+      );
+      if (outcome.kind === 'resolved' && outcome.value) {
+        this.deps.events.emit('send:pending', {
+          quoteId: outcome.value.id,
+          transactionId: outcome.value.transactionId,
+          protocol: 'spark',
+        });
+        return outcome.value;
+      }
+      return quote;
+    } catch (error) {
+      // Master fails the quote on a DomainError from `initiateSend` (invoice already paid / fee
+      // changed / insufficient) so the user can retry; mirror that.
+      if (error instanceof DomainError) {
+        await this.failSparkSendQuote(quote, error.message);
+        return quote;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * STEP a spark send to COMPLETED on a Breez `paymentSucceeded`. Reads FRESH DB state, emits
+   * `send:completed`. Manually pumpable.
+   *
+   * @param params.quoteId - the agicash spark send-quote id.
+   * @param params.paymentPreimage - the lightning preimage from the Breez payment.
+   */
+  async stepSparkSendCompleted(params: {
+    quoteId: string;
+    paymentPreimage: string;
+  }): Promise<void> {
+    const quote = await this.deps.sparkSendQuoteRepository.get(params.quoteId);
+    if (!quote || quote.state !== 'PENDING') {
+      return;
+    }
+    const outcome = await runStep(() =>
+      this.deps.sparkSendQuoteService.complete(quote, params.paymentPreimage),
+    );
+    if (outcome.kind === 'resolved' || outcome.kind === 'already-resolved') {
+      this.deps.events.emit('send:completed', {
+        quoteId: quote.id,
+        transactionId: quote.transactionId,
+        amount: quote.amount,
+        protocol: 'spark',
+      });
+    }
+  }
+
+  /**
+   * STEP a spark send to FAILED on a Breez `paymentFailed` (or initiation DomainError). Reads FRESH
+   * DB state, emits `send:failed`. Manually pumpable.
+   *
+   * @param params.quoteId - the agicash spark send-quote id.
+   * @param params.reason - the failure reason.
+   */
+  async stepSparkSendFailed(params: {
+    quoteId: string;
+    reason: string;
+  }): Promise<void> {
+    const quote = await this.deps.sparkSendQuoteRepository.get(params.quoteId);
+    if (!quote || (quote.state !== 'PENDING' && quote.state !== 'UNPAID')) {
+      return;
+    }
+    await this.failSparkSendQuote(quote, params.reason);
+  }
+
+  /** Fail the spark send quote + emit `send:failed`. */
+  private async failSparkSendQuote(
+    quote: SparkSendQuote,
+    reason: string,
+  ): Promise<void> {
+    await runStep(() => this.deps.sparkSendQuoteService.fail(quote, reason));
+    this.deps.events.emit('send:failed', {
+      quoteId: quote.id,
+      error: new DomainError(reason),
+      protocol: 'spark',
+    });
+  }
+
+  // ===========================================================================================
+  // CASHU lightning RECEIVE — drives UNPAID → PAID → COMPLETED off the mint mint-quote WS / poll.
+  // Source: receive/cashu-receive-quote-hooks.ts#useProcessCashuReceiveQuoteTasks (LIGHTNING branch).
+  // ===========================================================================================
+
+  /**
+   * START tracking a cashu lightning receive quote: register it in the in-flight index + open the
+   * mint-quote WS subscription for its mint (which pumps {@link stepCashuReceiveQuote} on each
+   * update). Returns the quote in its current state; `receive:completed` / `receive:expired` arrive
+   * via the subscription. (For mints without WebSocket support master polls; the leader-gated
+   * processor poll is Slice 5 — here the WS path + manual `step*` cover the testable core.)
+   *
+   * @param quote - the FULL receive quote (UNPAID on creation).
+   * @returns the same quote (resolves on start).
+   */
+  async startCashuReceiveQuote(
+    quote: CashuReceiveQuote,
+  ): Promise<CashuReceiveQuote> {
+    if (quote.type !== 'LIGHTNING' || this.isCashuReceiveTerminal(quote)) {
+      return quote;
+    }
+    const account = await this.requireCashuAccount(quote.accountId);
+    this.cashuReceiveSet.track({
+      protocolId: quote.quoteId,
+      agicashId: quote.id,
+      mintUrl: account.mintUrl,
+    });
+    await this.trySubscribeMint({
+      mintUrl: account.mintUrl,
+      quoteIds: [quote.quoteId],
+      onUpdate: (mintQuote) => {
+        void this.stepCashuReceiveQuote(mintQuote);
+      },
+    });
+    return quote;
+  }
+
+  /**
+   * STEP the cashu LIGHTNING receive machine on a mint-quote update. Manually pumpable. Resolves
+   * the agicash receive quote from the in-flight index → reads FRESH DB state → branches on the
+   * mint state as master's `useOnMintQuoteStateChange` does (PAID/ISSUED→complete-receive,
+   * UNPAID+expired→expire).
+   *
+   * @param mintQuote - the mint's mint-quote update.
+   */
+  async stepCashuReceiveQuote(
+    mintQuote: MintQuoteBolt11Response,
+  ): Promise<void> {
+    const tracked = this.cashuReceiveSet.getByProtocolId(mintQuote.quote);
+    if (!tracked) {
+      return;
+    }
+    const quote = await this.deps.cashuReceiveQuoteRepository.get(
+      tracked.agicashId,
+    );
+    if (!quote || this.isCashuReceiveTerminal(quote)) {
+      this.cashuReceiveSet.untrackByAgicashId(tracked.agicashId);
+      return;
+    }
+    const account = await this.requireCashuAccount(quote.accountId);
+
+    if (
+      mintQuote.state === MintQuoteState.PAID ||
+      mintQuote.state === MintQuoteState.ISSUED
+    ) {
+      // ISSUED → master re-runs complete in case the COMPLETED transition failed after minting
+      // (e.g. the browser was killed); `completeReceive` is idempotent.
+      await this.completeCashuReceive(account, quote);
+    } else if (
+      mintQuote.state === MintQuoteState.UNPAID &&
+      new Date(quote.expiresAt) < new Date()
+    ) {
+      await runStep(() => this.deps.cashuReceiveQuoteService.expire(quote));
+      this.emitCashuReceiveExpired(quote.id);
+      this.cashuReceiveSet.untrackByAgicashId(quote.id);
+    }
+  }
+
+  /** Complete the cashu receive (mint proofs + credit), emit `receive:completed`, stop tracking. */
+  private async completeCashuReceive(
+    account: CashuAccount,
+    quote: CashuReceiveQuote,
+  ): Promise<void> {
+    const outcome = await runStep(() =>
+      this.deps.cashuReceiveQuoteService.completeReceive(account, quote),
+    );
+    const completedQuote =
+      outcome.kind === 'resolved'
+        ? outcome.value.quote
+        : await this.deps.cashuReceiveQuoteRepository.get(quote.id);
+    this.cashuReceiveSet.untrackByAgicashId(quote.id);
+    // A cross-account CASHU_TOKEN destination is also tracked on the source-melt index; drop it too
+    // (the source melt is PAID by completion time, so its WS will not fire a terminal again).
+    this.cashuTokenReceiveSet.untrackByAgicashId(quote.id);
+    if (completedQuote && completedQuote.state === 'COMPLETED') {
+      this.deps.events.emit('receive:completed', {
+        quoteId: completedQuote.id,
+        transactionId: completedQuote.transactionId,
+        amount: completedQuote.amount,
+        protocol: 'cashu',
+      });
+    }
+  }
+
+  private emitCashuReceiveExpired(quoteId: string): void {
+    this.deps.events.emit('receive:expired', {
+      quoteId,
+      protocol: 'cashu',
+    });
+  }
+
+  private isCashuReceiveTerminal(quote: CashuReceiveQuote): boolean {
+    return (
+      quote.state === 'COMPLETED' ||
+      quote.state === 'EXPIRED' ||
+      quote.state === 'FAILED'
+    );
+  }
+
+  // ===========================================================================================
+  // CASHU same-mint token RECEIVE (swap) — drives PENDING → COMPLETED off proof-state / kickoff.
+  // Source: receive/cashu-receive-swap-hooks.ts#useProcessCashuReceiveSwapTasks.
+  // ===========================================================================================
+
+  /**
+   * STEP a same-mint cashu receive swap → COMPLETE it (execute the mint swap + store proofs).
+   * Reads FRESH DB state, emits `receive:completed` (or `receive:failed` if the token was already
+   * claimed — the service fails the swap in that case). Manually pumpable; also called inline by
+   * {@link receiveTokenSameMint}.
+   *
+   * @param tokenHash - the swap's token hash (the receive-swap's id key).
+   * @param userId - the owning user (the receive-swap repo keys on tokenHash+userId).
+   */
+  async stepCashuReceiveSwap(tokenHash: string, userId: string): Promise<void> {
+    const swap = await this.findPendingReceiveSwap(tokenHash, userId);
+    if (!swap || swap.state !== 'PENDING') {
+      return;
+    }
+    const account = await this.requireCashuAccount(swap.accountId);
+    const outcome = await runStep(() =>
+      this.deps.cashuReceiveSwapService.completeSwap(account, swap),
+    );
+    if (outcome.kind === 'already-resolved') {
+      return;
+    }
+    if (outcome.kind === 'resolved') {
+      const resultSwap = outcome.value.swap;
+      if (resultSwap.state === 'COMPLETED') {
+        this.deps.events.emit('receive:completed', {
+          quoteId: resultSwap.transactionId,
+          transactionId: resultSwap.transactionId,
+          amount: resultSwap.amountReceived,
+          protocol: 'cashu',
+        });
+      } else if (resultSwap.state === 'FAILED') {
+        this.deps.events.emit('receive:failed', {
+          quoteId: resultSwap.transactionId,
+          error: new DomainError(
+            resultSwap.failureReason ?? 'Token already claimed',
+          ),
+          protocol: 'cashu',
+        });
+      }
+    }
+  }
+
+  /** Find a PENDING receive swap by token hash (DB read via the repo's pending query). */
+  private async findPendingReceiveSwap(
+    tokenHash: string,
+    userId: string,
+  ): Promise<CashuReceiveSwap | undefined> {
+    const pending =
+      await this.deps.cashuReceiveSwapRepository.getPending(userId);
+    return pending.find((s) => s.tokenHash === tokenHash);
+  }
+
+  // ===========================================================================================
+  // CROSS-ACCOUNT token RECEIVE (cashu + spark destinations) — drives the melt off the melt-quote WS.
+  // Source: receive/{cashu,spark}-receive-quote-hooks.ts (the CASHU_TOKEN melt branch).
+  // ===========================================================================================
+
+  /**
+   * START tracking a cross-account CASHU_TOKEN cashu receive quote (token → a DIFFERENT cashu mint).
+   * Registers it on the melt-quote index + opens the source-mint melt-quote WS subscription (which
+   * pumps {@link stepCashuTokenReceiveMelt}). The melt of the source token funds the destination
+   * mint quote; once the melt is PAID the destination receive is completed.
+   *
+   * @param quote - the CASHU_TOKEN cashu receive quote (UNPAID).
+   * @returns the quote unchanged (resolves on start).
+   */
+  async startCashuTokenReceiveQuote(
+    quote: CashuReceiveQuote & { type: 'CASHU_TOKEN' },
+  ): Promise<CashuReceiveQuote> {
+    if (this.isCashuReceiveTerminal(quote)) {
+      return quote;
+    }
+    const sourceMintUrl = quote.tokenReceiveData.sourceMintUrl;
+    this.cashuTokenReceiveSet.track({
+      protocolId: quote.tokenReceiveData.meltQuoteId,
+      agicashId: quote.id,
+      mintUrl: sourceMintUrl,
+    });
+    await this.trySubscribeMelt({
+      mintUrl: sourceMintUrl,
+      quoteIds: [quote.tokenReceiveData.meltQuoteId],
+      onUpdate: (meltQuote) => {
+        void this.stepCashuTokenReceiveMelt(meltQuote);
+      },
+    });
+    // The mint quote on the DESTINATION mint is tracked separately so its PAID update completes the
+    // destination receive (the same path as a plain lightning receive).
+    await this.startCashuReceiveQuoteForToken(quote);
+    return quote;
+  }
+
+  /** Track the DESTINATION mint quote of a cross-account cashu-token receive (completes it on PAID). */
+  private async startCashuReceiveQuoteForToken(
+    quote: CashuReceiveQuote & { type: 'CASHU_TOKEN' },
+  ): Promise<void> {
+    const account = await this.requireCashuAccount(quote.accountId);
+    this.cashuReceiveSet.track({
+      protocolId: quote.quoteId,
+      agicashId: quote.id,
+      mintUrl: account.mintUrl,
+    });
+    await this.trySubscribeMint({
+      mintUrl: account.mintUrl,
+      quoteIds: [quote.quoteId],
+      onUpdate: (mintQuote) => {
+        void this.stepCashuReceiveQuote(mintQuote);
+      },
+    });
+  }
+
+  /**
+   * STEP the cross-account CASHU cashu-token melt on a SOURCE-mint melt-quote update. Manually
+   * pumpable. Branches as master's CASHU_TOKEN `useOnMeltQuoteStateChange` does: UNPAID→initiate
+   * the melt (or fail if it was already initiated, meaning the melt failed), PENDING→mark melt
+   * initiated, EXPIRED→expire.
+   *
+   * @param meltQuote - the source mint's melt-quote update.
+   */
+  async stepCashuTokenReceiveMelt(
+    meltQuote: MeltQuoteBolt11Response,
+  ): Promise<void> {
+    const tracked = this.cashuTokenReceiveSet.getByProtocolId(meltQuote.quote);
+    if (!tracked) {
+      return;
+    }
+    const quote = await this.deps.cashuReceiveQuoteRepository.get(
+      tracked.agicashId,
+    );
+    if (
+      !quote ||
+      quote.type !== 'CASHU_TOKEN' ||
+      this.isCashuReceiveTerminal(quote)
+    ) {
+      this.cashuTokenReceiveSet.untrackByAgicashId(tracked.agicashId);
+      return;
+    }
+    await this.driveTokenMelt({
+      meltQuote,
+      sourceMintUrl: quote.tokenReceiveData.sourceMintUrl,
+      tokenAmountCurrency: quote.tokenReceiveData.tokenAmount.currency,
+      meltInitiated: quote.tokenReceiveData.meltInitiated,
+      tokenProofs: quote.tokenReceiveData.tokenProofs,
+      meltQuoteId: quote.tokenReceiveData.meltQuoteId,
+      amount: quote.amount,
+      markMeltInitiated: () =>
+        this.deps.cashuReceiveQuoteService.markMeltInitiated(quote),
+      fail: (reason) => this.deps.cashuReceiveQuoteService.fail(quote, reason),
+      expire: () => this.deps.cashuReceiveQuoteService.expire(quote),
+      onExpired: () => {
+        this.emitCashuReceiveExpired(quote.id);
+        this.cashuTokenReceiveSet.untrackByAgicashId(quote.id);
+      },
+    });
+  }
+
+  /**
+   * START tracking a cross-account CASHU_TOKEN SPARK receive quote (token → spark). Same source-mint
+   * melt machine as the cashu cross-account path; the destination is a spark receive completed by
+   * the Breez listener (the kickoff `receiveTokenToSpark` waits for it inline).
+   *
+   * @param quote - the CASHU_TOKEN spark receive quote (UNPAID).
+   * @returns the quote unchanged (resolves on start).
+   */
+  async startSparkTokenReceiveQuote(
+    quote: SparkReceiveQuote & { type: 'CASHU_TOKEN' },
+  ): Promise<SparkReceiveQuote> {
+    if (quote.state !== 'UNPAID') {
+      return quote;
+    }
+    const sourceMintUrl = quote.tokenReceiveData.sourceMintUrl;
+    this.sparkTokenReceiveSet.track({
+      protocolId: quote.tokenReceiveData.meltQuoteId,
+      agicashId: quote.id,
+      mintUrl: sourceMintUrl,
+    });
+    await this.trySubscribeMelt({
+      mintUrl: sourceMintUrl,
+      quoteIds: [quote.tokenReceiveData.meltQuoteId],
+      onUpdate: (meltQuote) => {
+        void this.stepSparkTokenReceiveMelt(meltQuote);
+      },
+    });
+    return quote;
+  }
+
+  /**
+   * STEP the cross-account SPARK cashu-token melt on a SOURCE-mint melt-quote update. Manually
+   * pumpable. Same branch logic as {@link stepCashuTokenReceiveMelt} but over the spark
+   * receive-quote service.
+   *
+   * @param meltQuote - the source mint's melt-quote update.
+   */
+  async stepSparkTokenReceiveMelt(
+    meltQuote: MeltQuoteBolt11Response,
+  ): Promise<void> {
+    const tracked = this.sparkTokenReceiveSet.getByProtocolId(meltQuote.quote);
+    if (!tracked) {
+      return;
+    }
+    const quote = await this.deps.sparkReceiveQuoteRepository.get(
+      tracked.agicashId,
+    );
+    if (!quote || quote.type !== 'CASHU_TOKEN' || quote.state !== 'UNPAID') {
+      this.sparkTokenReceiveSet.untrackByAgicashId(tracked.agicashId);
+      return;
+    }
+    await this.driveTokenMelt({
+      meltQuote,
+      sourceMintUrl: quote.tokenReceiveData.sourceMintUrl,
+      tokenAmountCurrency: quote.tokenReceiveData.tokenAmount.currency,
+      meltInitiated: quote.tokenReceiveData.meltInitiated,
+      tokenProofs: quote.tokenReceiveData.tokenProofs,
+      meltQuoteId: quote.tokenReceiveData.meltQuoteId,
+      amount: quote.amount,
+      markMeltInitiated: () =>
+        this.deps.sparkReceiveQuoteService.markMeltInitiated(quote),
+      fail: (reason) => this.deps.sparkReceiveQuoteService.fail(quote, reason),
+      expire: () => this.deps.sparkReceiveQuoteService.expire(quote),
+      onExpired: () => {
+        this.deps.events.emit('receive:expired', {
+          quoteId: quote.id,
+          protocol: 'spark',
+        });
+        this.sparkTokenReceiveSet.untrackByAgicashId(quote.id);
+      },
+    });
+  }
+
+  /**
+   * The shared cross-account token-melt drive logic (cashu + spark destinations), parameterised by
+   * the destination's receive-quote service callbacks. Master duplicates this branch across the two
+   * receive hooks; the orchestrator factors it once (the melt itself is identical — it is always a
+   * SOURCE-mint melt; only the destination service differs).
+   */
+  private async driveTokenMelt(params: {
+    meltQuote: MeltQuoteBolt11Response;
+    sourceMintUrl: string;
+    tokenAmountCurrency: Currency;
+    meltInitiated: boolean;
+    tokenProofs: Proof[];
+    meltQuoteId: string;
+    amount: Money;
+    markMeltInitiated: () => Promise<unknown>;
+    fail: (reason: string) => Promise<void>;
+    expire: () => Promise<void>;
+    onExpired: () => void;
+  }): Promise<void> {
+    const { meltQuote } = params;
+    // The melt-quote WS reports only UNPAID/PENDING/PAID (no EXPIRED state); expiry is detected by
+    // a past-expiry UNPAID re-report, matching master's expiry-timer effect.
+    if (meltQuote.state === MeltQuoteState.UNPAID) {
+      if (new Date() > new Date(meltQuote.expiry * 1000)) {
+        await runStep(() => params.expire());
+        params.onExpired();
+        return;
+      }
+      if (params.meltInitiated) {
+        // Melt was initiated but is UNPAID again ⇒ the melt FAILED. Fail the receive quote.
+        await runStep(() => params.fail('Cashu token melt failed.'));
+        return;
+      }
+      await this.initiateTokenMelt(params);
+    } else if (meltQuote.state === MeltQuoteState.PENDING) {
+      await runStep(() => params.markMeltInitiated());
+    }
+    // PAID → the destination mint/spark quote completion is driven by its own mint-quote WS /
+    // Breez event (tracked separately at kickoff); nothing to do on the SOURCE melt here.
+  }
+
+  /** Initiate the source-token melt (idempotent, random change outputs); fail the receive on a permanent rejection. */
+  private async initiateTokenMelt(params: {
+    sourceMintUrl: string;
+    tokenAmountCurrency: Currency;
+    tokenProofs: Proof[];
+    meltQuoteId: string;
+    amount: Money;
+    fail: (reason: string) => Promise<void>;
+  }): Promise<void> {
+    const cashuUnit = getCashuUnit(params.tokenAmountCurrency);
+    // Resolve the source wallet: the orchestrator's WS factory gives a bare mint wallet; the melt
+    // needs the source mint's keysets, so build a wallet for it. Master uses the account wallet if
+    // the user has one, else `getInitializedCashuWallet`. Here the source is, by construction, a
+    // mint the user need not have an account for — use the WS-factory wallet, which cashu-ts lazily
+    // loads keysets for on the melt call.
+    const sourceWallet: ExtendedCashuWallet = getCashuWallet(
+      params.sourceMintUrl,
+    );
+    try {
+      await runStep(() =>
+        sourceWallet.meltProofsIdempotent(
+          {
+            quote: params.meltQuoteId,
+            amount: params.amount.toNumber(cashuUnit),
+          },
+          params.tokenProofs,
+          undefined,
+          // Random change outputs (no deterministic counter collision); change is discarded.
+          { type: 'random' },
+        ),
+      );
+    } catch (error) {
+      if (error instanceof DomainError) {
+        await params.fail(error.message);
+        return;
+      }
+      throw error;
+    }
+  }
+
+  // ===========================================================================================
+  // SPARK lightning RECEIVE — completed off the Breez paymentSucceeded event.
+  // Source: receive/spark-receive-quote-hooks.ts#useProcessSparkReceiveQuoteTasks (LIGHTNING branch).
+  // ===========================================================================================
+
+  /**
+   * STEP a spark LIGHTNING receive to PAID on a Breez `paymentSucceeded`. Reads FRESH DB state,
+   * emits `receive:completed`. Manually pumpable (the S5 spark-event substrate calls it).
+   *
+   * @param params.quoteId - the agicash spark receive-quote id.
+   * @param params.paymentPreimage - the lightning preimage.
+   * @param params.sparkTransferId - the Breez payment/transfer id.
+   */
+  async stepSparkReceiveCompleted(params: {
+    quoteId: string;
+    paymentPreimage: string;
+    sparkTransferId: string;
+  }): Promise<void> {
+    const quote = await this.deps.sparkReceiveQuoteRepository.get(
+      params.quoteId,
+    );
+    if (!quote || quote.state !== 'UNPAID') {
+      return;
+    }
+    const outcome = await runStep(() =>
+      this.deps.sparkReceiveQuoteService.complete(
+        quote,
+        params.paymentPreimage,
+        params.sparkTransferId,
+      ),
+    );
+    if (outcome.kind === 'resolved' || outcome.kind === 'already-resolved') {
+      this.deps.events.emit('receive:completed', {
+        quoteId: quote.id,
+        transactionId: quote.transactionId,
+        amount: quote.amount,
+        protocol: 'spark',
+      });
+    }
+  }
+
+  /**
+   * STEP a spark receive to EXPIRED (Breez `synced` + past-expiry). Reads FRESH DB state, emits
+   * `receive:expired`. Manually pumpable.
+   *
+   * @param quoteId - the agicash spark receive-quote id.
+   */
+  async stepSparkReceiveExpired(quoteId: string): Promise<void> {
+    const quote = await this.deps.sparkReceiveQuoteRepository.get(quoteId);
+    if (!quote || quote.state !== 'UNPAID') {
+      return;
+    }
+    await runStep(() => this.deps.sparkReceiveQuoteService.expire(quote));
+    this.deps.events.emit('receive:expired', {
+      quoteId: quote.id,
+      protocol: 'spark',
+    });
+  }
+
+  // ===========================================================================================
+  // Lifecycle + shared helpers
+  // ===========================================================================================
+
+  /** Tear down all live subscriptions + clear the in-flight indices (called from `Sdk.destroy()`). */
+  async destroy(): Promise<void> {
+    this.cashuSendSet.clear();
+    this.cashuReceiveSet.clear();
+    this.cashuTokenReceiveSet.clear();
+    this.sparkTokenReceiveSet.clear();
+    await Promise.all([
+      this.meltSubscriptions.closeAll(),
+      this.mintSubscriptions.closeAll(),
+    ]);
+  }
+
+  /**
+   * Open a melt-quote WS subscription, swallowing a connect failure (logged). The quote is already
+   * persisted, so a transient mint-WS outage must NOT fail the kickoff — the (Slice-5) resume sweep
+   * re-establishes the subscription. Master's `useOnMeltQuoteStateChange` similarly retries the
+   * subscribe mutation rather than propagating.
+   */
+  private async trySubscribeMelt(params: {
+    mintUrl: string;
+    quoteIds: string[];
+    onUpdate: (meltQuote: MeltQuoteBolt11Response) => void;
+  }): Promise<void> {
+    try {
+      await this.meltSubscriptions.subscribe(params);
+    } catch (error) {
+      console.warn('Failed to open melt-quote subscription', {
+        mintUrl: params.mintUrl,
+        cause: error,
+      });
+    }
+  }
+
+  /** Open a mint-quote WS subscription, swallowing a connect failure (logged). See {@link trySubscribeMelt}. */
+  private async trySubscribeMint(params: {
+    mintUrl: string;
+    quoteIds: string[];
+    onUpdate: (mintQuote: MintQuoteBolt11Response) => void;
+  }): Promise<void> {
+    try {
+      await this.mintSubscriptions.subscribe(params);
+    } catch (error) {
+      console.warn('Failed to open mint-quote subscription', {
+        mintUrl: params.mintUrl,
+        cause: error,
+      });
+    }
+  }
+
+  /** Fetch + assert a live cashu account (with its keyset-loaded wallet + decrypted proofs). */
+  private async requireCashuAccount(id: string): Promise<CashuAccount> {
+    const account = await this.deps.accounts.get(id);
+    if (!account || account.type !== 'cashu') {
+      throw new ConcurrencyError(`Cashu account not found for id: ${id}`);
+    }
+    return account;
+  }
+
+  /** Fetch + assert a live spark account (with its connected Breez wallet). */
+  private async requireSparkAccount(id: string): Promise<SparkAccount> {
+    const account: Account | null = await this.deps.accounts.get(id);
+    if (!account || account.type !== 'spark') {
+      throw new ConcurrencyError(`Spark account not found for id: ${id}`);
+    }
+    return account;
+  }
+}

--- a/packages/wallet-sdk/src/internal/receive-cashu-token-quote-service.ts
+++ b/packages/wallet-sdk/src/internal/receive-cashu-token-quote-service.ts
@@ -1,0 +1,281 @@
+/**
+ * Cross-account cashu-token receive QUOTE service — Slice 3 / PR5d.
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/receive/receive-cashu-token-quote-service.ts`. Master's
+ * `ReceiveCashuTokenQuoteService` is ALREADY a plain class (only `useReceiveCashuTokenQuoteService`
+ * couples it to React) over the cashu + spark receive-quote services — lifted near-verbatim,
+ * dropping the factory.
+ *
+ * It builds the paired quotes for a CROSS-account cashu-token claim (token → a DIFFERENT cashu
+ * mint, or token → spark): it iterates a SOURCE-mint melt quote against a DESTINATION mint/spark
+ * mint quote until the melt covers the destination amount, then persists a CASHU_TOKEN receive
+ * quote on the destination. The orchestrator's cross-account melt machine
+ * (`stepCashuTokenReceiveMelt` / `stepSparkTokenReceiveMelt`) then drives the source melt and the
+ * destination completion.
+ *
+ * @module
+ */
+import type { MeltQuoteBolt11Response, Token } from '@cashu/cashu-ts';
+import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+import type { CashuReceiveLightningQuote } from './cashu-receive-quote-core';
+import { getCashuUnit, tokenToMoney } from './lib-cashu-quotes';
+import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
+import type { SparkReceiveLightningQuote } from './spark-receive-quote-core';
+import { getLightningQuote as getSparkLightningQuote } from './spark-receive-quote-core';
+import { DomainError } from '../errors';
+import type { Account, CashuAccount, SparkAccount } from '../types/account';
+import { type Currency, Money } from '../types/money';
+import type { CashuReceiveQuote } from '../types/cashu';
+import type { SparkReceiveQuote } from '../types/spark';
+
+/** Params for {@link ReceiveCashuTokenQuoteService.createCrossAccountReceiveQuotes} (master verbatim). */
+type CreateCrossAccountReceiveQuotesProps = {
+  /** ID of the receiving user. */
+  userId: string;
+  /** The token to claim. */
+  token: Token;
+  /** The account to claim the token to (a DIFFERENT mint/currency than the source). */
+  destinationAccount: Account;
+  /** The account to claim the token from (a placeholder if the user has no account for the mint). */
+  sourceAccount: CashuAccount;
+  /** The source→destination exchange rate (string Big; `'1'` for same-currency). */
+  exchangeRate: string;
+};
+
+/**
+ * The result of building cross-account receive quotes. A discriminated union on the destination
+ * account type: a cashu destination carries the {@link CashuReceiveQuote} to complete after the
+ * melt, a spark destination the {@link SparkReceiveQuote}. Master verbatim.
+ */
+export type CrossAccountReceiveQuotesResult = {
+  /** The melt quote on the SOURCE mint (the token proofs are melted against it). */
+  cashuMeltQuote: MeltQuoteBolt11Response;
+} & (
+  | {
+      destinationType: 'cashu';
+      destinationAccount: CashuAccount;
+      cashuReceiveQuote: CashuReceiveQuote;
+    }
+  | {
+      destinationType: 'spark';
+      destinationAccount: SparkAccount;
+      sparkReceiveQuote: SparkReceiveQuote;
+    }
+);
+
+/** Cross-account cashu-token receive quote builder (master verbatim, framework-free). */
+export class ReceiveCashuTokenQuoteService {
+  constructor(
+    private readonly cashuReceiveQuoteService: CashuReceiveQuoteService,
+    private readonly sparkReceiveQuoteService: SparkReceiveQuoteService,
+  ) {}
+
+  /**
+   * Build the paired source-melt + destination-mint quotes for a cross-account token claim and
+   * persist the destination receive quote (CASHU_TOKEN). Master verbatim.
+   *
+   * @throws DomainError if the token is too small to cover the cashu/lightning fees.
+   */
+  async createCrossAccountReceiveQuotes({
+    userId,
+    token,
+    sourceAccount,
+    destinationAccount,
+    exchangeRate,
+  }: CreateCrossAccountReceiveQuotesProps): Promise<CrossAccountReceiveQuotesResult> {
+    const tokenAmount = tokenToMoney(token);
+    const sourceCashuUnit = getCashuUnit(sourceAccount.currency);
+
+    const feesForProofs = sourceAccount.wallet.getFeesForProofs(token.proofs);
+    const cashuReceiveFee = new Money({
+      amount: feesForProofs,
+      currency: tokenAmount.currency,
+      unit: sourceCashuUnit,
+    });
+
+    const targetAmount = tokenAmount.subtract(cashuReceiveFee);
+
+    if (targetAmount.isNegative()) {
+      throw new DomainError('Token amount is too small to cover cashu fees.');
+    }
+
+    const quotes = await this.getCrossMintQuotesWithinTargetAmount({
+      destinationAccount,
+      sourceAccount,
+      targetAmount,
+      exchangeRate,
+      description: token.memo,
+    });
+
+    const meltQuoteExpiresAt = new Date(
+      quotes.meltQuote.expiry * 1000,
+    ).toISOString();
+
+    const lightningFeeReserve = new Money({
+      amount: quotes.meltQuote.fee_reserve,
+      currency: tokenAmount.currency,
+      unit: sourceCashuUnit,
+    });
+
+    if (destinationAccount.type === 'cashu') {
+      const cashuReceiveQuote =
+        await this.cashuReceiveQuoteService.createReceiveQuote({
+          userId,
+          account: destinationAccount,
+          receiveType: 'CASHU_TOKEN',
+          lightningQuote: quotes.lightningQuote as CashuReceiveLightningQuote,
+          tokenAmount,
+          sourceMintUrl: sourceAccount.mintUrl,
+          tokenProofs: token.proofs,
+          meltQuoteId: quotes.meltQuote.quote,
+          meltQuoteExpiresAt,
+          cashuReceiveFee,
+          lightningFeeReserve,
+        });
+
+      return {
+        destinationType: 'cashu',
+        destinationAccount,
+        cashuReceiveQuote,
+        cashuMeltQuote: quotes.meltQuote,
+      };
+    }
+
+    const sparkReceiveQuote =
+      await this.sparkReceiveQuoteService.createReceiveQuote({
+        userId,
+        account: destinationAccount,
+        receiveType: 'CASHU_TOKEN',
+        lightningQuote: quotes.lightningQuote as SparkReceiveLightningQuote,
+        tokenAmount,
+        sourceMintUrl: sourceAccount.mintUrl,
+        tokenProofs: token.proofs,
+        meltQuoteId: quotes.meltQuote.quote,
+        meltQuoteExpiresAt,
+        cashuReceiveFee,
+        lightningFeeReserve,
+      });
+
+    return {
+      destinationType: 'spark',
+      destinationAccount,
+      sparkReceiveQuote,
+      cashuMeltQuote: quotes.meltQuote,
+    };
+  }
+
+  /**
+   * Iterate the source melt quote against the destination mint quote until the melt (amount +
+   * reserve) covers the destination amount (or 5 attempts). Master verbatim.
+   *
+   * @throws DomainError if the token is too small; Error if no valid quote is found in 5 tries.
+   */
+  private async getCrossMintQuotesWithinTargetAmount({
+    destinationAccount,
+    sourceAccount,
+    targetAmount,
+    exchangeRate,
+    description,
+  }: {
+    destinationAccount: Account;
+    sourceAccount: CashuAccount;
+    targetAmount: Money;
+    exchangeRate: string;
+    description?: string;
+  }): Promise<{
+    lightningQuote: CashuReceiveLightningQuote | SparkReceiveLightningQuote;
+    meltQuote: MeltQuoteBolt11Response;
+    amountToMint: Money;
+  }> {
+    const sourceCurrency = sourceAccount.currency;
+    const destinationCurrency = destinationAccount.currency;
+
+    let attempts = 0;
+    let amountToMelt = targetAmount;
+
+    while (attempts < 5) {
+      attempts++;
+
+      const amountToMint = amountToMelt.convert(
+        destinationCurrency,
+        exchangeRate,
+      );
+      const amountToMintNumber = amountToMint.toNumber(
+        getCashuUnit(destinationCurrency),
+      );
+
+      if (amountToMintNumber < 1) {
+        throw new DomainError('Token amount is too small to cover the fees.');
+      }
+
+      const { lightningQuote, paymentRequest } =
+        await this.getLightningQuoteForDestinationAccount({
+          destinationAccount,
+          amount: amountToMint,
+          description,
+        });
+
+      const meltQuote =
+        await sourceAccount.wallet.createMeltQuoteBolt11(paymentRequest);
+
+      const amountRequired = new Money({
+        amount: meltQuote.amount + meltQuote.fee_reserve,
+        currency: sourceCurrency,
+        unit: getCashuUnit(sourceCurrency),
+      });
+
+      const diff = amountRequired.subtract(targetAmount);
+
+      if (diff.lessThanOrEqual(Money.zero(diff.currency as Currency))) {
+        return {
+          meltQuote,
+          amountToMint,
+          lightningQuote,
+        };
+      }
+
+      amountToMelt = amountToMelt.subtract(diff);
+    }
+
+    throw new Error('Failed to find valid quotes after 5 attempts.');
+  }
+
+  /** Create the destination mint/spark quote (the lightning invoice the melt pays). Master verbatim. */
+  private async getLightningQuoteForDestinationAccount({
+    destinationAccount,
+    amount,
+    description,
+  }: {
+    destinationAccount: Account;
+    amount: Money;
+    description?: string;
+  }): Promise<{
+    lightningQuote: CashuReceiveLightningQuote | SparkReceiveLightningQuote;
+    paymentRequest: string;
+  }> {
+    if (destinationAccount.type === 'spark') {
+      const lightningQuote = await getSparkLightningQuote({
+        wallet: destinationAccount.wallet,
+        amount,
+      });
+
+      return {
+        lightningQuote,
+        paymentRequest: lightningQuote.invoice.paymentRequest,
+      };
+    }
+
+    const lightningQuote =
+      await this.cashuReceiveQuoteService.getLightningQuote({
+        wallet: destinationAccount.wallet,
+        amount,
+        description,
+      });
+
+    return {
+      lightningQuote,
+      paymentRequest: lightningQuote.mintQuote.request,
+    };
+  }
+}

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -51,8 +51,11 @@ import { CashuSendQuoteService } from './internal/cashu-send-quote-service';
 import { CashuSendSwapRepository } from './internal/cashu-send-swap-repository';
 import { CashuSendSwapService } from './internal/cashu-send-swap-service';
 import { MintMetadataCache } from './internal/cashu-wallet';
+import { ClaimCashuTokenFlow } from './internal/claim-cashu-token-flow';
 import { dbAccountToAccount } from './internal/db-account';
 import { createEncryption } from './internal/encryption';
+import { Orchestrator } from './internal/orchestrator';
+import { ReceiveCashuTokenQuoteService } from './internal/receive-cashu-token-quote-service';
 import { SparkBalanceTracker } from './internal/spark-balance-tracker';
 import { SparkReceiveQuoteRepository } from './internal/spark-receive-quote-repository';
 import { SparkReceiveQuoteService } from './internal/spark-receive-quote-service';
@@ -170,6 +173,12 @@ export type SdkConnections = {
    * `track(onlineSparkAccounts)` to start it.
    */
   readonly sparkBalanceTracker: SparkBalanceTracker;
+  /**
+   * The unified `executeQuote` ORCHESTRATOR (PR5d): the framework-free state machine the cashu +
+   * spark send/receive domains drive. Held so `destroy()` tears down its live mint-WS subscriptions
+   * + in-flight indices.
+   */
+  readonly orchestrator: Orchestrator;
 };
 
 /** Validate `config` (shape the rest of `create` relies on). Throws on a missing field. */
@@ -336,19 +345,7 @@ export class Sdk {
     const sparkCache = new SparkWalletCache();
     // Spark balance source (Breez listeners → `account:updated`). Built here, started by S5.
     const sparkBalanceTracker = new SparkBalanceTracker(events);
-
-    const connections: SdkConnections = {
-      supabase,
-      openSecret,
-      sessionToken,
-      storage: config.storage,
-      events,
-      queryClient,
-      clientId: config.clientId ?? generateClientId(),
-      mintCache,
-      sparkCache,
-      sparkBalanceTracker,
-    };
+    const clientId = config.clientId ?? generateClientId();
 
     // --- Slice 1: auth + user domains ----------------------------------------
     // The agicash domain `User` is the `wallet.users` row keyed by the OpenSecret user id,
@@ -454,24 +451,6 @@ export class Sdk {
       cashuReceiveQuoteRepository,
     );
 
-    const cashu = new CashuDomainImpl(
-      new CashuSendOpsImpl(
-        queryClient,
-        cashuSendQuoteService,
-        cashuSendSwapService,
-        cashuSendQuoteRepository,
-        cashuSendSwapRepository,
-        accountRepository,
-        session,
-      ),
-      new CashuReceiveOpsImpl(
-        queryClient,
-        cashuReceiveQuoteService,
-        cashuReceiveQuoteRepository,
-        session,
-      ),
-    );
-
     // --- Slice 3 / PR5c: spark send + receive ops ----------------------------
     // The spark repos write/read the `wallet.spark_{send,receive}_quotes` tables over the
     // SDK-owned Supabase client + the SDK Encryption (encrypt-on-write / decrypt-on-read of the
@@ -496,10 +475,91 @@ export class Sdk {
     const sparkReceiveQuoteService = new SparkReceiveQuoteService(
       sparkReceiveQuoteRepository,
     );
+
+    // --- Slice 3 / PR5d: the executeQuote ORCHESTRATOR -----------------------
+    // The framework-free state machine (build plan's single biggest net-new construct) that
+    // absorbs master's six React-resident `useProcess*Tasks` hooks. It DRIVES the idempotent
+    // PR5b/5c service primitives off FRESH DB reads (no cache) + the mint melt/mint-quote WS
+    // subscriptions, and emits the `send:*` / `receive:*` events. Shared by both protocols' send
+    // (`executeQuote`) + receive (kickoff/completion) domains so a kickoff and the (future,
+    // Slice-5) leader-gated processor act on one source of truth.
+    const orchestrator = new Orchestrator({
+      accounts: accountRepository,
+      events,
+      cashuSendQuoteService,
+      cashuSendQuoteRepository,
+      cashuSendSwapService,
+      cashuSendSwapRepository,
+      cashuReceiveQuoteService,
+      cashuReceiveQuoteRepository,
+      cashuReceiveSwapService,
+      cashuReceiveSwapRepository,
+      sparkSendQuoteService,
+      sparkSendQuoteRepository,
+      sparkReceiveQuoteService,
+      sparkReceiveQuoteRepository,
+    });
+
+    // The cross-account cashu-token receive quote builder + the token-claim flow behind
+    // `cashu.receive.receiveToken` (decode → resolve source/destination → same-mint swap OR
+    // cross-account melt-then-mint, all driven by the orchestrator).
+    const receiveCashuTokenQuoteService = new ReceiveCashuTokenQuoteService(
+      cashuReceiveQuoteService,
+      sparkReceiveQuoteService,
+    );
+    const claimCashuTokenFlow = new ClaimCashuTokenFlow({
+      accounts: accountRepository,
+      cashuReceiveSwapService,
+      receiveCashuTokenQuoteService,
+      orchestrator,
+      mintCache,
+    });
+
+    const cashu = new CashuDomainImpl(
+      new CashuSendOpsImpl(
+        queryClient,
+        cashuSendQuoteService,
+        cashuSendSwapService,
+        cashuSendQuoteRepository,
+        cashuSendSwapRepository,
+        accountRepository,
+        session,
+        orchestrator,
+      ),
+      new CashuReceiveOpsImpl(
+        queryClient,
+        cashuReceiveQuoteService,
+        cashuReceiveQuoteRepository,
+        session,
+        claimCashuTokenFlow,
+      ),
+    );
+
     const spark = new SparkDomainImpl(
-      new SparkSendOpsImpl(queryClient, sparkSendQuoteService, session),
+      new SparkSendOpsImpl(
+        queryClient,
+        sparkSendQuoteService,
+        session,
+        orchestrator,
+      ),
       new SparkReceiveOpsImpl(queryClient, sparkReceiveQuoteService, session),
     );
+
+    // The shared connection bundle (held by `Sdk` so `destroy()` can tear everything down). Built
+    // last because the orchestrator (PR5d) needs every protocol service/repo constructed first.
+    const connections: SdkConnections = {
+      supabase,
+      openSecret,
+      sessionToken,
+      storage: config.storage,
+      events,
+      queryClient,
+      clientId,
+      mintCache,
+      sparkCache,
+      sparkBalanceTracker,
+      orchestrator,
+    };
 
     return new Sdk(connections, { auth, user, accounts, scan, cashu, spark });
   }
@@ -528,8 +588,10 @@ export class Sdk {
     this.connections.sparkCache.clear();
     // Remove the spark Breez balance listeners (the `account:updated` source).
     this.connections.sparkBalanceTracker.stop();
-    // TODO(Slice 3/5): close mint melt/mint-quote WS subs + Breez SDK instances (call
-    // `disconnect()` on connected wallets) + halt the leader-elected processor + clear its
-    // timers (wired into this seam when those connections are opened).
+    // Close the orchestrator's live mint melt/mint-quote WS subscriptions + clear its in-flight
+    // indices (PR5d). The cashu account wallets' own mint sockets + the Breez SDK `disconnect()`
+    // are dropped with the live-handle memos above; the leader-elected processor + its timers are
+    // the Slice-5 addition to this same seam.
+    await this.connections.orchestrator.destroy();
   }
 }


### PR DESCRIPTION
## PR5d — the `executeQuote` orchestrator (reactive design B)

The heaviest slice of `@agicash/wallet-sdk`, but a **near-pure verbatim lift** of the proven no-cache orchestrator (`sdk/pr5d-orchestrator`) onto the reactive base. Replaces the `NotImplementedError` stubs PR5b/5c left for `executeQuote` (cashu + spark) and the `receiveToken` claim flow.

**Stack:** PR1 #1129 → PR2 #1130 → PR3 #1131 → PR4 #1132 → PR5a #1133 → PR5b #1134 → PR5c #1135 → **PR5d (this)**.

### What this implements
`executeQuote` and `receiveToken` are **ACTIONS → `Promise`** (no `Query` wraps — the observable reads were already wrapped in 5b/5c). So this is a lift of the orchestrator LOGIC with **no reactive read-surface changes** and **no cache-invalidation** (that freshness wiring is PR7).

New `internal/` modules (framework-free; no `react`/`@tanstack`):
- **`orchestrator.ts`** — the state machine absorbing master's six `useProcess*Tasks` hooks into plain async kickoff methods (`executeCashuSendQuote` / `executeCashuSendSwap` / `executeSparkSendQuote` + receive kickoffs) and manually-pumpable `step*` cores. **DB-read, not cache:** every mint-WS / Breez signal re-reads the DB via the working-set index and re-validates before acting.
- **`melt-quote-subscription-manager.ts`** / **`mint-quote-subscription-manager.ts`** — the mint-WS managers.
- **`orchestrator-retry.ts`** — wires `classify()` (already relocated to the package upstream in the reactive lineage) → the error model (transient→`ConcurrencyError`, permanent→`DomainError`, already-resolved→no-op, unhandled→propagate).
- **`orchestrator-working-set.ts`** — the protocol-quote-id → agicash-id index.
- **`claim-cashu-token-flow.ts`** + **`receive-cashu-token-quote-service.ts`** — the full `receiveToken` flow: same-mint internal `CashuReceiveSwap`, cross-account melt-then-mint, swallow-to-`ReceiveTokenResult` (**never throws**).
- **`lib-retry.ts`** / **`lib-timeout.ts`** — the `app/lib` single-source seams (`with-retry`, `timeout`, `isSubset`).

Wiring (`sdk.ts` + domains):
- `sdk.ts` builds the shared `Orchestrator` + `ReceiveCashuTokenQuoteService` + `ClaimCashuTokenFlow` after all protocol services, threads the orchestrator into the cashu/spark send ops + the claim flow into the cashu receive ops, holds it on `SdkConnections`, and tears it down in `destroy()`.
- `cashu.send.executeQuote` / `cashu.send.createTokenQuote` (swap kickoff) / `spark.send.executeQuote` delegate to the orchestrator; `cashu.receive.receiveToken` drives the claim flow → `Promise<ReceiveTokenResult>`.

### Lineage-drift reconciliation
- Redirected the orchestrator's `SdkEventMap` import `../events` → `../types/events` (the **only** path that moved on the reactive base; the event-map key set + payload shapes are identical).
- The reactive `types/cashu.ts` master-verbatim subset was **already sufficient** — no type extension needed (the lift type-checks as-is). `domains.ts` / `index.ts` / `ReceiveTokenResult` were already pre-applied on the reactive base.
- **No react-package tsconfig change needed** — the `app/lib` `~/*` seam stays within wallet-sdk's own tsconfig path map; `@agicash/react-wallet-sdk` typechecks clean.

### Tests
Ported the no-cache orchestrator state-machine / claim-flow / retry-verdict / working-set tests verbatim (highest-value tests in the stack — drive the manually-pumpable `step*`, assert transitions/idempotency/classify-verdict handling + the swallow-to-result claim tests). Reconciled the domain tests to the reactive constructor shape (leading `QueryClient` arg). The process-global `mock.module('@cashu/cashu-ts')` test stays dropped (coverage is indirect).

### Local CI gate (all green)
- `bun install` frozen — no new deps.
- `bun --filter='*' run test`: **wallet-sdk 319 pass / 0 fail**, **web-wallet 133 pass / 0 fail**.
- `bun --filter='*' run typecheck`: all 4 packages exit 0 (incl. `@agicash/react-wallet-sdk` + `web-wallet`).
- `format:check` clean; `lint:check` clean (only 2 pre-existing unrelated `ImportMeta` warnings, not from this PR).

**Diff:** 18 files, +3777 / −117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)