### PR TITLE
feat(wallet-sdk): transactions + contacts + transfers (PR6, reactive design B)

### DIFF
--- a/packages/react-wallet-sdk/tsconfig.json
+++ b/packages/react-wallet-sdk/tsconfig.json
@@ -8,7 +8,8 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["../../apps/web-wallet/app/*"]
+      "~/*": ["../../apps/web-wallet/app/*"],
+      "supabase/database.types": ["../../supabase/database.types.ts"]
     }
   }
 }

--- a/packages/wallet-sdk/src/domains/contacts.test.ts
+++ b/packages/wallet-sdk/src/domains/contacts.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { ContactsDomainImpl } from './contacts';
+import type { ContactRepository } from '../internal/contact-repository';
+import type { SessionResolver } from '../internal/session';
+import { QueryClient } from '../query';
+import type { Contact } from '../types/contact';
+
+/** A fresh QueryClient per domain (the SDK-internal one in production). */
+function makeClient(): QueryClient {
+  return new QueryClient();
+}
+
+const session = {
+  requireCurrentUser: mock(async () => ({ id: 'u1' })),
+} as unknown as SessionResolver;
+
+const contact: Contact = {
+  id: 'c1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ownerId: 'u1',
+  username: 'alice',
+  lud16: 'alice@agicash.me',
+};
+
+describe('ContactsDomain reads (Query<T>)', () => {
+  test('list() returns a Query that resolves to the user contacts', async () => {
+    const getAll = mock(async () => [contact]);
+    const repo = { getAll } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    const query = domain.list();
+    expect(typeof query.subscribe).toBe('function');
+    expect(typeof query.getSnapshot).toBe('function');
+    expect(await query.toPromise()).toEqual([contact]);
+    expect(getAll).toHaveBeenCalledWith('u1');
+    // Memoised: same stable ref.
+    expect(domain.list()).toBe(query);
+  });
+
+  test('get(id) returns a Query resolving to the contact', async () => {
+    const repo = {
+      get: mock(async () => contact),
+    } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    const query = domain.get('c1');
+    expect(typeof query.getSnapshot).toBe('function');
+    expect(await query.toPromise()).toBe(contact);
+    expect(domain.get('c1')).toBe(query);
+  });
+
+  test('get returns null (instead of throwing) when the repository read fails', async () => {
+    const repo = {
+      get: mock(async () => {
+        throw new Error('not found');
+      }),
+    } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    expect(await domain.get('missing').toPromise()).toBeNull();
+  });
+});
+
+describe('ContactsDomain actions (Promise)', () => {
+  test('add creates the contact owned by the current user (params, not full object)', async () => {
+    const create = mock(async () => contact);
+    const repo = { create } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    const result = await domain.add({ username: 'alice' });
+
+    expect(create).toHaveBeenCalledWith({ ownerId: 'u1', username: 'alice' });
+    expect(result).toBe(contact);
+  });
+
+  test('remove takes the FULL contact and deletes by id', async () => {
+    const del = mock(async () => undefined);
+    const repo = { delete: del } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    await domain.remove(contact);
+
+    expect(del).toHaveBeenCalledWith('c1');
+  });
+
+  test('search (one-shot Promise) forwards the query + current user to findContactCandidates', async () => {
+    const candidates = [{ id: 'p1', username: 'ali' }];
+    const findContactCandidates = mock(async () => candidates);
+    const repo = { findContactCandidates } as unknown as ContactRepository;
+    const domain = new ContactsDomainImpl(makeClient(), repo, session);
+
+    const result = await domain.search({ query: 'ali' });
+
+    expect(findContactCandidates).toHaveBeenCalledWith('ali', 'u1');
+    expect(result).toBe(candidates);
+  });
+});

--- a/packages/wallet-sdk/src/domains/contacts.ts
+++ b/packages/wallet-sdk/src/domains/contacts.ts
@@ -1,0 +1,155 @@
+/**
+ * `ContactsDomain` implementation — §8 of the contract, Slice 4 (reactive overlay, design B).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/contacts/contact-hooks.ts` (`useContacts` / `useContact` /
+ * `useCreateContact` / `useDeleteContact` / `useFindContactCandidates`) + `contact-repository.ts`.
+ * Master expresses these as React hooks over a TanStack `ContactsCache`.
+ *
+ * REACTIVE OVERLAY: TanStack is no longer in the consumer — it is hidden inside the SDK.
+ *  - `list()` / `get(id)` are OBSERVABLE FETCHES → each returns a `Query<T>`. The fetch body is
+ *    the no-cache read (the repository `getAll` / a row lookup, scoped to the resolved user),
+ *    wrapped via {@link toQuery} over the SDK-internal `QueryClient` and MEMOISED per key (`#q`)
+ *    so repeated calls return the SAME stable `Query` ref (`get` memoised per id). Realtime
+ *    (Slice 5) writes the same client to push fresh values / invalidate these keys when a
+ *    `contact:*` change arrives.
+ *  - `add(params)` CREATES; `remove(contact)` takes the FULL object; `search({ query })` is a
+ *    ONE-SHOT search (min-3, excludes existing) → all stay `Promise` (lifted verbatim).
+ *
+ * Two-mode API rule (Josip 6/01): `list`/`get` are observable fetches, `search` a one-shot fetch;
+ * `add` CREATES (params); `remove` takes the FULL contact object (user-invoked).
+ *
+ * Events: `contact:created`/`contact:deleted` are NOT emitted from these mutations — they are
+ * forwarded from the realtime DB-change broadcast (the single event source, like master's
+ * `CONTACT_CREATED`/`CONTACT_DELETED` trigger), via `internal/contact-event-forwarder.ts` (shape
+ * defined here, channel wired in Slice 5) — so `add`/`remove` never double-emit.
+ *
+ * @module
+ */
+import type { ContactRepository } from '../internal/contact-repository';
+import type { SessionResolver } from '../internal/session';
+import type { ContactsDomain } from '../domains';
+import { type QueryClient, toQuery } from '../query';
+import type { Contact } from '../types/contact';
+import type { Query } from '../types/query';
+import type { UserProfile } from '../types/user';
+
+/** Stable query-key prefix for the saved-contacts list. */
+const CONTACTS_KEY = 'contacts';
+/** Stable query-key prefix for a single contact by id. */
+const CONTACT_KEY = 'contact';
+
+/**
+ * The contacts domain. Construct with the SDK-internal `QueryClient` (backs the observable
+ * reads), the contact repository (DB read/write), and the session resolver (current user id —
+ * contacts are owned/searched per user).
+ */
+export class ContactsDomainImpl implements ContactsDomain {
+  /**
+   * Per-key memo of the `Query` handles this domain exposes, so repeated calls with the same
+   * arguments return the SAME stable reference. Hidden inside the SDK.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous Query<T> memo, keyed by string
+  readonly #q = new Map<string, Query<any>>();
+
+  /**
+   * @param client - the SDK-internal TanStack `QueryClient` (never exposed to consumers).
+   * @param contacts - the `wallet.contacts` repository (holds the SDK Supabase client + domain).
+   * @param session - resolves the current user (id).
+   */
+  constructor(
+    private readonly client: QueryClient,
+    private readonly contacts: ContactRepository,
+    private readonly session: SessionResolver,
+  ) {}
+
+  /**
+   * Memoise a `Query` per stringified key: the FIRST call for a key builds the `Query` via
+   * {@link toQuery}; later calls return the same stable ref. Mirrors the per-key-memo the other
+   * reactive domains use (e.g. `accounts.list`).
+   */
+  #memo<T>(key: readonly unknown[], fn: () => Promise<T>): Query<T> {
+    const id = JSON.stringify(key);
+    let q = this.#q.get(id);
+    if (!q) {
+      q = toQuery<T>(this.client, key, fn);
+      this.#q.set(id, q);
+    }
+    return q;
+  }
+
+  /**
+   * All of the user's saved contacts, alphabetical by username — as an observable {@link Query}.
+   * Re-houses master `useContacts` / `getAll`. Wrapped in a {@link toQuery}-backed `Query`,
+   * memoised per key.
+   *
+   * @returns a stable `Query<Contact[]>`.
+   */
+  list(): Query<Contact[]> {
+    return this.#memo([CONTACTS_KEY], async () => {
+      const user = await this.session.requireCurrentUser();
+      return this.contacts.getAll(user.id);
+    });
+  }
+
+  /**
+   * The saved contact with this id, or `null` — as an observable {@link Query}. Re-houses master
+   * `useContact` (which finds it in the contacts list); here the fetch body reads the row
+   * directly, returning null when not found (master's repository `get` throws on a missing row;
+   * the contract returns null). Memoised per id.
+   *
+   * @param id - the contact id.
+   * @returns a stable `Query<Contact | null>`.
+   */
+  get(id: string): Query<Contact | null> {
+    return this.#memo([CONTACT_KEY, id], async () => {
+      try {
+        return await this.contacts.get(id);
+      } catch {
+        return null;
+      }
+    });
+  }
+
+  /**
+   * Add a contact by username (create). Re-houses master `useCreateContact` →
+   * `contact-repository.create` (owned by the current user). The `contact:created` event is
+   * forwarded from the realtime broadcast, not emitted here. An ACTION → `Promise`.
+   *
+   * @param params - `{ username }` of the Agicash user to add.
+   * @returns the created contact.
+   * @throws DomainError if the user's contact limit is reached.
+   */
+  async add(params: { username: string }): Promise<Contact> {
+    const user = await this.session.requireCurrentUser();
+    return this.contacts.create({
+      ownerId: user.id,
+      username: params.username,
+    });
+  }
+
+  /**
+   * Remove a saved contact (FULL object). Re-houses master `useDeleteContact` →
+   * `contact-repository.delete`. The `contact:deleted` event is forwarded from the realtime
+   * broadcast, not emitted here. An ACTION → `Promise`.
+   *
+   * @param contact - the contact to remove.
+   */
+  async remove(contact: Contact): Promise<void> {
+    await this.contacts.delete(contact.id);
+  }
+
+  /**
+   * Search addable user profiles by query (ONE-SHOT fetch → `Promise`). Re-houses master
+   * `useFindContactCandidates` → `findContactCandidates`: minimum 3 characters (shorter queries
+   * return `[]`), and the current user's existing contacts are excluded (the
+   * `find_contact_candidates` RPC does both).
+   *
+   * @param params - `{ query }` (the partial username).
+   * @returns the matching addable profiles (empty for queries under 3 chars).
+   */
+  async search(params: { query: string }): Promise<UserProfile[]> {
+    const user = await this.session.requireCurrentUser();
+    return this.contacts.findContactCandidates(params.query, user.id);
+  }
+}

--- a/packages/wallet-sdk/src/domains/transactions.test.ts
+++ b/packages/wallet-sdk/src/domains/transactions.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { TransactionsDomainImpl } from './transactions';
+import type { SessionResolver } from '../internal/session';
+import type { TransactionRepository } from '../internal/transaction-repository';
+import { QueryClient } from '../query';
+import { type Currency, Money } from '../types/money';
+import type { Query } from '../types/query';
+import type { Transaction, TransactionState } from '../types/transaction';
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+/** A fresh QueryClient per domain (the SDK-internal one in production). */
+function makeClient(): QueryClient {
+  return new QueryClient();
+}
+
+/** A minimal transaction in the given state (only the read fields matter). */
+function tx(id: string, state: TransactionState): Transaction {
+  return {
+    id,
+    state,
+    createdAt: `2026-01-0${id.length}T00:00:00.000Z`,
+    amount: sats(100),
+  } as Transaction;
+}
+
+/** A session resolver whose current user is `u1`. */
+const session = {
+  requireCurrentUser: mock(async () => ({ id: 'u1' })),
+} as unknown as SessionResolver;
+
+describe('TransactionsDomain.list (Query<T>, PENDING-first ordering + page cap)', () => {
+  test('list() returns a Query<T> (observable fetch), not a bare Promise', () => {
+    const repo = {
+      list: mock(async () => ({ transactions: [], nextCursor: null })),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const query: Query<{ transactions: Transaction[]; nextCursor: unknown }> =
+      domain.list();
+
+    expect(typeof query.subscribe).toBe('function');
+    expect(typeof query.toPromise).toBe('function');
+    expect(typeof query.getSnapshot).toBe('function');
+    expect(typeof query.refetch).toBe('function');
+  });
+
+  test('memoises one stable Query per (accountId, cursor, pageSize)', () => {
+    const repo = {
+      list: mock(async () => ({ transactions: [], nextCursor: null })),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    // Same args -> same stable ref; different args -> different ref.
+    expect(domain.list({ pageSize: 25 })).toBe(domain.list({ pageSize: 25 }));
+    expect(domain.list({ pageSize: 25 })).not.toBe(
+      domain.list({ pageSize: 10 }),
+    );
+  });
+
+  test('returns the repository page in order (PENDING first, as the RPC sorts it)', async () => {
+    // The list_transactions RPC sorts PENDING first; the domain returns that order untouched.
+    const page = {
+      transactions: [
+        tx('p', 'PENDING'),
+        tx('c', 'COMPLETED'),
+        tx('f', 'FAILED'),
+      ],
+      nextCursor: { stateSortOrder: 1, createdAt: 'x', id: 'f' },
+    };
+    const repo = {
+      list: mock(async () => page),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const result = await domain.list({ pageSize: 25 }).toPromise();
+
+    expect(result.transactions.map((t) => t.state)).toEqual([
+      'PENDING',
+      'COMPLETED',
+      'FAILED',
+    ]);
+  });
+
+  test('caps paging: nextCursor is kept when the page is FULL', async () => {
+    const full = Array.from({ length: 25 }, (_, i) => tx(`t${i}`, 'COMPLETED'));
+    const cursor = { stateSortOrder: 1, createdAt: 'x', id: 't24' };
+    const repo = {
+      list: mock(async () => ({ transactions: full, nextCursor: cursor })),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const result = await domain.list({ pageSize: 25 }).toPromise();
+
+    expect(result.nextCursor).toEqual(cursor);
+  });
+
+  test('caps paging: nextCursor is NULLED when the page came back SHORT', async () => {
+    const short = [tx('a', 'COMPLETED'), tx('b', 'COMPLETED')];
+    const cursor = { stateSortOrder: 1, createdAt: 'x', id: 'b' };
+    const repo = {
+      list: mock(async () => ({ transactions: short, nextCursor: cursor })),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const result = await domain.list({ pageSize: 25 }).toPromise();
+
+    // A short page means no next page (master's useTransactions caps the same way).
+    expect(result.nextCursor).toBeNull();
+  });
+
+  test('forwards the user id, cursor, accountId + pageSize to the repository', async () => {
+    const repo = {
+      list: mock(async () => ({ transactions: [], nextCursor: null })),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+    const cursor = { stateSortOrder: 2, createdAt: 'x', id: 'p' };
+
+    await domain.list({ accountId: 'acc1', cursor, pageSize: 10 }).toPromise();
+
+    expect(repo.list).toHaveBeenCalledWith({
+      userId: 'u1',
+      cursor,
+      pageSize: 10,
+      accountId: 'acc1',
+    });
+  });
+});
+
+describe('TransactionsDomain.get (Query<T>)', () => {
+  test('get(id) returns a Query that resolves to the transaction', async () => {
+    const target = tx('t1', 'COMPLETED');
+    const repo = {
+      get: mock(async () => target),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const query = domain.get('t1');
+    expect(typeof query.getSnapshot).toBe('function');
+    expect(await query.toPromise()).toBe(target);
+    // Memoised per id.
+    expect(domain.get('t1')).toBe(query);
+  });
+});
+
+describe('TransactionsDomain.acknowledge / countPendingAck', () => {
+  test('acknowledge (Promise) takes the FULL transaction and acks it by id for the user', async () => {
+    const acknowledgeTransaction = mock(async () => undefined);
+    const repo = { acknowledgeTransaction } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    await domain.acknowledge(tx('t1', 'COMPLETED'));
+
+    expect(acknowledgeTransaction).toHaveBeenCalledWith({
+      userId: 'u1',
+      transactionId: 't1',
+    });
+  });
+
+  test('countPendingAck() returns a Query resolving to the repository count for the user', async () => {
+    const repo = {
+      countTransactionsPendingAck: mock(async () => 3),
+    } as unknown as TransactionRepository;
+    const domain = new TransactionsDomainImpl(makeClient(), repo, session);
+
+    const query = domain.countPendingAck();
+    expect(typeof query.getSnapshot).toBe('function');
+    expect(await query.toPromise()).toBe(3);
+    expect(repo.countTransactionsPendingAck).toHaveBeenCalledWith({
+      userId: 'u1',
+    });
+  });
+});

--- a/packages/wallet-sdk/src/domains/transactions.ts
+++ b/packages/wallet-sdk/src/domains/transactions.ts
@@ -1,0 +1,166 @@
+/**
+ * `TransactionsDomain` implementation — §7 of the contract, Slice 4 (reactive overlay, design B).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/transactions/transaction-hooks.ts` (`useTransactions` /
+ * `useTransaction` / `useHasTransactionsPendingAck` / `useAcknowledgeTransaction`) +
+ * `transaction-repository.ts`. Master expresses these as React hooks over a TanStack
+ * `TransactionsCache` + an infinite query.
+ *
+ * REACTIVE OVERLAY: TanStack is no longer in the consumer — it is hidden inside the SDK.
+ *  - `list(filter?)` / `get(id)` / `countPendingAck()` are OBSERVABLE FETCHES → each returns a
+ *    `Query<T>`. The fetch BODY is the no-cache read (the repository DB read via the
+ *    `list_transactions` RPC / a row lookup / a `pending` count, scoped to the resolved user),
+ *    wrapped via {@link toQuery} over the SDK-internal `QueryClient` and MEMOISED per key (`#q`)
+ *    so repeated calls with the same arguments return the SAME stable `Query` ref (matching the
+ *    per-key-memo the other reactive domains use). `list` is memoised per
+ *    `accountId`/`cursor`/`pageSize`; `get` per id. Realtime (Slice 5) writes the same client to
+ *    push fresh values / invalidate these keys when a `transaction:*` change arrives.
+ *  - `acknowledge(transaction)` is a WRITE → stays `Promise` (lifted verbatim).
+ *
+ * Two-mode API rule (Josip 6/01): `list`/`get`/`countPendingAck` are FETCHES; `acknowledge`
+ * takes the FULL transaction object (user-invoked). Background-processor DB reads are Slice 5.
+ *
+ * @module
+ */
+import {
+  DEFAULT_TRANSACTION_PAGE_SIZE,
+  type TransactionRepository,
+} from '../internal/transaction-repository';
+import type { SessionResolver } from '../internal/session';
+import type { TransactionsDomain } from '../domains';
+import { type QueryClient, toQuery } from '../query';
+import type { Query } from '../types/query';
+import type { Transaction, TransactionCursor } from '../types/transaction';
+
+/** Stable query-key prefix for the (paginated) transaction list. */
+const TRANSACTIONS_KEY = 'transactions';
+/** Stable query-key prefix for a single transaction by id. */
+const TRANSACTION_KEY = 'transaction';
+/** Stable query-key prefix for the pending-acknowledgment count. */
+const TRANSACTIONS_PENDING_ACK_KEY = 'transactions:pendingAck';
+
+/**
+ * The transactions domain. Construct with the SDK-internal `QueryClient` (backs the observable
+ * reads), the transaction repository (DB read/write), and the session resolver (current user id,
+ * for the RLS-scoped user-id filter the RPCs/counts take).
+ */
+export class TransactionsDomainImpl implements TransactionsDomain {
+  /**
+   * Per-key memo of the `Query` handles this domain exposes, so repeated calls with the same
+   * arguments return the SAME stable reference. Hidden inside the SDK.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous Query<T> memo, keyed by string
+  readonly #q = new Map<string, Query<any>>();
+
+  /**
+   * @param client - the SDK-internal TanStack `QueryClient` (never exposed to consumers).
+   * @param transactions - the `wallet.transactions` repository.
+   * @param session - resolves the current user (id).
+   */
+  constructor(
+    private readonly client: QueryClient,
+    private readonly transactions: TransactionRepository,
+    private readonly session: SessionResolver,
+  ) {}
+
+  /**
+   * Memoise a `Query` per stringified key: the FIRST call for a key builds the `Query` via
+   * {@link toQuery}; later calls return the same stable ref. Mirrors the per-key-memo the other
+   * reactive domains use (e.g. `accounts.list`).
+   */
+  #memo<T>(key: readonly unknown[], fn: () => Promise<T>): Query<T> {
+    const id = JSON.stringify(key);
+    let q = this.#q.get(id);
+    if (!q) {
+      q = toQuery<T>(this.client, key, fn);
+      this.#q.set(id, q);
+    }
+    return q;
+  }
+
+  /**
+   * List transactions — as an observable {@link Query} of a state-sorted (PENDING first),
+   * cursor-paginated page. Re-houses master `useTransactions`: the fetch body calls the
+   * repository `list` (the `list_transactions` RPC) for the user, then CAPS paging exactly as
+   * master does — `nextCursor` is non-null only when the page came back full (a short page means
+   * there is no next page). `pageSize` defaults to master's 25. The reactive overlay wraps the
+   * body in a {@link toQuery}-backed `Query`, memoised per `accountId`/`cursor`/`pageSize`.
+   *
+   * @param params - optional `{ accountId, cursor, pageSize }`.
+   * @returns a stable `Query<{ transactions, nextCursor }>` (nextCursor null when exhausted).
+   */
+  list(params?: {
+    accountId?: string;
+    cursor?: TransactionCursor;
+    pageSize?: number;
+  }): Query<{
+    transactions: Transaction[];
+    nextCursor: TransactionCursor | null;
+  }> {
+    const pageSize = params?.pageSize ?? DEFAULT_TRANSACTION_PAGE_SIZE;
+    const accountId = params?.accountId;
+    const cursor = params?.cursor ?? null;
+
+    return this.#memo(
+      [TRANSACTIONS_KEY, accountId ?? null, cursor, pageSize],
+      async () => {
+        const user = await this.session.requireCurrentUser();
+        const result = await this.transactions.list({
+          userId: user.id,
+          cursor,
+          pageSize,
+          accountId,
+        });
+
+        return {
+          transactions: result.transactions,
+          // Master caps paging: only advance the cursor when the page was full.
+          nextCursor:
+            result.transactions.length === pageSize ? result.nextCursor : null,
+        };
+      },
+    );
+  }
+
+  /**
+   * The transaction with this id, or `null` — as an observable {@link Query}. Re-houses master
+   * `useTransaction`'s read (without the React `NotFoundError`-on-missing throw — the contract
+   * returns null). Memoised per id.
+   *
+   * @param id - the transaction id.
+   * @returns a stable `Query<Transaction | null>`.
+   */
+  get(id: string): Query<Transaction | null> {
+    return this.#memo([TRANSACTION_KEY, id], () => this.transactions.get(id));
+  }
+
+  /**
+   * The count of the user's transactions whose `acknowledgmentStatus` is `pending` — as an
+   * observable {@link Query}. Re-houses master `useHasTransactionsPendingAck`'s
+   * `countTransactionsPendingAck` (returning the count, not the `> 0` boolean the hook derives).
+   *
+   * @returns a stable `Query<number>`.
+   */
+  countPendingAck(): Query<number> {
+    return this.#memo([TRANSACTIONS_PENDING_ACK_KEY], async () => {
+      const user = await this.session.requireCurrentUser();
+      return this.transactions.countTransactionsPendingAck({ userId: user.id });
+    });
+  }
+
+  /**
+   * Mark `transaction` as acknowledged (FULL object). Re-houses master
+   * `useAcknowledgeTransaction`'s mutation (sans the cache writes — the consumer updates its own
+   * read-model from the resulting `transaction:updated` event). An ACTION → `Promise`.
+   *
+   * @param transaction - the transaction to acknowledge.
+   */
+  async acknowledge(transaction: Transaction): Promise<void> {
+    const user = await this.session.requireCurrentUser();
+    await this.transactions.acknowledgeTransaction({
+      userId: user.id,
+      transactionId: transaction.id,
+    });
+  }
+}

--- a/packages/wallet-sdk/src/domains/transfers.test.ts
+++ b/packages/wallet-sdk/src/domains/transfers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { TransfersDomainImpl } from './transfers';
+import type { SessionResolver } from '../internal/session';
+import type { TransferService } from '../internal/transfer-service';
+import type { CashuAccount, SparkAccount } from '../types/account';
+import { type Currency, Money } from '../types/money';
+import type { TransferQuote } from '../types/transfer';
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+const cashuSource = { id: 'cashu-src', type: 'cashu' } as CashuAccount;
+const sparkDest = { id: 'spark-dst', type: 'spark' } as SparkAccount;
+
+const session = {
+  requireCurrentUser: mock(async () => ({ id: 'u1' })),
+} as unknown as SessionResolver;
+
+/**
+ * The VERBATIM-FULL transfer quote the service returns from `getTransferQuote`: each leg carries
+ * its live `lightningQuote` as a VISIBLE, plain-data field (no symbol carrier). This is exactly
+ * what `createQuote` exposes and what `executeQuote` hands straight back to `initiateTransfer`.
+ */
+const fullQuote: TransferQuote = {
+  amount: sats(100),
+  amountToReceive: sats(98),
+  totalFees: sats(2),
+  totalCost: sats(100),
+  receive: {
+    account: sparkDest,
+    fee: sats(0),
+    lightningQuote: { invoice: { paymentRequest: 'lnbc-dest' } } as never,
+  },
+  send: {
+    account: cashuSource,
+    lightningQuote: { amountToReceive: sats(98) } as never,
+  },
+};
+
+describe('TransfersDomain createQuote → executeQuote (verbatim-full quote, no symbol)', () => {
+  test('createQuote returns the VERBATIM-FULL quote — legs are visible plain data WITH their lightningQuote', async () => {
+    const transferService = {
+      getTransferQuote: mock(async () => fullQuote),
+      initiateTransfer: mock(async () => ({
+        transferId: 't',
+        receiveTransactionId: 'r',
+        sendTransactionId: 's',
+      })),
+    } as unknown as TransferService;
+    const domain = new TransfersDomainImpl(transferService, session);
+
+    const quote = await domain.createQuote({
+      sourceAccount: cashuSource,
+      destinationAccount: sparkDest,
+      amount: sats(100),
+    });
+
+    // The full quote IS what the service produced (no slim projection).
+    expect(quote).toBe(fullQuote);
+    expect(quote.amount.toString()).toBe(sats(100).toString());
+    expect(quote.amountToReceive.toString()).toBe(sats(98).toString());
+    expect(quote.totalFees.toString()).toBe(sats(2).toString());
+    expect(quote.totalCost.toString()).toBe(sats(100).toString());
+    // Both legs expose the account AND the live lightningQuote as VISIBLE plain-data fields.
+    expect(quote.receive.account).toBe(sparkDest);
+    expect(quote.send.account).toBe(cashuSource);
+    expect(quote.receive.lightningQuote).toBeDefined();
+    expect(quote.send.lightningQuote).toBeDefined();
+    // The live legs ENUMERATE (no non-enumerable symbol carrier).
+    expect(Object.keys(quote.receive)).toEqual([
+      'account',
+      'fee',
+      'lightningQuote',
+    ]);
+    expect(Object.keys(quote.send)).toEqual(['account', 'lightningQuote']);
+  });
+
+  test('executeQuote reads the live legs DIRECTLY off the full quote and initiates the transfer with it', async () => {
+    const transferService = {
+      getTransferQuote: mock(async () => fullQuote),
+      initiateTransfer: mock(async () => ({
+        transferId: 't1',
+        receiveTransactionId: 'rx',
+        sendTransactionId: 'tx',
+      })),
+    } as unknown as TransferService;
+    const domain = new TransfersDomainImpl(transferService, session);
+
+    const quote = await domain.createQuote({
+      sourceAccount: cashuSource,
+      destinationAccount: sparkDest,
+      amount: sats(100),
+    });
+    const result = await domain.executeQuote(quote);
+
+    // The EXACT full quote (with the live legs) was handed to initiateTransfer — no recovery step.
+    expect(transferService.initiateTransfer).toHaveBeenCalledWith({
+      userId: 'u1',
+      quote: fullQuote,
+    });
+    expect(result).toEqual({
+      transferId: 't1',
+      receiveTransactionId: 'rx',
+      sendTransactionId: 'tx',
+    });
+  });
+
+  test('executeQuote accepts ANY full quote (no "must be created via createQuote" guard)', async () => {
+    const transferService = {
+      getTransferQuote: mock(async () => fullQuote),
+      initiateTransfer: mock(async () => ({
+        transferId: 't2',
+        receiveTransactionId: 'r2',
+        sendTransactionId: 's2',
+      })),
+    } as unknown as TransferService;
+    const domain = new TransfersDomainImpl(transferService, session);
+
+    // A hand-built full quote (the verbatim-full shape, never passed through createQuote) executes
+    // directly — the legs are just data; there is no provenance guard.
+    const handBuilt: TransferQuote = {
+      amount: sats(50),
+      amountToReceive: sats(49),
+      totalFees: sats(1),
+      totalCost: sats(50),
+      receive: {
+        account: sparkDest,
+        fee: sats(0),
+        lightningQuote: { invoice: { paymentRequest: 'lnbc-x' } } as never,
+      },
+      send: {
+        account: cashuSource,
+        lightningQuote: { amountToReceive: sats(49) } as never,
+      },
+    };
+
+    const result = await domain.executeQuote(handBuilt);
+
+    expect(transferService.initiateTransfer).toHaveBeenCalledWith({
+      userId: 'u1',
+      quote: handBuilt,
+    });
+    expect(result.transferId).toBe('t2');
+  });
+});

--- a/packages/wallet-sdk/src/domains/transfers.ts
+++ b/packages/wallet-sdk/src/domains/transfers.ts
@@ -1,0 +1,83 @@
+/**
+ * `TransfersDomain` implementation — §9 of the contract, Slice 4.
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/transfer/transfer-hooks.ts` (`useGetTransferQuote` /
+ * `useInitiateTransfer`) + `transfer-service.ts`. Master expresses these as TanStack mutations
+ * over the service; the SDK exposes them as `createQuote` / `executeQuote` (naming aligned with
+ * cashu/spark, decision 4) over the re-housed `internal/transfer-service.ts`.
+ *
+ * A transfer COMPOSES a Slice-3 cashu leg + a spark leg: `createQuote` fetches both legs'
+ * lightning quotes (does not persist); `executeQuote` persists the paired send + receive quotes
+ * linked by a `transferId`, AUTO-FAILING the receive if the send fails to persist (§9). The
+ * background processor then drives the send to completion (no `transfer:*` events, decision 5 —
+ * the consumer reconstructs status from the two linked `transaction:*` events).
+ *
+ * Two-mode API rule: `executeQuote` takes the FULL {@link TransferQuote} returned by
+ * `createQuote`. That quote is the VERBATIM-FULL master shape (§9) — each leg's live Lightning
+ * quote is a VISIBLE, plain-data field — so `executeQuote` hands the quote straight back to the
+ * service, which reads the live legs DIRECTLY (no slim projection, no symbol carrier, no
+ * "must be created via createQuote" guard, no re-quoting the mint).
+ *
+ * @module
+ */
+import type { SessionResolver } from '../internal/session';
+import type { TransferService } from '../internal/transfer-service';
+import type { TransfersDomain } from '../domains';
+import type { Account } from '../types/account';
+import type { Money } from '../types/money';
+import type { TransferQuote, TransferResult } from '../types/transfer';
+
+/**
+ * The transfers domain. Construct with the internal transfer service and the session resolver
+ * (current user id, for the persist path).
+ */
+export class TransfersDomainImpl implements TransfersDomain {
+  /**
+   * @param transferService - the re-housed cross-account transfer service.
+   * @param session - resolves the current user (id).
+   */
+  constructor(
+    private readonly transferService: TransferService,
+    private readonly session: SessionResolver,
+  ) {}
+
+  /**
+   * Quote a cross-account transfer (cost preview; not persisted). Re-houses master
+   * `useGetTransferQuote` → `getTransferQuote`. Returns the VERBATIM-FULL {@link TransferQuote}:
+   * both legs expose their live Lightning quote as plain data, so the quote round-trips to
+   * `executeQuote` with no symbol carrier and no re-quoting.
+   *
+   * @param params - `{ sourceAccount, destinationAccount, amount }`.
+   * @returns the full transfer quote (live legs visible).
+   * @throws DomainError if the source can't send / the destination can't receive over Lightning.
+   */
+  createQuote(params: {
+    sourceAccount: Account;
+    destinationAccount: Account;
+    amount: Money;
+  }): Promise<TransferQuote> {
+    return this.transferService.getTransferQuote(params);
+  }
+
+  /**
+   * Execute a previously-created transfer quote (FULL object). Re-houses master
+   * `useInitiateTransfer` → `initiateTransfer`: persists the paired send + receive quotes linked
+   * by a `transferId` (auto-failing the receive on send-persist failure, §9). Resolves with both
+   * leg transaction ids + the shared `transferId`; the background processor drives the send.
+   *
+   * Reads the live legs DIRECTLY off the full `quote` (the verbatim-full master shape) — no
+   * symbol recovery, no guard.
+   *
+   * @param quote - the full quote returned by {@link createQuote} (its legs carry the live
+   *   Lightning quotes the persist path consumes).
+   * @returns `{ transferId, receiveTransactionId, sendTransactionId }`.
+   */
+  async executeQuote(quote: TransferQuote): Promise<TransferResult> {
+    const user = await this.session.requireCurrentUser();
+    return this.transferService.initiateTransfer({
+      userId: user.id,
+      quote,
+    });
+  }
+}

--- a/packages/wallet-sdk/src/index.ts
+++ b/packages/wallet-sdk/src/index.ts
@@ -95,9 +95,11 @@ export type {
 } from './types/transaction';
 
 export type { Contact } from './types/contact';
+export type { Destination } from './types/destination';
 
 export type {
-  TransferLeg,
+  TransferReceiveSide,
+  TransferSendSide,
   TransferQuote,
   TransferResult,
 } from './types/transfer';

--- a/packages/wallet-sdk/src/internal/contact-event-forwarder.test.ts
+++ b/packages/wallet-sdk/src/internal/contact-event-forwarder.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { ContactEventForwarder } from './contact-event-forwarder';
+import { TypedEventEmitter } from './event-emitter';
+import type { AgicashDbContact } from './db-contact';
+import type { SdkEventMap } from '../types/events';
+
+const row: AgicashDbContact = {
+  id: 'c1',
+  created_at: '2026-02-02T00:00:00.000Z',
+  owner_id: 'u1',
+  username: 'alice',
+};
+
+describe('ContactEventForwarder (net-new contact:* events, §11)', () => {
+  test('CONTACT_CREATED → contact:created carrying the domain Contact (lud16 computed)', () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    const seen: SdkEventMap['contact:created'][] = [];
+    events.on('contact:created', (e) => seen.push(e));
+
+    new ContactEventForwarder('agicash.me', events).handleChange(
+      'CONTACT_CREATED',
+      row,
+    );
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.contact).toEqual({
+      id: 'c1',
+      createdAt: '2026-02-02T00:00:00.000Z',
+      ownerId: 'u1',
+      username: 'alice',
+      lud16: 'alice@agicash.me',
+    });
+  });
+
+  test('CONTACT_DELETED → contact:deleted carrying ONLY the contactId', () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    const seen: SdkEventMap['contact:deleted'][] = [];
+    events.on('contact:deleted', (e) => seen.push(e));
+
+    new ContactEventForwarder('agicash.me', events).handleChange(
+      'CONTACT_DELETED',
+      row,
+    );
+
+    expect(seen).toEqual([{ contactId: 'c1' }]);
+  });
+
+  test('the op is read from the event NAME (a CREATE does not emit contact:deleted)', () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    let deleted = 0;
+    events.on('contact:deleted', () => deleted++);
+
+    new ContactEventForwarder('agicash.me', events).handleChange(
+      'CONTACT_CREATED',
+      row,
+    );
+
+    expect(deleted).toBe(0);
+  });
+});

--- a/packages/wallet-sdk/src/internal/contact-event-forwarder.ts
+++ b/packages/wallet-sdk/src/internal/contact-event-forwarder.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal contact realtime → SDK-event forwarder — Slice 4 (contacts).
+ *
+ * NET-NEW (the event-SHAPE contract for `contact:created` / `contact:deleted`, §11). GENERALIZES
+ * master's `contact-hooks.ts#useContactChangeHandlers` (which maps the `CONTACT_CREATED` /
+ * `CONTACT_DELETED` broadcast events into TanStack-cache add/remove): here it translates them into
+ * the SDK's typed events.
+ *
+ * The op is encoded in the event NAME → distinct typed events: `CONTACT_CREATED` →
+ * `contact:created` (carrying the full {@link Contact}, with its `lud16` computed from the
+ * configured `domain`); `CONTACT_DELETED` → `contact:deleted` (carrying only the `contactId` —
+ * contacts have no `version`, so dedupe/order is op-type + refetch, §8).
+ *
+ * The REALTIME SUBSCRIPTION that delivers these payloads is Slice 5/PR7 — THIS slice DEFINES +
+ * tests the shape + the emit path. Slice 5 wires the channel to call {@link handleChange}.
+ *
+ * @module
+ */
+import { ContactRepository } from './contact-repository';
+import type { TypedEventEmitter } from './event-emitter';
+import type { AgicashDbContact } from './db-contact';
+import type { SdkEventMap } from '../types/events';
+
+/** The two contact realtime event names master broadcasts. */
+export type ContactChangeEvent = 'CONTACT_CREATED' | 'CONTACT_DELETED';
+
+/**
+ * Translates `wallet.contacts` realtime DB-change payloads into the SDK's typed `contact:*`
+ * events. Holds the Agicash `domain` (to compute a created contact's `lud16`) + the event
+ * emitter; constructed by the SDK and driven by the Slice-5 realtime channel.
+ */
+export class ContactEventForwarder {
+  /**
+   * @param domain - the Agicash Lightning-address domain (for a created contact's `lud16`).
+   * @param events - the SDK event emitter.
+   */
+  constructor(
+    private readonly domain: string,
+    private readonly events: TypedEventEmitter<SdkEventMap>,
+  ) {}
+
+  /**
+   * Translate one contact DB-change into the matching typed SDK event.
+   *
+   * - `CONTACT_CREATED` → `contact:created` (the row mapped to a domain {@link Contact}).
+   * - `CONTACT_DELETED` → `contact:deleted` (only the id is carried).
+   *
+   * @param event - the broadcast event name (encodes the op).
+   * @param payload - the changed contact row.
+   */
+  handleChange(event: ContactChangeEvent, payload: AgicashDbContact): void {
+    if (event === 'CONTACT_CREATED') {
+      const contact = ContactRepository.toContact(payload, this.domain);
+      this.events.emit('contact:created', { contact });
+      return;
+    }
+
+    this.events.emit('contact:deleted', { contactId: payload.id });
+  }
+}

--- a/packages/wallet-sdk/src/internal/contact-repository.test.ts
+++ b/packages/wallet-sdk/src/internal/contact-repository.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { ContactRepository } from './contact-repository';
+import type { AgicashDbContact } from './db-contact';
+import type { WalletSupabaseClient } from './supabase-client';
+
+// -- Fakes ----------------------------------------------------------------------------------
+
+/** Terminal result shape every builder call resolves to. */
+type Result = { data: unknown; error: unknown };
+
+/**
+ * A fake Supabase client. The fluent `from(...).select/eq/limit/order/insert/delete/...` chain is
+ * a no-op thenable that resolves to `fromResult`; the terminal `single()` resolves to it too. The
+ * `rpc(name, args)` records its call and resolves to `rpcResult`. Only the methods the contact
+ * repository touches are implemented.
+ */
+function fakeDb(
+  fromResult: Result,
+  rpcResult: Result = { data: [], error: null },
+) {
+  const rpcCalls: Array<{ fn: string; args: unknown }> = [];
+  const chain: Record<string, unknown> & PromiseLike<Result> = {
+    select: () => chain,
+    insert: () => chain,
+    delete: () => chain,
+    eq: () => chain,
+    limit: () => chain,
+    order: () => chain,
+    abortSignal: () => chain,
+    single: async () => fromResult,
+    // biome-ignore lint/suspicious/noThenProperty: intentionally mocking the thenable Supabase query builder.
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve(fromResult).then(onFulfilled, onRejected),
+  };
+  const rpcChain: Record<string, unknown> & PromiseLike<Result> = {
+    abortSignal: () => rpcChain,
+    // biome-ignore lint/suspicious/noThenProperty: intentionally mocking the thenable Supabase rpc builder.
+    then: (onFulfilled, onRejected) =>
+      Promise.resolve(rpcResult).then(onFulfilled, onRejected),
+  };
+  const db = {
+    from: () => chain,
+    rpc: mock((fn: string, args: unknown) => {
+      rpcCalls.push({ fn, args });
+      return rpcChain;
+    }),
+  } as unknown as WalletSupabaseClient;
+  return { db, rpcCalls };
+}
+
+const row: AgicashDbContact = {
+  id: 'c1',
+  created_at: '2026-02-02T00:00:00.000Z',
+  owner_id: 'u1',
+  username: 'alice',
+};
+
+// -- toContact / CONTACT DRIFT ----------------------------------------------------------------
+
+describe('ContactRepository.toContact (CONTACT DRIFT — master shape)', () => {
+  test('createdAt is the ISO string off the row + lud16 is computed `${username}@${domain}`', () => {
+    const contact = ContactRepository.toContact(row, 'agicash.me');
+
+    expect(contact).toEqual({
+      id: 'c1',
+      createdAt: '2026-02-02T00:00:00.000Z', // string, NOT a Date
+      ownerId: 'u1',
+      username: 'alice',
+      lud16: 'alice@agicash.me', // computed at runtime, not stored
+    });
+    // createdAt must be a string per the master-verbatim reconciliation.
+    expect(typeof contact.createdAt).toBe('string');
+  });
+
+  test('a null username coalesces to an empty username', () => {
+    const contact = ContactRepository.toContact(
+      { ...row, username: null },
+      'agicash.me',
+    );
+    expect(contact.username).toBe('');
+  });
+});
+
+// -- getAll / lud16 over a list ---------------------------------------------------------------
+
+describe('ContactRepository.getAll', () => {
+  test('maps each row to a domain contact with a computed lud16', async () => {
+    const rows: AgicashDbContact[] = [
+      row,
+      {
+        id: 'c2',
+        created_at: '2026-02-03T00:00:00.000Z',
+        owner_id: 'u1',
+        username: 'bob',
+      },
+    ];
+    const { db } = fakeDb({ data: rows, error: null });
+    const repo = new ContactRepository(db, 'agicash.me');
+
+    const contacts = await repo.getAll('u1');
+
+    expect(contacts.map((c) => c.lud16)).toEqual([
+      'alice@agicash.me',
+      'bob@agicash.me',
+    ]);
+  });
+});
+
+// -- search (findContactCandidates) -----------------------------------------------------------
+
+describe('ContactRepository.findContactCandidates (search)', () => {
+  test('returns [] WITHOUT hitting the RPC for a query under 3 chars (incl. after trim)', async () => {
+    const { db, rpcCalls } = fakeDb({ data: null, error: null });
+    const repo = new ContactRepository(db, 'agicash.me');
+
+    expect(await repo.findContactCandidates('ab', 'u1')).toEqual([]);
+    expect(await repo.findContactCandidates('  a ', 'u1')).toEqual([]);
+    // The min-3 guard short-circuits before the RPC.
+    expect(rpcCalls).toHaveLength(0);
+  });
+
+  test('calls find_contact_candidates with the TRIMMED query + current user (server excludes existing)', async () => {
+    const candidates = [
+      { id: 'p1', username: 'alice' },
+      { id: 'p2', username: 'alistair' },
+    ];
+    const { db, rpcCalls } = fakeDb(
+      { data: null, error: null },
+      { data: candidates, error: null },
+    );
+    const repo = new ContactRepository(db, 'agicash.me');
+
+    const result = await repo.findContactCandidates('  ali  ', 'u1');
+
+    // The RPC (which excludes the user's existing contacts) is called with the trimmed query.
+    expect(rpcCalls).toEqual([
+      {
+        fn: 'find_contact_candidates',
+        args: { partial_username: 'ali', current_user_id: 'u1' },
+      },
+    ]);
+    // Returns the (already-excluded) candidates verbatim — UserProfiles carry NO lud16.
+    expect(result).toEqual(candidates);
+    expect(result[0]).not.toHaveProperty('lud16');
+  });
+
+  test('throws when the search RPC errors', async () => {
+    const { db } = fakeDb(
+      { data: null, error: null },
+      { data: null, error: { message: 'boom' } },
+    );
+    const repo = new ContactRepository(db, 'agicash.me');
+
+    await expect(repo.findContactCandidates('alice', 'u1')).rejects.toThrow(
+      'Failed to search users',
+    );
+  });
+});

--- a/packages/wallet-sdk/src/internal/contact-repository.ts
+++ b/packages/wallet-sdk/src/internal/contact-repository.ts
@@ -1,0 +1,225 @@
+/**
+ * Internal `wallet.contacts` repository — Slice 4 (contacts).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/contacts/contact-repository.ts`. Master's `ContactRepository` is
+ * ALREADY a plain class taking `(db, domain)` — only the `useContactRepository()` factory (which
+ * reads `agicashDbClient` + `useLocationData().domain`) couples it to React. Here it takes the
+ * SDK-owned Supabase client + the `domain` from {@link SdkConfig} (re-housed off the hook). All
+ * query logic — `get` / `getAll` (alpha-sorted, limit 150) / `create` / `delete` /
+ * `findContactCandidates` (the `find_contact_candidates` RPC) — is verbatim from master.
+ *
+ * `toContact` computes the contact's `lud16` as `` `${username}@${domain}` `` at runtime (the
+ * CONTACT DRIFT reconciliation — `lud16` is NOT a stored column, `createdAt` is the ISO string
+ * straight off the row). Contacts have no `version` column.
+ *
+ * @module
+ */
+import { DomainError } from '../errors';
+import type { AgicashDbContact } from './db-contact';
+import type { WalletSupabaseClient } from './supabase-client';
+import type { Contact } from '../types/contact';
+import type { UserProfile } from '../types/user';
+
+/** Per-call query options (an abort signal, matching master). */
+type Options = { abortSignal?: AbortSignal };
+
+/** Params for {@link ContactRepository.create} (master `CreateContact`). */
+type CreateContact = {
+  /** Id of the user creating the contact. */
+  ownerId: string;
+  /** Username of the user within this app to add as a contact. */
+  username: string;
+};
+
+/**
+ * Reads + writes for the `wallet.contacts` table, scoped (via RLS) to the signed-in user. Holds
+ * the SDK-owned Supabase client + the Agicash `domain` used to compute each contact's `lud16`.
+ */
+export class ContactRepository {
+  /**
+   * @param db - the SDK-owned Supabase client (schema pinned to `wallet`).
+   * @param domain - the Agicash Lightning-address domain (for `lud16`); empty string if unset.
+   */
+  constructor(
+    private readonly db: WalletSupabaseClient,
+    private readonly domain: string,
+  ) {}
+
+  /**
+   * Get the contact with the given id.
+   *
+   * Verbatim logic from master `ContactRepository.get`.
+   *
+   * @param contactId - the contact id.
+   * @returns the contact.
+   * @throws Error if the read fails (master throws on not-found too).
+   */
+  async get(contactId: string): Promise<Contact> {
+    const query = this.db.from('contacts').select().eq('id', contactId);
+
+    const { data, error } = await query.single();
+
+    if (error) {
+      throw new Error('Failed to get contact', { cause: error });
+    }
+
+    return ContactRepository.toContact(data as AgicashDbContact, this.domain);
+  }
+
+  /**
+   * Get all contacts for a user, alphabetically by username (limit 150).
+   *
+   * Verbatim logic from master `ContactRepository.getAll`.
+   *
+   * @param ownerId - the id of the user whose contacts to fetch.
+   * @param options - optional abort signal.
+   * @returns the contacts.
+   * @throws Error if the read fails.
+   */
+  async getAll(ownerId: string, options?: Options): Promise<Contact[]> {
+    const query = this.db
+      .from('contacts')
+      .select()
+      .eq('owner_id', ownerId)
+      .limit(150)
+      .order('username', { ascending: true }); // sort alphabetically
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error('Failed to get contacts', { cause: error });
+    }
+
+    return (data as AgicashDbContact[]).map((contact) =>
+      ContactRepository.toContact(contact, this.domain),
+    );
+  }
+
+  /**
+   * Create a new contact for a user.
+   *
+   * Verbatim logic from master `ContactRepository.create`.
+   *
+   * @param contact - `{ ownerId, username }`.
+   * @param options - optional abort signal.
+   * @returns the created contact.
+   * @throws DomainError if the user's contact limit is reached.
+   * @throws Error if the insert otherwise fails.
+   */
+  async create(contact: CreateContact, options?: Options): Promise<Contact> {
+    const query = this.db
+      .from('contacts')
+      .insert({
+        owner_id: contact.ownerId,
+        username: contact.username,
+      })
+      .select();
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query.single();
+
+    if (error) {
+      if (error.hint === 'LIMIT_REACHED') {
+        throw new DomainError(`${error.message} ${error.details ?? ''}`.trim());
+      }
+
+      throw new Error('Failed to create contact', { cause: error });
+    }
+
+    return ContactRepository.toContact(data as AgicashDbContact, this.domain);
+  }
+
+  /**
+   * Delete a contact.
+   *
+   * Verbatim logic from master `ContactRepository.delete`.
+   *
+   * @param contactId - the id of the contact to delete.
+   * @param options - optional abort signal.
+   * @throws Error if the delete fails.
+   */
+  async delete(contactId: string, options?: Options): Promise<void> {
+    const query = this.db.from('contacts').delete().eq('id', contactId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { error } = await query;
+
+    if (error) {
+      throw new Error('Failed to delete contact', { cause: error });
+    }
+  }
+
+  /**
+   * Search for user profiles by partial username, EXCLUDING the current user's existing
+   * contacts. Returns an empty array for queries shorter than 3 characters (after trim).
+   *
+   * Verbatim logic from master `ContactRepository.findContactCandidates` (the
+   * `find_contact_candidates` RPC).
+   *
+   * @param query - the partial username to search for.
+   * @param currentUserId - the id of the current user (its contacts are excluded).
+   * @param options - optional abort signal.
+   * @returns the matching addable user profiles.
+   * @throws Error if the search fails.
+   */
+  async findContactCandidates(
+    query: string,
+    currentUserId: string,
+    options?: Options,
+  ): Promise<UserProfile[]> {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length < 3) {
+      return [];
+    }
+
+    // The `find_contact_candidates` RPC lives in the stored procedure, not the untyped client's
+    // type space — cast the call (matching the other repos).
+    // biome-ignore lint/suspicious/noExplicitAny: see above.
+    let rpcQuery = (this.db.rpc as any)('find_contact_candidates', {
+      partial_username: trimmedQuery,
+      current_user_id: currentUserId,
+    });
+
+    if (options?.abortSignal) {
+      rpcQuery = rpcQuery.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await rpcQuery;
+
+    if (error) {
+      throw new Error('Failed to search users', { cause: error });
+    }
+
+    return data as UserProfile[];
+  }
+
+  /**
+   * Map a `wallet.contacts` DB row to the domain {@link Contact}, computing `lud16` as
+   * `` `${username}@${domain}` `` (the runtime-derived field — CONTACT DRIFT reconciliation).
+   * Verbatim from master `ContactRepository.toContact`.
+   *
+   * @param dbContact - the contact row.
+   * @param domain - the Agicash Lightning-address domain.
+   * @returns the domain contact.
+   */
+  static toContact(dbContact: AgicashDbContact, domain: string): Contact {
+    return {
+      id: dbContact.id,
+      createdAt: dbContact.created_at,
+      ownerId: dbContact.owner_id,
+      username: dbContact.username ?? '',
+      lud16: `${dbContact.username}@${domain}`,
+    };
+  }
+}

--- a/packages/wallet-sdk/src/internal/db-contact.ts
+++ b/packages/wallet-sdk/src/internal/db-contact.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal `wallet.contacts` DB row type — Slice 4 (contacts).
+ *
+ * Lifted from master `agicash-db/database.ts#AgicashDbContact`
+ * (`Database['wallet']['Tables']['contacts']['Row']`, generated in `supabase/database.types.ts`).
+ * Hand-written here (as in `db-account.ts` / `db-transaction.ts`) so the SDK can type the
+ * otherwise-untyped Supabase reads without pulling the full generated `Database` types. NOTE:
+ * `username` is nullable on the row (master's `toContact` coalesces it to `''`); there is NO
+ * `version` column (contacts are CREATE/DELETE only).
+ *
+ * @module
+ */
+
+/** A row of the `wallet.contacts` table. */
+export type AgicashDbContact = {
+  /** UUID primary key. */
+  id: string;
+  /** Row creation time, ISO 8601. */
+  created_at: string;
+  /** Owning user id. */
+  owner_id: string;
+  /** Referenced user's username (nullable on the row). */
+  username: string | null;
+};

--- a/packages/wallet-sdk/src/internal/db-transaction.ts
+++ b/packages/wallet-sdk/src/internal/db-transaction.ts
@@ -1,0 +1,81 @@
+/**
+ * Internal `wallet.transactions` DB row type — Slice 4 (transactions).
+ *
+ * Lifted from master `agicash-db/database.ts#AgicashDbTransaction`
+ * (`Database['wallet']['Tables']['transactions']['Row']`, generated in
+ * `supabase/database.types.ts`). Hand-written here (as in `db-account.ts` / the quote repos)
+ * so the SDK can type the otherwise-untyped Supabase reads without pulling the full generated
+ * `Database` types (lifted in a later slice). The `list_transactions` RPC returns this same
+ * row shape.
+ *
+ * `encrypted_transaction_details` is ENCRYPTED ciphertext (the per-variant `*DbData` jsonb,
+ * decrypted + parsed by {@link TransactionRepository.toTransaction}); `transaction_details` is
+ * the small unencrypted jsonb the parsers also read (`paymentHash` / `sparkId` / `transferId`).
+ *
+ * @module
+ */
+import type { Json } from 'supabase/database.types';
+import type { AccountPurpose, AccountType } from '../types/account';
+import type { Currency } from '../types/money';
+import type {
+  TransactionDirection,
+  TransactionState,
+  TransactionType,
+} from '../types/transaction';
+
+/** Small unencrypted `transactions.transaction_details` jsonb the parsers read (master `Json`). */
+type AgicashDbTransactionDetailsJson = Json | null;
+
+/**
+ * A row of the `wallet.transactions` table (and the shape returned by the `list_transactions`
+ * RPC). Verbatim columns from the generated `transactions` Row.
+ */
+export type AgicashDbTransaction = {
+  /** UUID primary key. */
+  id: string;
+  /** Owning user id. */
+  user_id: string;
+  /** Account the transaction debited/credited; null if that account was since deleted. */
+  account_id: string | null;
+  /** Denormalized account name at transaction time. */
+  account_name: string;
+  /** Denormalized account type at transaction time. */
+  account_type: AccountType;
+  /** Denormalized account purpose at transaction time. */
+  account_purpose: AccountPurpose;
+  /** Account currency. */
+  currency: Currency;
+  /** SEND or RECEIVE. */
+  direction: TransactionDirection;
+  /** Protocol + rail. */
+  type: TransactionType;
+  /** Lifecycle state. */
+  state: TransactionState;
+  /** Encrypted per-variant details jsonb (decrypted + parsed in `toTransaction`). */
+  encrypted_transaction_details: string;
+  /** Small unencrypted details jsonb (paymentHash / sparkId / transferId). */
+  transaction_details: AgicashDbTransactionDetailsJson;
+  /** `'PAYMENT' | 'BUY_CASHAPP' | 'TRANSFER'`. */
+  purpose: TransactionPurposeColumn;
+  /** Tri-state ack column. */
+  acknowledgment_status: 'pending' | 'acknowledged' | null;
+  /** UUID of the transaction this one reverses, if any. */
+  reversed_transaction_id: string | null;
+  /** State-derived sort key (PENDING sorts first); computed DB-side. */
+  state_sort_order: number | null;
+  /** Row creation time, ISO 8601. */
+  created_at: string;
+  /** When set to pending, ISO 8601. */
+  pending_at: string | null;
+  /** When completed, ISO 8601. */
+  completed_at: string | null;
+  /** When failed, ISO 8601. */
+  failed_at: string | null;
+  /** When reversed, ISO 8601. */
+  reversed_at: string | null;
+  /** Row version (optimistic lock). */
+  version: number;
+};
+
+/** The `transactions.purpose` enum column. */
+type TransactionPurposeColumn = 'PAYMENT' | 'BUY_CASHAPP' | 'TRANSFER';

--- a/packages/wallet-sdk/src/internal/destination.test.ts
+++ b/packages/wallet-sdk/src/internal/destination.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveDestination } from './destination';
+import type { Contact } from '../types/contact';
+import type { Destination } from '../types/destination';
+
+const contact: Contact = {
+  id: 'c1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ownerId: 'u1',
+  username: 'alice',
+  lud16: 'alice@agicash.me',
+};
+
+describe('resolveDestination (typed Destination, decision 6)', () => {
+  test('agicash-contact resolves to the contact lud16 + preserves the contact link', () => {
+    const dest: Destination = { kind: 'agicash-contact', contact };
+
+    const resolved = resolveDestination(dest);
+
+    // Resolves to the contact's lud16 (so createLightningQuote can LNURL-resolve it)...
+    expect(resolved.paymentTarget).toBe('alice@agicash.me');
+    // ...and stamps the AGICASH_CONTACT details with the contactId (the preserved link).
+    expect(resolved.destinationDetails).toEqual({
+      sendType: 'AGICASH_CONTACT',
+      contactId: 'c1',
+    });
+  });
+
+  test('payment-request that is an ln-address stamps LN_ADDRESS details', () => {
+    const dest: Destination = {
+      kind: 'payment-request',
+      paymentRequest: 'bob@example.com',
+    };
+
+    const resolved = resolveDestination(dest);
+
+    expect(resolved.paymentTarget).toBe('bob@example.com');
+    expect(resolved.destinationDetails).toEqual({
+      sendType: 'LN_ADDRESS',
+      lnAddress: 'bob@example.com',
+    });
+  });
+
+  test('payment-request that is a bare bolt11 carries NO destinationDetails', () => {
+    const dest: Destination = {
+      kind: 'payment-request',
+      paymentRequest: 'lnbc1pabc...',
+    };
+
+    const resolved = resolveDestination(dest);
+
+    expect(resolved.paymentTarget).toBe('lnbc1pabc...');
+    expect(resolved.destinationDetails).toBeUndefined();
+  });
+});

--- a/packages/wallet-sdk/src/internal/destination.ts
+++ b/packages/wallet-sdk/src/internal/destination.ts
@@ -1,0 +1,63 @@
+/**
+ * Internal send-`Destination` resolution — Slice 4 (contacts / send-to-contact).
+ *
+ * Pure helper backing the net-new typed {@link Destination} (decision 6). GENERALIZES master's
+ * `send/resolve-destination.ts` `AGICASH_CONTACT` branch: given a `Destination`, produce the two
+ * things the cashu/spark lightning-send path consumes —
+ *  - the `paymentTarget` string the send's `createLightningQuote` resolves (a bolt11 invoice or a
+ *    `user@domain` ln-address; for a contact it is the contact's `lud16`, resolved via LNURL-pay),
+ *  - the optional {@link DestinationDetails} stamped on the send so the resulting transaction
+ *    records `{ sendType: 'AGICASH_CONTACT', contactId }` (master's contact link) or
+ *    `{ sendType: 'LN_ADDRESS', lnAddress }`, undefined when paying a bare bolt11.
+ *
+ * Pure (no DB, no network) — so it can be unit-tested directly and reused by both send domains.
+ *
+ * @module
+ */
+import type { DestinationDetails } from '../types/cashu';
+import type { Destination } from '../types/destination';
+
+/** The resolved send target derived from a {@link Destination}. */
+export type ResolvedDestination = {
+  /** The bolt11 invoice OR `user@domain` ln-address the send resolves (a contact's `lud16`). */
+  paymentTarget: string;
+  /**
+   * The details stamped on the send for history. Present for a contact (`AGICASH_CONTACT`) or an
+   * ln-address (`LN_ADDRESS`); `undefined` when the target is a bare bolt11 invoice.
+   */
+  destinationDetails?: DestinationDetails;
+};
+
+/**
+ * Resolve a typed {@link Destination} into its `{ paymentTarget, destinationDetails }`.
+ *
+ * - `agicash-contact` → target = the contact's `lud16`; details = `{ sendType: 'AGICASH_CONTACT',
+ *   contactId }` (preserves the contact link).
+ * - `payment-request` → target = the raw string; details = `{ sendType: 'LN_ADDRESS', lnAddress }`
+ *   when it is a `user@domain` ln-address (detected by an `@`), else `undefined` (a bare bolt11).
+ *
+ * @param destination - the typed destination.
+ * @returns the resolved target + optional details.
+ */
+export function resolveDestination(
+  destination: Destination,
+): ResolvedDestination {
+  if (destination.kind === 'agicash-contact') {
+    return {
+      paymentTarget: destination.contact.lud16,
+      destinationDetails: {
+        sendType: 'AGICASH_CONTACT',
+        contactId: destination.contact.id,
+      },
+    };
+  }
+
+  const { paymentRequest } = destination;
+  if (paymentRequest.includes('@')) {
+    return {
+      paymentTarget: paymentRequest,
+      destinationDetails: { sendType: 'LN_ADDRESS', lnAddress: paymentRequest },
+    };
+  }
+  return { paymentTarget: paymentRequest };
+}

--- a/packages/wallet-sdk/src/internal/lib-contacts.ts
+++ b/packages/wallet-sdk/src/internal/lib-contacts.ts
@@ -1,0 +1,15 @@
+/**
+ * SDK-internal contact **runtime schema** single-source re-export — Slice 4 (contacts).
+ *
+ * Re-exports master's `ContactSchema` + `isContact` guard from
+ * `apps/web-wallet/app/features/contacts/contact.ts` (pure `zod/mini` — verified no react /
+ * @tanstack) via the relative path, single-source, so the public `Contact` `z.infer` shape in
+ * `types/contact.ts` can never drift from master's schema. The repository maps rows directly
+ * (master does not `parse` in `toContact`), but the guard is available for callers + tests.
+ *
+ * @module
+ */
+export {
+  type Contact as ContactSchemaInfer,
+  isContact,
+} from '../../../../apps/web-wallet/app/features/contacts/contact';

--- a/packages/wallet-sdk/src/internal/lib-transactions.ts
+++ b/packages/wallet-sdk/src/internal/lib-transactions.ts
@@ -1,0 +1,50 @@
+/**
+ * SDK-internal transaction **runtime schemas + parser** single-source re-export — Slice 4.
+ *
+ * The transaction repository (`./transaction-repository`) parses a DB row → the domain
+ * {@link Transaction} exactly as master does: decrypt the `encrypted_transaction_details`
+ * jsonb, validate it with {@link TransactionDetailsDbDataSchema}, run the per-variant
+ * {@link TransactionDetailsParser} (the 6 `z.pipe` parsers), then validate the assembled row
+ * with {@link TransactionSchema}. Those runtime validators are LIFTED single-source from
+ * `apps/web-wallet/app/features/transactions/**` via the `~/*` path alias (mapped in the
+ * package `tsconfig.json` to `apps/web-wallet/app/*`), so there is exactly ONE implementation
+ * and the public `z.infer` TS shapes in `types/transaction.ts` + `types/transaction-details.ts`
+ * can never drift from them.
+ *
+ * Re-housing approach (matches `./lib-cashu-quotes`): re-export the SINGLE live source. The
+ * whole `transaction.ts` → `transaction-details/*` → `transaction-enums.ts` chain is pure
+ * `zod/mini` + `Money` + the `agicash-db/json-models` schemas (verified: no `react` /
+ * `@tanstack/*` — the React-coupled `transaction-hooks.ts` / `transaction-details.tsx` /
+ * `transaction-ack-status-store.ts` are NOT in this chain and are re-housed separately). The
+ * `transaction-details-types.ts` `Json` import resolves to `supabase/database.types` via the
+ * `~/*` alias.
+ *
+ * The DB-data union ({@link TransactionDetailsDbDataSchema}) + the per-variant parsers stay
+ * SDK-INTERNAL (decision 7-ii: the SDK parses DB→domain inside; the DB-data shape is never
+ * public). The public surface is only the domain `z.infer` types.
+ *
+ * The two account-capability gates ({@link canSendToLightning} / {@link canReceiveFromLightning})
+ * are re-exported here too (they are the pure `accounts/account.ts` predicates the transfer
+ * service gates on, §9) — single-source, same seam.
+ *
+ * @module
+ */
+
+// --- runtime transaction domain schemas (transactions/transaction.ts) --------------------
+export {
+  BaseTransactionSchema,
+  TransactionSchema,
+} from '../../../../apps/web-wallet/app/features/transactions/transaction';
+
+// --- the internal DB-data union + the per-variant z.pipe parser (decision 7-ii) ----------
+export {
+  TransactionDetailsDbDataSchema,
+  type TransactionDetailsParserInput,
+} from '../../../../apps/web-wallet/app/features/transactions/transaction-details/transaction-details-types';
+export { TransactionDetailsParser } from '../../../../apps/web-wallet/app/features/transactions/transaction-details/transaction-details-parser';
+
+// --- account-capability gates (accounts/account.ts) — transfer leg validation (§9) -------
+export {
+  canReceiveFromLightning,
+  canSendToLightning,
+} from '../../../../apps/web-wallet/app/features/accounts/account';

--- a/packages/wallet-sdk/src/internal/stub-domains.ts
+++ b/packages/wallet-sdk/src/internal/stub-domains.ts
@@ -18,11 +18,8 @@
 import type {
   BackgroundDomain,
   CashuDomain,
-  ContactsDomain,
   ExchangeRateDomain,
   SparkDomain,
-  TransactionsDomain,
-  TransfersDomain,
 } from '../domains';
 import { NotImplementedError } from '../errors';
 import type { Query } from '../types/query';
@@ -91,28 +88,9 @@ export const createSparkStub = (): SparkDomain => ({
   },
 });
 
-/** Stub `TransactionsDomain` (real impl: Slice 4). */
-export const createTransactionsStub = (): TransactionsDomain => ({
-  list: () => stubQuery('transactions.list'),
-  get: () => stubQuery('transactions.get'),
-  countPendingAck: () => stubQuery('transactions.countPendingAck'),
-  acknowledge: () => unimplemented('transactions.acknowledge'),
-});
-
-/** Stub `ContactsDomain` (real impl: Slice 4). */
-export const createContactsStub = (): ContactsDomain => ({
-  list: () => stubQuery('contacts.list'),
-  get: () => stubQuery('contacts.get'),
-  add: () => unimplemented('contacts.add'),
-  remove: () => unimplemented('contacts.remove'),
-  search: () => unimplemented('contacts.search'),
-});
-
-/** Stub `TransfersDomain` (real impl: Slice 4). */
-export const createTransfersStub = (): TransfersDomain => ({
-  createQuote: () => unimplemented('transfers.createQuote'),
-  executeQuote: () => unimplemented('transfers.executeQuote'),
-});
+// NOTE: `TransactionsDomain` + `ContactsDomain` + `TransfersDomain` are REAL as of Slice 4 (see
+// ../domains/transactions + ../domains/contacts + ../domains/transfers, wired in Sdk.create) —
+// their stubs are removed.
 
 /** Stub `ExchangeRateDomain` (real impl: a later slice). */
 export const createExchangeRateStub = (): ExchangeRateDomain => ({

--- a/packages/wallet-sdk/src/internal/transaction-ack-status-store.test.ts
+++ b/packages/wallet-sdk/src/internal/transaction-ack-status-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { TransactionAckStatusStore } from './transaction-ack-status-store';
+import type { Transaction } from '../types/transaction';
+
+/** Build a minimal transaction with the given id + ack status (only those fields are read). */
+function tx(
+  id: string,
+  acknowledgmentStatus: Transaction['acknowledgmentStatus'],
+): Transaction {
+  return { id, acknowledgmentStatus } as Transaction;
+}
+
+describe('TransactionAckStatusStore (tri-state ack)', () => {
+  test('tracks all three states (null / pending / acknowledged)', () => {
+    const store = new TransactionAckStatusStore();
+    store.setAckStatus(tx('a', null));
+    store.setAckStatus(tx('b', 'pending'));
+    store.setAckStatus(tx('c', 'acknowledged'));
+
+    expect(store.get('a')).toBe(null);
+    expect(store.get('b')).toBe('pending');
+    expect(store.get('c')).toBe('acknowledged');
+  });
+
+  test('get returns undefined for an unseen id (distinct from a tracked null)', () => {
+    const store = new TransactionAckStatusStore();
+    expect(store.get('missing')).toBeUndefined();
+    expect(store.has('missing')).toBe(false);
+
+    store.setAckStatus(tx('seen', null));
+    expect(store.has('seen')).toBe(true);
+    // Tracked-null is distinguishable from never-seen (undefined).
+    expect(store.get('seen')).toBe(null);
+  });
+
+  test('setIfMissing records the FIRST-seen status and does not overwrite on re-delivery', () => {
+    const store = new TransactionAckStatusStore();
+    store.setIfMissing(tx('x', 'pending'));
+    expect(store.get('x')).toBe('pending');
+
+    // A later re-delivery (now acknowledged) must NOT change the first-seen status.
+    store.setIfMissing(tx('x', 'acknowledged'));
+    expect(store.get('x')).toBe('pending');
+  });
+
+  test('setAckStatus DOES overwrite an existing entry', () => {
+    const store = new TransactionAckStatusStore();
+    store.setIfMissing(tx('x', 'pending'));
+    store.setAckStatus(tx('x', 'acknowledged'));
+    expect(store.get('x')).toBe('acknowledged');
+  });
+});

--- a/packages/wallet-sdk/src/internal/transaction-ack-status-store.ts
+++ b/packages/wallet-sdk/src/internal/transaction-ack-status-store.ts
@@ -1,0 +1,74 @@
+/**
+ * Internal transaction acknowledgment-status store — Slice 4 (transactions).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/transactions/transaction-ack-status-store.ts`. Master expresses
+ * this as a Zustand store consumed through the React-Router outlet context; here it is a plain
+ * class holding the same `Map<transactionId, acknowledgmentStatus>` with the same tri-state
+ * semantics (`null` "nothing to ack" / `'pending'` / `'acknowledged'`).
+ *
+ * Purpose (master): track the ack status a transaction had **when first seen** so the UI can
+ * show a one-shot "new" affordance without it flickering back as realtime updates re-deliver
+ * the row. `setIfMissing` records the status only the first time a transaction id is seen;
+ * `setAckStatus` always overwrites. The SDK keeps this as a tiny helper the consumer (or a
+ * future surface) can use; it holds NO domain data beyond the per-id ack status (not a cache).
+ *
+ * @module
+ */
+import type { Transaction } from '../types/transaction';
+
+/** The acknowledgment status carried per transaction (`null` = nothing to acknowledge). */
+type AckStatus = Transaction['acknowledgmentStatus'];
+
+/**
+ * A tri-state per-transaction acknowledgment-status tracker.
+ *
+ * Holds, for each transaction id seen, the ack status it had when first observed (unless
+ * overwritten via {@link setAckStatus}). Framework-free analogue of master's Zustand store.
+ */
+export class TransactionAckStatusStore {
+  /** transactionId → the tracked ack status. */
+  private readonly statuses = new Map<string, AckStatus>();
+
+  /**
+   * Record `transaction`'s current ack status ONLY if this id has not been seen before. A no-op
+   * for an already-tracked id (so the first-seen status is preserved across re-deliveries).
+   *
+   * @param transaction - the transaction to record.
+   */
+  setIfMissing(transaction: Transaction): void {
+    if (this.statuses.has(transaction.id)) {
+      return;
+    }
+    this.setAckStatus(transaction);
+  }
+
+  /**
+   * Record (or overwrite) `transaction`'s current ack status.
+   *
+   * @param transaction - the transaction whose status to store.
+   */
+  setAckStatus(transaction: Transaction): void {
+    this.statuses.set(transaction.id, transaction.acknowledgmentStatus);
+  }
+
+  /**
+   * The tracked ack status for a transaction id, or `undefined` if it has not been seen.
+   *
+   * @param transactionId - the transaction id.
+   * @returns the tracked ack status, or `undefined`.
+   */
+  get(transactionId: string): AckStatus | undefined {
+    return this.statuses.get(transactionId);
+  }
+
+  /**
+   * Whether a transaction id has been recorded.
+   *
+   * @param transactionId - the transaction id.
+   * @returns true if seen.
+   */
+  has(transactionId: string): boolean {
+    return this.statuses.has(transactionId);
+  }
+}

--- a/packages/wallet-sdk/src/internal/transaction-details-parser.test.ts
+++ b/packages/wallet-sdk/src/internal/transaction-details-parser.test.ts
@@ -1,0 +1,285 @@
+/**
+ * DB→domain `TransactionDetails` parser round-trip — all 6 domain variants (§7, decision 7-ii).
+ *
+ * Drives the REAL internal pipeline via `TransactionRepository.toTransaction`: a fake `Encryption`
+ * yields the per-variant decrypted `*DbData` (with live `Money`), the row carries the small
+ * unencrypted `transaction_details`, and we assert the parsed DOMAIN `details` shape. This proves
+ * the single-source `TransactionDetailsParser` (the 6 `z.pipe` parsers) + `TransactionSchema` work
+ * re-housed in the SDK, and that the public domain shape differs from the DB-data shape.
+ */
+import type { Json } from 'supabase/database.types';
+import { describe, expect, test } from 'bun:test';
+import type { Encryption } from './encryption';
+import { TransactionRepository } from './transaction-repository';
+import type { AgicashDbTransaction } from './db-transaction';
+import type { WalletSupabaseClient } from './supabase-client';
+import { type Currency, Money } from '../types/money';
+import type {
+  TransactionDirection,
+  TransactionState,
+  TransactionType,
+} from '../types/transaction';
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+/**
+ * Assert an object's fields against `expected`, comparing `Money` values BY VALUE (`.toString()`)
+ * — two equal `Money` instances are distinct objects that bun's `toEqual` treats as unequal (see
+ * `orchestrator.test.ts`). Also asserts the key SET matches exactly.
+ */
+function expectDetails(
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+): void {
+  expect(new Set(Object.keys(actual))).toEqual(new Set(Object.keys(expected)));
+  for (const [key, value] of Object.entries(expected)) {
+    if (value instanceof Money) {
+      expect((actual[key] as Money)?.toString()).toBe(value.toString());
+    } else {
+      expect(actual[key]).toBe(value as never);
+    }
+  }
+}
+
+/** A minimal valid cashu Proof (id/amount/secret/C; dleq/witness optional). */
+const proof = { id: 'ks1', amount: 1, secret: 's', C: '02ab' };
+
+/** A repository whose `encryption.decrypt` returns a pre-set DbData object (already deserialized). */
+function repoFor(dbData: unknown): TransactionRepository {
+  const encryption = {
+    decrypt: async () => dbData,
+  } as unknown as Encryption;
+  // The db client is never touched by toTransaction (it only decrypts + parses the passed row).
+  return new TransactionRepository({} as WalletSupabaseClient, encryption);
+}
+
+/** Build a transactions row for the given type/direction/state + small `transaction_details`. */
+function row(
+  type: TransactionType,
+  direction: TransactionDirection,
+  state: TransactionState,
+  transactionDetails: Json | null,
+): AgicashDbTransaction {
+  return {
+    id: 't1',
+    user_id: 'u1',
+    account_id: 'acc1',
+    account_name: 'acc',
+    account_type: type === 'SPARK_LIGHTNING' ? 'spark' : 'cashu',
+    account_purpose: 'transactional',
+    currency: 'BTC',
+    direction,
+    type,
+    state,
+    encrypted_transaction_details: 'ciphertext',
+    transaction_details: transactionDetails,
+    purpose: 'PAYMENT',
+    acknowledgment_status: null,
+    reversed_transaction_id: null,
+    state_sort_order: 1,
+    created_at: '2026-01-01T00:00:00.000Z',
+    pending_at: null,
+    completed_at: null,
+    failed_at: null,
+    reversed_at: null,
+    version: 1,
+  };
+}
+
+describe('TransactionDetailsParser round-trip — 6 domain variants', () => {
+  test('CASHU_TOKEN SEND → CashuTokenSendTransactionDetails', async () => {
+    const dbData = {
+      tokenMintUrl: 'https://mint',
+      amountReceived: sats(90),
+      cashuReceiveFee: sats(2),
+      amountToSend: sats(92),
+      cashuSendFee: sats(1),
+      amountSpent: sats(93),
+      amountReserved: sats(100),
+      totalFee: sats(3),
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('CASHU_TOKEN', 'SEND', 'COMPLETED', null),
+    );
+
+    expect(tx.type).toBe('CASHU_TOKEN');
+    expect(tx.direction).toBe('SEND');
+    expectDetails(tx.details as Record<string, unknown>, {
+      tokenAmount: sats(92), // = amountToSend
+      tokenMintUrl: 'https://mint',
+      amountReserved: sats(100),
+      amount: sats(93), // COMPLETED → amountSpent
+      amountReceived: sats(90),
+      cashuReceiveFee: sats(2),
+      cashuSendFee: sats(1),
+      totalFee: sats(3),
+    });
+    // Domain `amount` is lifted onto the transaction.
+    expect(tx.amount.toString()).toBe(sats(93).toString());
+  });
+
+  test('CASHU_TOKEN RECEIVE (same-mint swap) → CashuTokenReceiveTransactionDetails', async () => {
+    const dbData = {
+      tokenMintUrl: 'https://mint',
+      tokenAmount: sats(100),
+      tokenProofs: [proof],
+      tokenDescription: 'gift',
+      amountReceived: sats(98),
+      outputAmounts: [64, 32, 2],
+      cashuReceiveFee: sats(2),
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('CASHU_TOKEN', 'RECEIVE', 'COMPLETED', null),
+    );
+
+    expectDetails(tx.details as Record<string, unknown>, {
+      tokenAmount: sats(100),
+      tokenMintUrl: 'https://mint',
+      description: 'gift',
+      amount: sats(98),
+      cashuReceiveFee: sats(2),
+      totalFee: sats(2), // same-mint: totalFee = cashuReceiveFee
+    });
+  });
+
+  test('CASHU_LIGHTNING SEND (completed) → CompletedCashuLightningSendTransactionDetails', async () => {
+    const dbData = {
+      paymentRequest: 'lnbc1...',
+      amountRequested: sats(50),
+      amountRequestedInMsat: 50_000,
+      amountReceived: sats(50),
+      lightningFeeReserve: sats(5),
+      cashuSendFee: sats(1),
+      meltQuoteId: 'melt1',
+      amountReserved: sats(56),
+      paymentPreimage: 'preimage',
+      amountSpent: sats(53),
+      lightningFee: sats(2),
+      totalFee: sats(3),
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('CASHU_LIGHTNING', 'SEND', 'COMPLETED', {
+        paymentHash: 'hash',
+      }),
+    );
+
+    // Completed adds preimage + lightningFee + totalFee on top of the incomplete shape.
+    expect(tx.details).toMatchObject({
+      paymentRequest: 'lnbc1...',
+      paymentHash: 'hash', // read from the unencrypted transaction_details
+      amountReserved: sats(56),
+      amountReceived: sats(50),
+      lightningFeeReserve: sats(5),
+      cashuSendFee: sats(1),
+      estimatedTotalFee: sats(6), // lightningFeeReserve + cashuSendFee
+      preimage: 'preimage',
+      lightningFee: sats(2),
+      totalFee: sats(3),
+    });
+  });
+
+  test('CASHU_LIGHTNING RECEIVE → CashuLightningReceiveTransactionDetails', async () => {
+    const dbData = {
+      paymentRequest: 'lnbc1...',
+      mintQuoteId: 'mq1',
+      amountReceived: sats(100),
+      description: 'tip',
+      mintingFee: sats(1),
+      totalFee: sats(1),
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('CASHU_LIGHTNING', 'RECEIVE', 'COMPLETED', { paymentHash: 'hash' }),
+    );
+
+    expectDetails(tx.details as Record<string, unknown>, {
+      paymentRequest: 'lnbc1...',
+      paymentHash: 'hash',
+      description: 'tip',
+      mintingFee: sats(1),
+      amount: sats(100),
+      totalFee: sats(1),
+      transferId: undefined,
+    });
+  });
+
+  test('SPARK_LIGHTNING SEND (completed) → CompletedSparkLightningSendTransactionDetails', async () => {
+    const dbData = {
+      paymentRequest: 'lnbc1...',
+      amountReceived: sats(40),
+      estimatedLightningFee: sats(3),
+      amountSpent: sats(42),
+      lightningFee: sats(2),
+      paymentPreimage: 'preimage',
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('SPARK_LIGHTNING', 'SEND', 'COMPLETED', {
+        paymentHash: 'hash',
+        sparkId: 'spk1',
+        sparkTransferId: 'tr1',
+      }),
+    );
+
+    expect(tx.details).toMatchObject({
+      amountReceived: sats(40),
+      estimatedFee: sats(3),
+      paymentRequest: 'lnbc1...',
+      paymentHash: 'hash',
+      amount: sats(42), // amountSpent
+      fee: sats(2), // actual lightningFee
+      sparkId: 'spk1',
+      sparkTransferId: 'tr1',
+      paymentPreimage: 'preimage',
+    });
+  });
+
+  test('SPARK_LIGHTNING RECEIVE → CompletedSparkLightningReceiveTransactionDetails', async () => {
+    const dbData = {
+      paymentRequest: 'lnbc1...',
+      amountReceived: sats(75),
+      description: 'invoice',
+      paymentPreimage: 'preimage',
+      totalFee: sats(0),
+    };
+    const tx = await repoFor(dbData).toTransaction(
+      row('SPARK_LIGHTNING', 'RECEIVE', 'COMPLETED', {
+        paymentHash: 'hash',
+        sparkId: 'spk1',
+        sparkTransferId: 'tr1',
+      }),
+    );
+
+    expect(tx.details).toMatchObject({
+      paymentRequest: 'lnbc1...',
+      paymentHash: 'hash',
+      sparkId: 'spk1',
+      description: 'invoice',
+      amount: sats(75),
+      paymentPreimage: 'preimage',
+      sparkTransferId: 'tr1',
+    });
+  });
+
+  test('TRANSFER purpose injects details.transferId (a transfer leg)', async () => {
+    const dbData = {
+      paymentRequest: 'lnbc1...',
+      mintQuoteId: 'mq1',
+      amountReceived: sats(100),
+      totalFee: sats(0),
+    };
+    const transferRow = {
+      ...row('CASHU_LIGHTNING', 'RECEIVE', 'COMPLETED', {
+        paymentHash: 'hash',
+        transferId: 'transfer-1',
+      }),
+      purpose: 'TRANSFER' as const,
+    };
+    const tx = await repoFor(dbData).toTransaction(transferRow);
+
+    expect(tx.purpose).toBe('TRANSFER');
+    // The parser carries transferId from the unencrypted transaction_details into details.
+    expect((tx.details as { transferId?: string }).transferId).toBe(
+      'transfer-1',
+    );
+  });
+});

--- a/packages/wallet-sdk/src/internal/transaction-event-forwarder.test.ts
+++ b/packages/wallet-sdk/src/internal/transaction-event-forwarder.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { TransactionEventForwarder } from './transaction-event-forwarder';
+import { TypedEventEmitter } from './event-emitter';
+import type { AgicashDbTransaction } from './db-transaction';
+import type { TransactionRepository } from './transaction-repository';
+import type { SdkEventMap } from '../types/events';
+import { type Currency, Money } from '../types/money';
+import type { Transaction } from '../types/transaction';
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+/** A repository whose `toTransaction` yields a transaction with the given id + version. */
+function repoYielding(tx: Transaction): TransactionRepository {
+  return {
+    toTransaction: mock(async () => tx),
+  } as unknown as TransactionRepository;
+}
+
+const tx = (id: string, version: number): Transaction =>
+  ({ id, version, amount: sats(1) }) as Transaction;
+
+/** The DB-change payload is just a row; the forwarder parses it via the repo. */
+const payload = { id: 'tx1' } as AgicashDbTransaction;
+
+describe('TransactionEventForwarder (net-new transaction:* events, §11)', () => {
+  test('TRANSACTION_CREATED → transaction:created carrying the domain transaction (+version)', async () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    const seen: SdkEventMap['transaction:created'][] = [];
+    events.on('transaction:created', (e) => seen.push(e));
+
+    await new TransactionEventForwarder(
+      repoYielding(tx('tx1', 4)),
+      events,
+    ).handleChange('TRANSACTION_CREATED', payload);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.transaction.id).toBe('tx1');
+    // version is forwarded on the transaction (consumer orders by it).
+    expect(seen[0]?.transaction.version).toBe(4);
+  });
+
+  test('TRANSACTION_UPDATED → transaction:updated (the op comes from the event NAME)', async () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    let created = 0;
+    const updated: SdkEventMap['transaction:updated'][] = [];
+    events.on('transaction:created', () => created++);
+    events.on('transaction:updated', (e) => updated.push(e));
+
+    await new TransactionEventForwarder(
+      repoYielding(tx('tx1', 5)),
+      events,
+    ).handleChange('TRANSACTION_UPDATED', payload);
+
+    expect(created).toBe(0);
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.transaction.version).toBe(5);
+  });
+
+  test('create-dedupe: a second CREATE for the same id is suppressed', async () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    let created = 0;
+    events.on('transaction:created', () => created++);
+
+    const forwarder = new TransactionEventForwarder(
+      repoYielding(tx('tx1', 1)),
+      events,
+    );
+    await forwarder.handleChange('TRANSACTION_CREATED', payload);
+    await forwarder.handleChange('TRANSACTION_CREATED', payload);
+
+    // The SDK promises no-duplicate CREATE events.
+    expect(created).toBe(1);
+  });
+
+  test('an UPDATE is NOT deduped (always re-emitted)', async () => {
+    const events = new TypedEventEmitter<SdkEventMap>();
+    let updated = 0;
+    events.on('transaction:updated', () => updated++);
+
+    const forwarder = new TransactionEventForwarder(
+      repoYielding(tx('tx1', 2)),
+      events,
+    );
+    await forwarder.handleChange('TRANSACTION_UPDATED', payload);
+    await forwarder.handleChange('TRANSACTION_UPDATED', payload);
+
+    expect(updated).toBe(2);
+  });
+});

--- a/packages/wallet-sdk/src/internal/transaction-event-forwarder.ts
+++ b/packages/wallet-sdk/src/internal/transaction-event-forwarder.ts
@@ -1,0 +1,80 @@
+/**
+ * Internal transaction realtime → SDK-event forwarder — Slice 4 (transactions).
+ *
+ * NET-NEW (the event-SHAPE contract for `transaction:created` / `transaction:updated`, §11). It
+ * GENERALIZES master's `transaction-hooks.ts#useTransactionChangeHandlers` (which translates the
+ * `TRANSACTION_CREATED` / `TRANSACTION_UPDATED` broadcast events into TanStack-cache upserts):
+ * here it instead translates them into the SDK's typed events.
+ *
+ * Master encodes the operation in the event NAME (`TRANSACTION_CREATED` vs `TRANSACTION_UPDATED`);
+ * the SDK reads the name and emits the DISTINCT typed event (§11) — `transaction:created` for a
+ * CREATE, `transaction:updated` for an UPDATE — each carrying the full domain `Transaction`
+ * (which carries its `version`, so the consumer orders by `incoming.version > existing.version`).
+ *
+ * The REALTIME SUBSCRIPTION that actually delivers these DB-change payloads (the single
+ * `wallet:${userId}` broadcast channel) is Slice 5/PR7 — THIS slice only DEFINES + tests the
+ * shape + the emit path. Slice 5 wires the channel to call {@link handleChange}.
+ *
+ * Optional CREATE-dedupe (§11): the SDK promises no-duplicate CREATE events, so a CREATE for an
+ * already-seen id is suppressed (a lightweight id set, NOT a cache — it holds no domain data).
+ *
+ * @module
+ */
+import type { TypedEventEmitter } from './event-emitter';
+import type { AgicashDbTransaction } from './db-transaction';
+import type { TransactionRepository } from './transaction-repository';
+import type { SdkEventMap } from '../types/events';
+
+/** The two transaction realtime event names master broadcasts. */
+export type TransactionChangeEvent =
+  | 'TRANSACTION_CREATED'
+  | 'TRANSACTION_UPDATED';
+
+/**
+ * Translates `wallet.transactions` realtime DB-change payloads into the SDK's typed
+ * `transaction:*` events. Holds the transaction repository (to parse a row → domain transaction)
+ * + the event emitter; constructed by the SDK and driven by the Slice-5 realtime channel.
+ */
+export class TransactionEventForwarder {
+  /** Ids for which a CREATE has already been emitted (create-dedupe; not a cache). */
+  private readonly seenCreates = new Set<string>();
+
+  /**
+   * @param repository - parses a DB row → the domain {@link Transaction}.
+   * @param events - the SDK event emitter.
+   */
+  constructor(
+    private readonly repository: TransactionRepository,
+    private readonly events: TypedEventEmitter<SdkEventMap>,
+  ) {}
+
+  /**
+   * Translate one transaction DB-change into the matching typed SDK event.
+   *
+   * - `TRANSACTION_CREATED` → `transaction:created` (suppressed if the id was already created).
+   * - `TRANSACTION_UPDATED` → `transaction:updated`.
+   *
+   * The row is parsed to the domain {@link Transaction} via the repository's internal DB→domain
+   * pipeline (so the emitted event carries the public domain shape, never the DB-data shape).
+   *
+   * @param event - the broadcast event name (encodes the op).
+   * @param payload - the changed transaction row.
+   */
+  async handleChange(
+    event: TransactionChangeEvent,
+    payload: AgicashDbTransaction,
+  ): Promise<void> {
+    const transaction = await this.repository.toTransaction(payload);
+
+    if (event === 'TRANSACTION_CREATED') {
+      if (this.seenCreates.has(transaction.id)) {
+        return;
+      }
+      this.seenCreates.add(transaction.id);
+      this.events.emit('transaction:created', { transaction });
+      return;
+    }
+
+    this.events.emit('transaction:updated', { transaction });
+  }
+}

--- a/packages/wallet-sdk/src/internal/transaction-repository.ts
+++ b/packages/wallet-sdk/src/internal/transaction-repository.ts
@@ -1,0 +1,275 @@
+/**
+ * Internal `wallet.transactions` repository — Slice 4 (transactions).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/transactions/transaction-repository.ts`. Master expresses this
+ * over a React-hook-constructed repo wired to the module-global `agicashDbClient` +
+ * `useEncryption`; here it is a plain class over the SDK-owned Supabase client + the SDK
+ * {@link Encryption} (both injected). The `list_transactions` RPC + the cursor-paging +
+ * the DB→domain parse (`toTransaction`) are unchanged from master.
+ *
+ * The DB→domain parse is the internal pipeline (decision 7-ii): decrypt the
+ * `encrypted_transaction_details` jsonb, validate it with `TransactionDetailsDbDataSchema`,
+ * run the 6-variant `TransactionDetailsParser` (the `z.pipe` parsers), then validate the
+ * assembled row with `TransactionSchema`. Those runtime schemas are the single-source
+ * re-export (`./lib-transactions`); the DB-row type is the hand-written
+ * {@link AgicashDbTransaction}.
+ *
+ * @module
+ */
+import type { z } from 'zod/mini';
+import type { Encryption } from './encryption';
+import {
+  type BaseTransactionSchema,
+  TransactionDetailsDbDataSchema,
+  type TransactionDetailsParserInput,
+  TransactionDetailsParser,
+  TransactionSchema,
+} from './lib-transactions';
+import type { AgicashDbTransaction } from './db-transaction';
+import type { WalletSupabaseClient } from './supabase-client';
+import type { Transaction, TransactionCursor } from '../types/transaction';
+
+/** Per-call query options (an abort signal, matching master). */
+type Options = { abortSignal?: AbortSignal };
+
+/** Parameters for {@link TransactionRepository.list} (master `ListOptions`). */
+type ListOptions = Options & {
+  userId: string;
+  cursor?: TransactionCursor | null;
+  pageSize?: number;
+  accountId?: string;
+};
+
+/** The default page size master uses for transaction history. */
+export const DEFAULT_TRANSACTION_PAGE_SIZE = 25;
+
+/**
+ * Reads + writes for the `wallet.transactions` table, scoped (via RLS) to the signed-in user.
+ * Holds the SDK-owned Supabase client + the SDK {@link Encryption}.
+ */
+export class TransactionRepository {
+  /**
+   * @param db - the SDK-owned Supabase client (schema pinned to `wallet`).
+   * @param encryption - the SDK encryption (decrypts each row's `encrypted_transaction_details`).
+   */
+  constructor(
+    private readonly db: WalletSupabaseClient,
+    private readonly encryption: Encryption,
+  ) {}
+
+  /**
+   * Get the transaction with the given id (or null if not found).
+   *
+   * Verbatim logic from master `TransactionRepository.get`.
+   *
+   * @param transactionId - the transaction id.
+   * @param options - optional abort signal.
+   * @returns the transaction, or null.
+   * @throws Error if the read fails.
+   */
+  async get(
+    transactionId: string,
+    options?: Options,
+  ): Promise<Transaction | null> {
+    const query = this.db.from('transactions').select().eq('id', transactionId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      throw new Error('Failed to get transaction', { cause: error });
+    }
+
+    return data ? this.toTransaction(data as AgicashDbTransaction) : null;
+  }
+
+  /**
+   * List transactions for the user, newest-relevant first (state-sorted: PENDING first), paged
+   * by an opaque cursor.
+   *
+   * Verbatim logic from master `TransactionRepository.list`: calls the `list_transactions` RPC
+   * (the state-sort + cursor are computed DB-side), parses each row, and derives the
+   * `nextCursor` from the last row (`stateSortOrder` = 2 for PENDING else 1). Note the cursor
+   * always reflects the last returned row; the caller (`TransactionsDomain.list`) caps paging by
+   * nulling it when the page came back short, matching master's `useTransactions`.
+   *
+   * @param options - `{ userId, cursor?, pageSize?, accountId?, abortSignal? }`.
+   * @returns `{ transactions, nextCursor }`.
+   * @throws Error if the read fails.
+   */
+  async list({
+    userId,
+    cursor = null,
+    pageSize = DEFAULT_TRANSACTION_PAGE_SIZE,
+    accountId,
+    abortSignal,
+  }: ListOptions): Promise<{
+    transactions: Transaction[];
+    nextCursor: TransactionCursor | null;
+  }> {
+    // The Supabase client is untyped until the generated Database types are lifted (a later
+    // slice); the `list_transactions` RPC name/args live in the stored procedure, not the client's
+    // type space — cast the call (matching the other repos) and the resulting rows.
+    // biome-ignore lint/suspicious/noExplicitAny: see above.
+    let query = (this.db.rpc as any)('list_transactions', {
+      p_user_id: userId,
+      p_cursor_state_sort_order: cursor?.stateSortOrder,
+      p_cursor_created_at: cursor?.createdAt,
+      p_cursor_id: cursor?.id,
+      p_page_size: pageSize,
+      p_account_id: accountId,
+    });
+
+    if (abortSignal) {
+      query = query.abortSignal(abortSignal);
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      throw new Error('Failed to fetch transactions', { cause: error });
+    }
+
+    const rows = data as AgicashDbTransaction[];
+    const transactions = await Promise.all(
+      rows.map((transaction) => this.toTransaction(transaction)),
+    );
+    const lastTransaction = transactions[transactions.length - 1];
+
+    return {
+      transactions,
+      nextCursor: lastTransaction
+        ? {
+            stateSortOrder: lastTransaction.state === 'PENDING' ? 2 : 1,
+            createdAt: lastTransaction.createdAt,
+            id: lastTransaction.id,
+          }
+        : null,
+    };
+  }
+
+  /**
+   * Count the user's transactions whose `acknowledgment_status` is `pending`.
+   *
+   * Verbatim logic from master `TransactionRepository.countTransactionsPendingAck`.
+   *
+   * @param params - `{ userId }`.
+   * @param options - optional abort signal.
+   * @returns the number of unacknowledged transactions.
+   * @throws Error if the count fails.
+   */
+  async countTransactionsPendingAck(
+    { userId }: { userId: string },
+    options?: Options,
+  ): Promise<number> {
+    const query = this.db
+      .from('transactions')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('acknowledgment_status', 'pending');
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { count, error } = await query;
+
+    if (error || count === null) {
+      throw new Error('Failed to count transactions pending acknowledgment', {
+        cause: error,
+      });
+    }
+
+    return count;
+  }
+
+  /**
+   * Set a transaction's acknowledgment status to `acknowledged`.
+   *
+   * Verbatim logic from master `TransactionRepository.acknowledgeTransaction`.
+   *
+   * @param params - `{ userId, transactionId }`.
+   * @param options - optional abort signal.
+   * @throws Error if the update fails.
+   */
+  async acknowledgeTransaction(
+    { userId, transactionId }: { userId: string; transactionId: string },
+    options?: Options,
+  ): Promise<void> {
+    const query = this.db
+      .from('transactions')
+      .update({ acknowledgment_status: 'acknowledged' })
+      .eq('id', transactionId)
+      .eq('user_id', userId);
+
+    if (options?.abortSignal) {
+      query.abortSignal(options.abortSignal);
+    }
+
+    const { error } = await query;
+
+    if (error) {
+      throw new Error('Failed to mark transaction as seen', { cause: error });
+    }
+  }
+
+  /**
+   * Map a `wallet.transactions` DB row to the domain {@link Transaction}.
+   *
+   * Verbatim logic from master `TransactionRepository.toTransaction` — the internal DB→domain
+   * pipeline (decision 7-ii): decrypt the `encrypted_transaction_details`, validate it as the
+   * DB-data union, run the per-variant `z.pipe` parser to the domain `details`, then validate
+   * the assembled row with `TransactionSchema`. Public to the SDK's own realtime forwarder
+   * (Slice 5 calls this to translate a DB-change payload into a `transaction:*` event), but the
+   * DB-data shape it consumes is never exposed.
+   *
+   * @param data - the transaction row.
+   * @returns the domain transaction.
+   * @throws Error if decryption or schema validation fails.
+   */
+  async toTransaction(data: AgicashDbTransaction): Promise<Transaction> {
+    const decryptedData = await this.encryption.decrypt(
+      data.encrypted_transaction_details,
+    );
+    const decryptedTransactionDetails =
+      TransactionDetailsDbDataSchema.parse(decryptedData);
+
+    const details = TransactionDetailsParser.parse({
+      type: data.type,
+      direction: data.direction,
+      state: data.state,
+      transactionDetails: data.transaction_details ?? undefined,
+      decryptedTransactionDetails,
+    } satisfies TransactionDetailsParserInput);
+
+    return TransactionSchema.parse({
+      id: data.id,
+      userId: data.user_id,
+      accountId: data.account_id,
+      accountName: data.account_name,
+      accountType: data.account_type,
+      accountPurpose: data.account_purpose,
+      createdAt: data.created_at,
+      pendingAt: data.pending_at,
+      completedAt: data.completed_at,
+      failedAt: data.failed_at,
+      reversedTransactionId: data.reversed_transaction_id,
+      purpose: data.purpose,
+      reversedAt: data.reversed_at,
+      acknowledgmentStatus: data.acknowledgment_status,
+      version: data.version,
+      direction: data.direction,
+      type: data.type,
+      state: data.state,
+      amount: details.amount,
+      details,
+      // The single-source runtime `TransactionSchema` is authoritative; cast its parse output to
+      // the hand-mirrored public `Transaction` (matching the cashu/spark repos' `toQuote` casts —
+      // `z.infer` and the hand-written TS shape differ only in optional-vs-Required narrowing).
+    } satisfies z.input<typeof BaseTransactionSchema>) as Transaction;
+  }
+}

--- a/packages/wallet-sdk/src/internal/transfer-service.test.ts
+++ b/packages/wallet-sdk/src/internal/transfer-service.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
+import type { CashuSendQuoteService } from './cashu-send-quote-service';
+import type { SparkSendQuoteService } from './spark-send-quote-service';
+import {
+  TransferService,
+  type TransferQuoteInternal,
+} from './transfer-service';
+import type { CashuAccount, SparkAccount } from '../types/account';
+import { type Currency, Money } from '../types/money';
+
+const sats = (n: number): Money =>
+  new Money({ amount: n, currency: 'BTC' as Currency, unit: 'sat' });
+
+// The SEND leg is SPARK (canSendToLightning short-circuits `true` for spark; the send leg uses the
+// stubbable `sparkSendQuoteService.getLightningSendQuote`). The RECEIVE leg is CASHU (it uses the
+// stubbable `cashuReceiveQuoteService.getLightningQuote`; the gate `canReceiveFromLightning` reads
+// `getMintInfo().isSupported(4)` — NUT-04 mint enabled). This avoids the two standalone-core paths
+// (spark RECEIVE core + cashu SEND core) that would need a live wallet to stub.
+const sparkSource = {
+  id: 'spark-src',
+  name: 'Spark',
+  type: 'spark',
+  currency: 'BTC',
+  wallet: {},
+} as unknown as SparkAccount;
+
+const cashuDest = {
+  id: 'cashu-dst',
+  name: 'Mint',
+  type: 'cashu',
+  purpose: 'transactional',
+  isOnline: true,
+  isTestMint: false,
+  currency: 'BTC',
+  wallet: {
+    getMintInfo: () => ({ isSupported: () => ({ disabled: false }) }),
+  },
+} as unknown as CashuAccount;
+
+/**
+ * Build a `TransferService` whose receive leg (cashu) yields a known mint-quote invoice + the send
+ * leg (spark) yields a known fee estimate. `failSendPersist` makes the send-quote persist throw (to
+ * exercise the auto-fail-the-receive path). Returns the service + the receive/send spies.
+ */
+function buildService({
+  failSendPersist = false,
+}: { failSendPersist?: boolean } = {}) {
+  const cashuReceiveQuoteService = {
+    getLightningQuote: mock(async () => ({
+      mintQuote: { request: 'lnbc-dest' },
+      mintingFee: sats(0),
+    })),
+    createReceiveQuote: mock(async () => ({ transactionId: 'rx-tx' })),
+    fail: mock(async () => undefined),
+  } as unknown as CashuReceiveQuoteService;
+
+  const sparkReceiveQuoteService = {
+    getLightningQuote: mock(async () => ({})),
+    createReceiveQuote: mock(async () => ({ transactionId: 'rx-tx' })),
+    fail: mock(async () => undefined),
+  } as unknown as SparkReceiveQuoteService;
+
+  const cashuSendQuoteService = {
+    getLightningQuote: mock(async () => ({})),
+    createSendQuote: mock(async () => ({ transactionId: 'tx-tx' })),
+  } as unknown as CashuSendQuoteService;
+
+  const sparkSendQuoteService = {
+    getLightningSendQuote: mock(async () => ({
+      amountToReceive: sats(100),
+      estimatedTotalFee: sats(5),
+    })),
+    createSendQuote: failSendPersist
+      ? mock(async () => {
+          throw new Error('send persist failed');
+        })
+      : mock(async () => ({ transactionId: 'tx-tx' })),
+  } as unknown as SparkSendQuoteService;
+
+  const service = new TransferService(
+    cashuReceiveQuoteService,
+    sparkReceiveQuoteService,
+    cashuSendQuoteService,
+    sparkSendQuoteService,
+  );
+  return {
+    service,
+    sparkSendQuoteService,
+    cashuReceiveQuoteService,
+  };
+}
+
+describe('TransferService.getTransferQuote (composes a send leg + a receive leg)', () => {
+  test('quotes both legs and sums fees/cost', async () => {
+    const { service, cashuReceiveQuoteService, sparkSendQuoteService } =
+      buildService();
+
+    const quote = await service.getTransferQuote({
+      sourceAccount: sparkSource,
+      destinationAccount: cashuDest,
+      amount: sats(100),
+    });
+
+    // The receive (cashu) leg + the send (spark) leg were BOTH quoted.
+    expect(cashuReceiveQuoteService.getLightningQuote).toHaveBeenCalledTimes(1);
+    expect(sparkSendQuoteService.getLightningSendQuote).toHaveBeenCalledTimes(
+      1,
+    );
+    // The source leg paid the invoice (the destination mint-quote request) the receive leg produced.
+    expect(sparkSendQuoteService.getLightningSendQuote).toHaveBeenCalledWith({
+      account: sparkSource,
+      paymentRequest: 'lnbc-dest',
+    });
+    // Money is compared by value (.toString()) — distinct equal instances aren't toEqual in bun.
+    expect(quote.amount.toString()).toBe(sats(100).toString());
+    expect(quote.amountToReceive.toString()).toBe(sats(100).toString());
+    // totalFees = send estimatedTotalFee (5) + receive fee (cashu mintingFee = 0).
+    expect(quote.totalFees.toString()).toBe(sats(5).toString());
+    expect(quote.totalCost.toString()).toBe(sats(105).toString());
+  });
+
+  test('rejects when the destination cannot receive over Lightning (a test mint)', async () => {
+    const { service } = buildService();
+    const testMintDest = {
+      ...cashuDest,
+      isTestMint: true,
+    } as unknown as CashuAccount;
+
+    await expect(
+      service.getTransferQuote({
+        sourceAccount: sparkSource,
+        destinationAccount: testMintDest,
+        amount: sats(100),
+      }),
+    ).rejects.toThrow('cannot receive Lightning payments');
+  });
+});
+
+describe('TransferService.initiateTransfer (auto-fail-receive-on-send-fail, §9)', () => {
+  /** A valid internal quote (cashu receive leg + spark send leg). */
+  function internalQuote(): TransferQuoteInternal {
+    return {
+      amount: sats(100),
+      amountToReceive: sats(100),
+      totalFees: sats(5),
+      totalCost: sats(105),
+      receive: {
+        account: cashuDest,
+        fee: sats(0),
+        lightningQuote: {
+          mintQuote: { request: 'lnbc-dest' },
+        } as never,
+      },
+      send: {
+        account: sparkSource,
+        lightningQuote: {
+          amountToReceive: sats(100),
+          estimatedTotalFee: sats(5),
+        } as never,
+      },
+    };
+  }
+
+  test('persists both legs and returns the transferId + both transaction ids', async () => {
+    const { service } = buildService();
+
+    const result = await service.initiateTransfer({
+      userId: 'u1',
+      quote: internalQuote(),
+    });
+
+    expect(result.receiveTransactionId).toBe('rx-tx');
+    expect(result.sendTransactionId).toBe('tx-tx');
+    expect(typeof result.transferId).toBe('string');
+    expect(result.transferId.length).toBeGreaterThan(0);
+  });
+
+  test('when the SEND persist fails, the already-persisted RECEIVE quote is auto-failed', async () => {
+    const { service, cashuReceiveQuoteService } = buildService({
+      failSendPersist: true,
+    });
+
+    await expect(
+      service.initiateTransfer({ userId: 'u1', quote: internalQuote() }),
+    ).rejects.toThrow('send persist failed');
+
+    // The receive quote must be failed to avoid an orphaned credit.
+    expect(cashuReceiveQuoteService.fail).toHaveBeenCalledTimes(1);
+    expect(cashuReceiveQuoteService.fail).toHaveBeenCalledWith(
+      { transactionId: 'rx-tx' },
+      'Transfer initiation failed',
+    );
+  });
+});

--- a/packages/wallet-sdk/src/internal/transfer-service.ts
+++ b/packages/wallet-sdk/src/internal/transfer-service.ts
@@ -1,0 +1,299 @@
+/**
+ * Internal transfer service — Slice 4 (transfers).
+ *
+ * EXTRACTED (re-housed framework-free) from
+ * `apps/web-wallet/app/features/transfer/transfer-service.ts`. Master's `TransferService` is
+ * ALREADY a plain class taking the four quote services — only the `useTransferService()` factory
+ * couples it to React. Here it takes the SDK's re-housed cashu/spark send + receive quote
+ * services. All logic — the `canSendToLightning`/`canReceiveFromLightning` gates, fetching both
+ * legs' lightning quotes, and `initiateTransfer`'s persist-receive → persist-send →
+ * AUTO-FAIL-the-receive-on-send-fail (§9) — is verbatim from master.
+ *
+ * The transfer quote is the VERBATIM-FULL master shape — the public {@link TransferQuote} (§9):
+ * each leg carries its live `lightningQuote` (the mint/Breez quote the send/receive persists from)
+ * as a VISIBLE, plain-data field. {@link TransfersDomain.executeQuote} hands that full quote
+ * straight back to {@link TransferService.initiateTransfer}, which reads the live legs directly
+ * (no slim projection, no symbol carrier). {@link TransferQuoteInternal} is kept as an alias of
+ * the public {@link TransferQuote} for back-compat with callers/tests that referenced it.
+ *
+ * @module
+ */
+import type { CashuReceiveLightningQuote } from './cashu-receive-quote-core';
+import type {
+  CashuLightningQuote,
+  CashuSendQuoteService,
+} from './cashu-send-quote-service';
+import {
+  canReceiveFromLightning,
+  canSendToLightning,
+} from './lib-transactions';
+import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
+import type { SparkReceiveLightningQuote } from './spark-receive-quote-core';
+import { getLightningQuote as getSparkReceiveLightningQuote } from './spark-receive-quote-core';
+import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
+import type {
+  SparkLightningQuote,
+  SparkSendQuoteService,
+} from './spark-send-quote-service';
+import { DomainError } from '../errors';
+import type { Account } from '../types/account';
+import type { CashuReceiveQuote } from '../types/cashu';
+import { Money } from '../types/money';
+import type { SparkReceiveQuote } from '../types/spark';
+import type {
+  TransferQuote,
+  TransferReceiveSide,
+  TransferSendSide,
+} from '../types/transfer';
+
+// The transfer leg shapes are the PUBLIC, verbatim-full master shapes (each leg carries its live
+// `lightningQuote` as visible plain data). Re-exported here so the internal service + its tests
+// keep their existing import surface.
+export type { TransferReceiveSide, TransferSendSide } from '../types/transfer';
+
+/**
+ * The transfer quote — an ALIAS of the public {@link TransferQuote} (§9). Verbatim-full: both legs
+ * carry their live `lightningQuote` as visible plain data; there is no slim projection. Kept as a
+ * named alias for back-compat with callers/tests that referenced `TransferQuoteInternal`.
+ */
+export type TransferQuoteInternal = TransferQuote;
+
+/** The bolt11 payment request the source leg must pay to fund the destination leg. */
+function extractPaymentRequest(receive: TransferReceiveSide): string {
+  if (receive.account.type === 'cashu') {
+    return (receive.lightningQuote as CashuReceiveLightningQuote).mintQuote
+      .request;
+  }
+  return (receive.lightningQuote as SparkReceiveLightningQuote).invoice
+    .paymentRequest;
+}
+
+/**
+ * Cross-account transfer orchestration (cashu↔spark via Lightning). Construct with the cashu +
+ * spark receive + send quote services (the SDK-internal re-housed ones).
+ */
+export class TransferService {
+  /**
+   * @param cashuReceiveQuoteService - cashu receive (the destination cashu leg).
+   * @param sparkReceiveQuoteService - spark receive (the destination spark leg).
+   * @param cashuSendQuoteService - cashu send (the source cashu leg).
+   * @param sparkSendQuoteService - spark send (the source spark leg).
+   */
+  constructor(
+    private readonly cashuReceiveQuoteService: CashuReceiveQuoteService,
+    private readonly sparkReceiveQuoteService: SparkReceiveQuoteService,
+    private readonly cashuSendQuoteService: CashuSendQuoteService,
+    private readonly sparkSendQuoteService: SparkSendQuoteService,
+  ) {}
+
+  /**
+   * Build an internal transfer quote for `amount` from `sourceAccount` to `destinationAccount`.
+   * Only fetches the lightning quotes (does NOT persist them). Verbatim from master
+   * `getTransferQuote`.
+   *
+   * @param params - `{ sourceAccount, destinationAccount, amount }`.
+   * @returns the internal transfer quote (with live legs).
+   * @throws DomainError if the source cannot send / the destination cannot receive over Lightning.
+   */
+  async getTransferQuote({
+    sourceAccount,
+    destinationAccount,
+    amount,
+  }: {
+    sourceAccount: Account;
+    destinationAccount: Account;
+    amount: Money;
+  }): Promise<TransferQuoteInternal> {
+    if (!canSendToLightning(sourceAccount)) {
+      throw new DomainError(
+        `${sourceAccount.name} cannot send Lightning payments`,
+      );
+    }
+    if (!canReceiveFromLightning(destinationAccount)) {
+      throw new DomainError(
+        `${destinationAccount.name} cannot receive Lightning payments`,
+      );
+    }
+
+    const receive = await this.getReceiveSide(destinationAccount, amount);
+    const paymentRequest = extractPaymentRequest(receive);
+    const send = await this.getSendSide(sourceAccount, paymentRequest);
+
+    const amountToReceive = send.lightningQuote.amountToReceive;
+    const totalFees = send.lightningQuote.estimatedTotalFee.add(receive.fee);
+    const totalCost = amountToReceive.add(totalFees);
+
+    return { amount, amountToReceive, totalFees, totalCost, receive, send };
+  }
+
+  /**
+   * Initiate a transfer by persisting the receive then the send quote (linked by a fresh
+   * `transferId`). The background processor picks up the created send quote and drives the send.
+   * If the send quote fails to persist, the already-persisted receive quote is AUTO-FAILED so no
+   * orphan credit is left (§9). Verbatim from master `initiateTransfer`.
+   *
+   * @param params - `{ userId, quote }` (the internal transfer quote).
+   * @returns the `transferId` + both leg transaction ids.
+   * @throws Error if the receive or send quote fails to persist.
+   */
+  async initiateTransfer({
+    userId,
+    quote,
+  }: {
+    userId: string;
+    quote: TransferQuoteInternal;
+  }): Promise<{
+    transferId: string;
+    receiveTransactionId: string;
+    sendTransactionId: string;
+  }> {
+    const transferId = crypto.randomUUID();
+    const { receive, send } = quote;
+
+    const receiveQuote = await this.persistReceiveQuote(
+      userId,
+      receive,
+      transferId,
+    );
+
+    try {
+      const sendQuote = await this.persistSendQuote(userId, send, transferId);
+      return {
+        transferId,
+        receiveTransactionId: receiveQuote.transactionId,
+        sendTransactionId: sendQuote.transactionId,
+      };
+    } catch (error) {
+      try {
+        await this.failReceiveQuote(receive, receiveQuote);
+      } catch (failError) {
+        console.error('Failed to cleanup receive quote', {
+          cause: failError,
+          transferId,
+          receiveAccountId: receive.account.id,
+          sendAccountId: send.account.id,
+        });
+      }
+      throw error;
+    }
+  }
+
+  private async getReceiveSide(
+    account: Account,
+    amount: Money,
+  ): Promise<TransferReceiveSide> {
+    if (account.type === 'cashu') {
+      const lightningQuote =
+        await this.cashuReceiveQuoteService.getLightningQuote({
+          wallet: account.wallet,
+          amount,
+        });
+      return {
+        account,
+        fee: lightningQuote.mintingFee ?? Money.zero(amount.currency),
+        lightningQuote,
+      };
+    }
+    return {
+      account,
+      fee: Money.zero(amount.currency),
+      lightningQuote: await getSparkReceiveLightningQuote({
+        wallet: account.wallet,
+        amount,
+      }),
+    };
+  }
+
+  private async getSendSide(
+    account: Account,
+    paymentRequest: string,
+  ): Promise<TransferSendSide> {
+    if (account.type === 'cashu') {
+      return {
+        account,
+        lightningQuote: await this.cashuSendQuoteService.getLightningQuote({
+          account,
+          paymentRequest,
+        }),
+      };
+    }
+    return {
+      account,
+      lightningQuote: await this.sparkSendQuoteService.getLightningSendQuote({
+        account,
+        paymentRequest,
+      }),
+    };
+  }
+
+  private async persistReceiveQuote(
+    userId: string,
+    receive: TransferReceiveSide,
+    transferId: string,
+  ): Promise<CashuReceiveQuote | SparkReceiveQuote> {
+    if (receive.account.type === 'cashu') {
+      return this.cashuReceiveQuoteService.createReceiveQuote({
+        userId,
+        account: receive.account,
+        lightningQuote: receive.lightningQuote as CashuReceiveLightningQuote,
+        receiveType: 'LIGHTNING',
+        purpose: 'TRANSFER',
+        transferId,
+      });
+    }
+    return this.sparkReceiveQuoteService.createReceiveQuote({
+      userId,
+      account: receive.account,
+      lightningQuote: receive.lightningQuote as SparkReceiveLightningQuote,
+      receiveType: 'LIGHTNING',
+      purpose: 'TRANSFER',
+      transferId,
+    });
+  }
+
+  private async failReceiveQuote(
+    receive: TransferReceiveSide,
+    quote: CashuReceiveQuote | SparkReceiveQuote,
+  ): Promise<void> {
+    if (receive.account.type === 'cashu') {
+      await this.cashuReceiveQuoteService.fail(
+        quote as CashuReceiveQuote,
+        'Transfer initiation failed',
+      );
+    } else {
+      await this.sparkReceiveQuoteService.fail(
+        quote as SparkReceiveQuote,
+        'Transfer initiation failed',
+      );
+    }
+  }
+
+  private async persistSendQuote(
+    userId: string,
+    send: TransferSendSide,
+    transferId: string,
+  ): Promise<{ transactionId: string }> {
+    if (send.account.type === 'cashu') {
+      const quote = send.lightningQuote as CashuLightningQuote;
+      return this.cashuSendQuoteService.createSendQuote({
+        userId,
+        account: send.account,
+        sendQuote: {
+          paymentRequest: quote.paymentRequest,
+          amountRequested: quote.amountRequested,
+          amountRequestedInBtc: quote.amountRequestedInBtc,
+          meltQuote: quote.meltQuote,
+        },
+        purpose: 'TRANSFER',
+        transferId,
+      });
+    }
+    return this.sparkSendQuoteService.createSendQuote({
+      userId,
+      account: send.account,
+      quote: send.lightningQuote as SparkLightningQuote,
+      purpose: 'TRANSFER',
+      transferId,
+    });
+  }
+}

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -39,9 +39,14 @@ import {
   CashuSendOpsImpl,
 } from './domains/cashu';
 import { ScanDomainImpl } from './domains/scan';
+import { ContactsDomainImpl } from './domains/contacts';
+import { TransactionsDomainImpl } from './domains/transactions';
+import { TransfersDomainImpl } from './domains/transfers';
 import { UserDomainImpl } from './domains/user';
 import { LiveAccountHandleResolver } from './internal/account-handle-resolver';
 import { AccountRepository } from './internal/account-repository';
+import { ContactEventForwarder } from './internal/contact-event-forwarder';
+import { ContactRepository } from './internal/contact-repository';
 import { CashuReceiveQuoteRepository } from './internal/cashu-receive-quote-repository';
 import { CashuReceiveQuoteService } from './internal/cashu-receive-quote-service';
 import { CashuReceiveSwapRepository } from './internal/cashu-receive-swap-repository';
@@ -73,11 +78,11 @@ import { OpenSecretClient } from './internal/open-secret';
 import { SessionResolver } from './internal/session';
 import {
   createBackgroundStub,
-  createContactsStub,
   createExchangeRateStub,
-  createTransactionsStub,
-  createTransfersStub,
 } from './internal/stub-domains';
+import { TransactionEventForwarder } from './internal/transaction-event-forwarder';
+import { TransactionRepository } from './internal/transaction-repository';
+import { TransferService } from './internal/transfer-service';
 import {
   type SupabaseConnectionConfig,
   type WalletSupabaseClient,
@@ -179,6 +184,17 @@ export type SdkConnections = {
    * + in-flight indices.
    */
   readonly orchestrator: Orchestrator;
+  /**
+   * Realtime → `transaction:*` event forwarder (Slice 4 defines the shape + emit path). Held so the
+   * Slice-5 realtime hub can drive it from the `wallet:${userId}` broadcast channel; it carries no
+   * subscription yet.
+   */
+  readonly transactionEventForwarder: TransactionEventForwarder;
+  /**
+   * Realtime → `contact:*` event forwarder (Slice 4 defines the shape + emit path). Held for the
+   * Slice-5 realtime hub, like {@link transactionEventForwarder}.
+   */
+  readonly contactEventForwarder: ContactEventForwarder;
 };
 
 /** Validate `config` (shape the rest of `create` relies on). Throws on a missing field. */
@@ -269,6 +285,9 @@ export class Sdk {
       scan: ScanDomain;
       cashu: CashuDomain;
       spark: SparkDomain;
+      transactions: TransactionsDomain;
+      contacts: ContactsDomain;
+      transfers: TransfersDomain;
     },
   ) {
     this.connections = connections;
@@ -283,11 +302,12 @@ export class Sdk {
     this.cashu = domains.cashu;
     // Slice 3 / PR5c: spark send + receive ops (executeQuote orchestrator deferred to PR5d).
     this.spark = domains.spark;
+    // Slice 4: transactions + contacts + transfers.
+    this.transactions = domains.transactions;
+    this.contacts = domains.contacts;
+    this.transfers = domains.transfers;
 
     // --- domain accessors still STUBBED (swap per slice) ---------------------
-    this.transactions = createTransactionsStub();
-    this.contacts = createContactsStub();
-    this.transfers = createTransfersStub();
     this.exchangeRate = createExchangeRateStub();
     this.background = createBackgroundStub();
   }
@@ -545,6 +565,54 @@ export class Sdk {
       new SparkReceiveOpsImpl(queryClient, sparkReceiveQuoteService, session),
     );
 
+    // --- Slice 4: transactions + contacts + transfers ------------------------
+    // Transactions: the repo reads `wallet.transactions` over the SDK Supabase client + Encryption
+    // (it decrypts each row's `encrypted_transaction_details` then runs the internal 6-variant
+    // DB→domain parser, decision 7-ii); the reactive domain wraps its reads in `Query<T>` over the
+    // shared QueryClient. Contacts: the repo reads `wallet.contacts` and computes each contact's
+    // `lud16` from `config.domain` (the CONTACT DRIFT reconciliation — `lud16` derived, not stored);
+    // its reads are likewise `Query<T>`. Transfers: the service COMPOSES the PR5b/5c cashu + spark
+    // send/receive quote services (a transfer = a cashu leg + a spark leg) and auto-fails the
+    // receive on a send-persist failure; the domain's createQuote/executeQuote are `Promise`
+    // actions over the VERBATIM-FULL `TransferQuote` (each leg's live Lightning quote is plain data,
+    // read directly — no symbol carrier).
+    const agicashDomain = config.domain ?? '';
+    const transactionRepository = new TransactionRepository(
+      supabase,
+      encryption,
+    );
+    const contactRepository = new ContactRepository(supabase, agicashDomain);
+    const transferService = new TransferService(
+      cashuReceiveQuoteService,
+      sparkReceiveQuoteService,
+      cashuSendQuoteService,
+      sparkSendQuoteService,
+    );
+
+    const transactions = new TransactionsDomainImpl(
+      queryClient,
+      transactionRepository,
+      session,
+    );
+    const contacts = new ContactsDomainImpl(
+      queryClient,
+      contactRepository,
+      session,
+    );
+    const transfers = new TransfersDomainImpl(transferService, session);
+
+    // Realtime → SDK-event forwarders (Slice 4 defines the `transaction:*` / `contact:*` event
+    // SHAPES + emit path; the Slice-5 realtime hub will drive them from the `wallet:${userId}`
+    // broadcast channel — no subscription is opened here).
+    const transactionEventForwarder = new TransactionEventForwarder(
+      transactionRepository,
+      events,
+    );
+    const contactEventForwarder = new ContactEventForwarder(
+      agicashDomain,
+      events,
+    );
+
     // The shared connection bundle (held by `Sdk` so `destroy()` can tear everything down). Built
     // last because the orchestrator (PR5d) needs every protocol service/repo constructed first.
     const connections: SdkConnections = {
@@ -559,9 +627,21 @@ export class Sdk {
       sparkCache,
       sparkBalanceTracker,
       orchestrator,
+      transactionEventForwarder,
+      contactEventForwarder,
     };
 
-    return new Sdk(connections, { auth, user, accounts, scan, cashu, spark });
+    return new Sdk(connections, {
+      auth,
+      user,
+      accounts,
+      scan,
+      cashu,
+      spark,
+      transactions,
+      contacts,
+      transfers,
+    });
   }
 
   /**

--- a/packages/wallet-sdk/src/types/destination.ts
+++ b/packages/wallet-sdk/src/types/destination.ts
@@ -1,0 +1,29 @@
+/**
+ * Send `Destination` — §8 of the contract, Slice 4. NET-NEW typed union (decision 6).
+ *
+ * The user-facing target of a send. A send to a saved {@link Contact} rides the typed
+ * `agicash-contact` kind (which PRESERVES the contact context — the `contactId` so the SDK can
+ * stamp the lightning send's `DestinationDetails` as `{ sendType: 'AGICASH_CONTACT', contactId }`,
+ * §5 — and the `lud16` so it can resolve the invoice via LNURL-pay) rather than collapsing the
+ * contact down to a bare `lud16` string (which would lose the contact link on the resulting
+ * transaction). A raw bolt11 / ln-address rides the `payment-request` kind.
+ *
+ * This GENERALIZES master's `send/resolve-destination.ts#SendDestination` (whose `AGICASH_CONTACT`
+ * branch carries the full `Contact`) into the SDK's framework-free surface: it is the input the
+ * send domains can accept to know they are paying a contact. The pure
+ * `internal/destination.ts#resolveDestination` derives the `{ paymentTarget, destinationDetails }`
+ * the cashu/spark lightning-send path needs.
+ */
+import type { Contact } from './contact';
+
+/**
+ * A send target.
+ *
+ * - `payment-request`: a raw bolt11 invoice or `user@domain` Lightning address string (the
+ *   ln-address is resolved to an invoice inside `createLightningQuote`, §3).
+ * - `agicash-contact`: a send to a saved {@link Contact} — preserves the contact link so the
+ *   resulting transaction records `sendType: 'AGICASH_CONTACT'` with the `contactId`.
+ */
+export type Destination =
+  | { kind: 'payment-request'; paymentRequest: string }
+  | { kind: 'agicash-contact'; contact: Contact };

--- a/packages/wallet-sdk/src/types/transfer.ts
+++ b/packages/wallet-sdk/src/types/transfer.ts
@@ -1,27 +1,84 @@
-// Transfer domain types
-
+/**
+ * Transfer domain types — §9 of the contract (cross-account, cashu<->spark via LN).
+ *
+ * `TransferQuote` is the VERBATIM-FULL master shape (`app/features/transfer/transfer-service.ts`
+ * `getTransferQuote`'s return): each leg carries its live per-leg Lightning quote as a VISIBLE,
+ * plain-data field. This deliberately DIVERGES from the no-cache PR6's slim cost-preview (which
+ * stashed the live legs on a non-enumerable symbol — serialization-fragile). Here the legs are
+ * just data: {@link TransfersDomain.executeQuote} reads them DIRECTLY off the full quote (no
+ * symbol recovery, no "must be created via createQuote" guard).
+ *
+ * `TransferQuote` is EPHEMERAL (not persisted). Executing it persists the paired send+receive
+ * quotes, linked by a `transferId`; the receive is AUTO-FAILED if the send fails to persist.
+ *
+ * @module
+ */
+import type { CashuReceiveLightningQuote } from '../internal/cashu-receive-quote-core';
+import type { CashuLightningQuote } from '../internal/cashu-send-quote-service';
+import type { SparkReceiveLightningQuote } from '../internal/spark-receive-quote-core';
+import type { SparkLightningQuote } from '../internal/spark-send-quote-service';
 import type { CashuAccount, SparkAccount } from './account';
 import type { Money } from './money';
 
-export type TransferLeg =
-  | { account: CashuAccount; fee: Money }
-  | { account: SparkAccount; fee: Money };
+/**
+ * The destination (receive) leg of a {@link TransferQuote}: the account being credited, the fee
+ * charged on that leg, and the live Lightning RECEIVE quote (the mint/Breez quote the receive is
+ * later persisted from). VERBATIM from master `TransferReceiveSide` — the `lightningQuote` is a
+ * VISIBLE field (no symbol).
+ */
+export type TransferReceiveSide =
+  | {
+      account: CashuAccount;
+      fee: Money;
+      lightningQuote: CashuReceiveLightningQuote;
+    }
+  | {
+      account: SparkAccount;
+      fee: Money;
+      lightningQuote: SparkReceiveLightningQuote;
+    };
 
 /**
- * Ephemeral cost-preview — not persisted.
- * The paired send+receive quotes persist, linked by transferId.
+ * The source (send) leg of a {@link TransferQuote}: the account being debited and the live
+ * Lightning SEND quote (the quote the send is later persisted from — its `estimatedTotalFee` is
+ * the send-leg fee, so unlike the receive leg there is no separate `fee` field). VERBATIM from
+ * master `TransferSendSide` — the `lightningQuote` is a VISIBLE field (no symbol).
+ */
+export type TransferSendSide =
+  | { account: CashuAccount; lightningQuote: CashuLightningQuote }
+  | { account: SparkAccount; lightningQuote: SparkLightningQuote };
+
+/**
+ * An ephemeral quote for a cross-account transfer (cashu↔spark via Lightning), produced by
+ * {@link TransfersDomain.createQuote}. The VERBATIM-FULL master shape: both legs expose their
+ * live per-leg Lightning quote as plain data, so {@link TransfersDomain.executeQuote} reads them
+ * directly. Not persisted — the underlying paired send+receive quotes persist, linked by a
+ * `transferId`.
  */
 export type TransferQuote = {
+  /** The amount the user asked to transfer. */
   amount: Money;
+  /** What the destination account will actually receive after fees. */
   amountToReceive: Money;
+  /** Sum of both legs' fees (the send leg's `estimatedTotalFee` + the receive leg's `fee`). */
   totalFees: Money;
+  /** Total debited from the source: `amountToReceive` + `totalFees`. */
   totalCost: Money;
-  receive: TransferLeg;
-  send: TransferLeg;
+  /** The destination leg (account credited + its fee + the live receive Lightning quote). */
+  receive: TransferReceiveSide;
+  /** The source leg (account debited + the live send Lightning quote). */
+  send: TransferSendSide;
 };
 
+/**
+ * The outcome of {@link TransfersDomain.executeQuote}. A transfer is TWO transactions — a debit
+ * and a credit — linked by `transferId`; this returns the ids of both plus the shared link.
+ */
 export type TransferResult = {
+  /** Links the paired send + receive transactions. */
   transferId: string;
+  /** UUID of the credit (receive) transaction. */
   receiveTransactionId: string;
+  /** UUID of the debit (send) transaction. */
   sendTransactionId: string;
 };

--- a/packages/wallet-sdk/tsconfig.json
+++ b/packages/wallet-sdk/tsconfig.json
@@ -7,7 +7,8 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["../../apps/web-wallet/app/*"]
+      "~/*": ["../../apps/web-wallet/app/*"],
+      "supabase/database.types": ["../../supabase/database.types.ts"]
     }
   }
 }


### PR DESCRIPTION
**Slice 4** of the reactive `@agicash/wallet-sdk` (design B): the transactions/contacts **read-model** + cross-account **transfers**. Lifts the proven no-cache PR6 (`sdk/pr6-transactions-contacts-transfers`) onto the reactive base (PR5d), wrapping the observable reads in `Query<T>`.

Stack: PR1 #1129 + PR2 #1130 → PR3 #1131 → PR4 #1132 → PR5a #1133 → PR5b #1134 → PR5c #1135 → PR5d #1136 → **PR6 (this)**.

### Reactive overlay (the reads become `Query<T>`)
TanStack stays hidden inside the SDK; these are wrapped via `toQuery` and memoised per key (same pattern as PR5b/5c):
- `transactions.list(filter?): Query<{ transactions; nextCursor }>` (cursor pagination, PENDING-first, page-cap), `transactions.get(id): Query<Transaction | null>`, `transactions.countPendingAck(): Query<number>`
- `contacts.list(): Query<Contact[]>`, `contacts.get(id): Query<Contact | null>`

Actions/writes stay `Promise` (lifted verbatim): `transactions.acknowledge`, `contacts.search` (one-shot), `contacts.add/remove`, `transfers.createQuote/executeQuote`.

### Lifted verbatim from no-cache PR6
- `Transaction` (9-variant union + enums + `TransactionCursor`); the 6-variant **public** `TransactionDetails` union + the **internal** DB→domain parser (decrypt → `DbData` schema → per-variant `z.pipe` → `TransactionSchema`, decision 7-ii) + the transaction repository (the `list_transactions` RPC, cursor paging, page-cap) + the tri-state ack store.
- `Contact` / `UserProfile` (master-shaped: `createdAt: string`, `UserProfile = Pick<User,'id'|'username'>`, `lud16` repo-materialized) + the contact repository (min-3 search excluding existing).
- The transfer service (two-leg compose + **auto-fail-receive-on-send-fail**), the typed `Destination` (`agicash-contact`), the `TransferResult`, and the `transaction:*` / `contact:*` event **shapes** + their realtime forwarders (**emitted by PR7's realtime — not wired here**). No `transfer:*` events (a transfer surfaces as two linked `transaction:*` events).

### The one deliberate divergence — verbatim-full `TransferQuote`
The no-cache PR6 made the public `TransferQuote` a slim cost-preview and stashed the live per-leg quotes on a **non-enumerable symbol** (serialization-fragile). **Dropped entirely.** This PR exposes master's **verbatim-full `TransferQuote`** (`getTransferQuote`'s real return): each leg carries its live per-leg Lightning quote as a **visible plain-data field** (`receive: TransferReceiveSide`, `send: TransferSendSide`). `transfers.executeQuote(quote)` reads the legs **directly off the full quote** — no symbol recovery, no `DomainError` "not from createQuote" guard. The quote stays ephemeral; the paired send+receive quotes persist linked by `transferId`.

### Lineage-drift reconciliation
- Forwarders import `SdkEventMap` from `../types/events` (the base's location; the shapes are already present there).
- `UserProfile` kept in `types/user` (the base's location), **not** re-defined in `types/contact`; the contacts repo/domain import it from `../types/user`.
- The `supabase/database.types` path alias added to **both** `packages/wallet-sdk/tsconfig.json` **and** `packages/react-wallet-sdk/tsconfig.json` — `react-wallet-sdk` typechecks the SDK sources transitively and `db-transaction.ts` imports `Json` from there.

### Tests
Ported the no-cache PR6 tests (parser 6-variant round-trip, list PENDING-first + page-cap, tri-state ack, contact search min-3 + excludes-existing, typed `Destination`, transfers two-leg compose + auto-fail-receive-on-send-fail) + added `Query<T>` assertions for the read methods. The transfers tests are **updated for the verbatim-full quote** (legs are visible plain-data, `executeQuote` reads them directly; the slim/symbol + "rejects foreign quote" assertions removed).

### CI gate (local, green)
- `@agicash/wallet-sdk`: **368 pass / 0 fail** · `@agicash/react-wallet-sdk`: **5 pass / 0 fail** · `web-wallet`: **133 pass / 0 fail**
- `tsc --noEmit` clean across **all** packages (incl. `@agicash/react-wallet-sdk`)
- `biome format` + `lint` clean (the 2 repo-wide lint warnings are pre-existing in `apps/web-wallet/vite-env.d.ts`, untouched)
- `bun install --frozen-lockfile` — **no new deps**

🤖 Generated with [Claude Code](https://claude.com/claude-code)