### PR TITLE
feat(web): SDK provider + deps + singleton (PR8a)

### DIFF
--- a/apps/web-wallet/app/entry.client.tsx
+++ b/apps/web-wallet/app/entry.client.tsx
@@ -11,6 +11,7 @@ import { HydratedRouter } from 'react-router/dom';
 import { getEnvironment, isServedLocally } from './environment';
 import { featureFlagsQueryOptions } from './features/shared/feature-flags';
 import { getQueryClient } from './features/shared/query-client';
+import { getSdk } from './features/shared/sdk';
 import { Money } from '@agicash/lib';
 import { ensureBreezWasm } from './lib/spark';
 import { getTracesSampleRate, sanitizeUrl } from './tracing-utils';
@@ -33,6 +34,15 @@ if (!openSecretClientId) {
 configure({
   apiUrl: openSecretApiUrl,
   clientId: openSecretClientId,
+});
+
+// Eagerly create the (browser-only) Sdk singleton so its promise is already settling before
+// hydration — `SdkProvider`'s `use(getSdk())` then resolves without suspending. PR8a only makes
+// the SDK available via its provider; it is NOT started (the web keeps driving its own caches +
+// realtime + task-processor), and `Sdk.create` opens no connections, so this is inert. Swallow
+// the rejection here; a genuinely broken config also surfaces through `SdkProvider`.
+getSdk().catch(() => {
+  // Surfaced via SdkProvider when the SDK is first read (no reads in PR8a).
 });
 
 // Start Breez WASM fetch/compile as early as possible so it overlaps with

--- a/apps/web-wallet/app/features/shared/sdk-provider.test.tsx
+++ b/apps/web-wallet/app/features/shared/sdk-provider.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from 'bun:test';
+import { AgicashProvider, useSdk } from '@agicash/react-wallet-sdk';
+import type { Sdk } from '@agicash/wallet-sdk';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SdkProvider } from './sdk-provider';
+
+/**
+ * PR8a smoke. `renderToStaticMarkup` runs with `isServer === true`, so it exercises
+ * `SdkProvider`'s server branch: it must be an inert pass-through (no `window`/`Sdk.create`
+ * access, no throw) that renders its children. The client branch (which `use(getSdk())`s the
+ * browser singleton) is covered by hydration in the browser, not here.
+ */
+test('SdkProvider renders children on the server without touching the browser SDK', () => {
+  const html = renderToStaticMarkup(
+    <SdkProvider>
+      <span>child</span>
+    </SdkProvider>,
+  );
+  expect(html).toContain('child');
+});
+
+/**
+ * The provider/consumer contract the web wires to (PR8a): a tree wrapped in `AgicashProvider`
+ * resolves the supplied `Sdk` via `useSdk`. This is what `SdkProvider`'s client branch composes
+ * once the singleton resolves.
+ */
+test('AgicashProvider resolves the provided Sdk via useSdk', () => {
+  const sdk = { id: 'pr8a-smoke' } as unknown as Sdk;
+
+  function Probe() {
+    const resolved = useSdk() as unknown as { id: string };
+    return <span>{resolved.id}</span>;
+  }
+
+  const html = renderToStaticMarkup(
+    <AgicashProvider sdk={sdk}>
+      <Probe />
+    </AgicashProvider>,
+  );
+  expect(html).toContain('pr8a-smoke');
+});

--- a/apps/web-wallet/app/features/shared/sdk-provider.tsx
+++ b/apps/web-wallet/app/features/shared/sdk-provider.tsx
@@ -1,0 +1,28 @@
+import { AgicashProvider } from '@agicash/react-wallet-sdk';
+import { isServer } from '@tanstack/react-query';
+import { type ReactNode, use } from 'react';
+import { getSdk } from './sdk';
+
+/**
+ * Mounts {@link AgicashProvider} with the browser `Sdk` singleton (PR8a).
+ *
+ * The `Sdk` is browser-only and `Sdk.create` is async, while the app root (`root.tsx`) is
+ * sync and also runs during SSR. So:
+ * - On the server we render `children` directly (no provider). The SDK context default is the
+ *   "no provider" sentinel; nothing reads the SDK in PR8a, and a context provider emits no DOM,
+ *   so the server and client trees hydrate identically.
+ * - On the client we unwrap the memoised `getSdk()` promise with React's `use`. `Sdk.create`
+ *   opens no network connections and does no I/O (constructors only), so the promise settles in
+ *   a microtask — `use` resolves before paint and does not block the app.
+ */
+export function SdkProvider({ children }: { children: ReactNode }) {
+  if (isServer) {
+    return <>{children}</>;
+  }
+  return <ClientSdkProvider>{children}</ClientSdkProvider>;
+}
+
+function ClientSdkProvider({ children }: { children: ReactNode }) {
+  const sdk = use(getSdk());
+  return <AgicashProvider sdk={sdk}>{children}</AgicashProvider>;
+}

--- a/apps/web-wallet/app/features/shared/sdk.ts
+++ b/apps/web-wallet/app/features/shared/sdk.ts
@@ -1,0 +1,78 @@
+import { Sdk, type SdkConfig, type StorageAdapter } from '@agicash/wallet-sdk';
+
+/**
+ * Browser-side `Sdk` singleton (PR8a).
+ *
+ * Mirrors the {@link ./query-client} `browserQueryClient` pattern: the app builds ONE
+ * `Sdk` instance per browser session and shares it through `AgicashProvider`. `Sdk.create`
+ * is async, so initialisation happens client-side in `entry.client.tsx` (the app's `App`
+ * root is sync and also runs during SSR — the SDK is browser-only). The promise is memoised
+ * here so a re-import never constructs a second instance.
+ *
+ * The SDK is INSTANTIATED but NOT STARTED in PR8a: the web keeps driving its own TanStack
+ * caches, Supabase realtime, and task-processor. `Sdk.create` opens no network connections
+ * on its own (OpenSecret `configure` is a module-global no-op; the Supabase client is built
+ * but its realtime channel only subscribes on `background.start()`, which PR8a never calls).
+ */
+let sdkPromise: Promise<Sdk> | undefined;
+
+/** A `localStorage`-backed {@link StorageAdapter} for the browser (the SDK's web storage). */
+const browserStorage: StorageAdapter = {
+  getItem: (key) => window.localStorage.getItem(key),
+  setItem: (key, value) => {
+    window.localStorage.setItem(key, value);
+  },
+  removeItem: (key) => {
+    window.localStorage.removeItem(key);
+  },
+};
+
+/**
+ * Build the {@link SdkConfig} from the same `VITE_*` credentials the web app already reads
+ * (OpenSecret in `entry.client.tsx`, Supabase in `agicash-db/database.client.ts`, Breez in
+ * `features/shared/spark.ts`). Browser-only — uses `window.location.host` for the LN-address
+ * domain.
+ */
+function getSdkConfig(): SdkConfig {
+  const openSecretUrl = import.meta.env.VITE_OPEN_SECRET_API_URL ?? '';
+  if (!openSecretUrl) {
+    throw new Error('VITE_OPEN_SECRET_API_URL is not set');
+  }
+  const openSecretClientId = import.meta.env.VITE_OPEN_SECRET_CLIENT_ID ?? '';
+  if (!openSecretClientId) {
+    throw new Error('VITE_OPEN_SECRET_CLIENT_ID is not set');
+  }
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? '';
+  if (!supabaseUrl) {
+    throw new Error('VITE_SUPABASE_URL is not set');
+  }
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY ?? '';
+  if (!supabaseAnonKey) {
+    throw new Error('VITE_SUPABASE_ANON_KEY is not set');
+  }
+  const breezApiKey = import.meta.env.VITE_BREEZ_API_KEY ?? '';
+  if (!breezApiKey) {
+    throw new Error('VITE_BREEZ_API_KEY is not set');
+  }
+
+  return {
+    openSecret: { url: openSecretUrl, clientId: openSecretClientId },
+    supabase: { url: supabaseUrl, anonKey: supabaseAnonKey },
+    breezApiKey,
+    storage: browserStorage,
+    domain: window.location.host,
+  };
+}
+
+/**
+ * Create (once) and return the browser `Sdk` singleton. Safe to call repeatedly — the
+ * underlying `Sdk.create` promise is memoised. Call only in the browser.
+ *
+ * @returns the initialised `Sdk` instance.
+ */
+export function getSdk(): Promise<Sdk> {
+  if (!sdkPromise) {
+    sdkPromise = Sdk.create(getSdkConfig());
+  }
+  return sdkPromise;
+}

--- a/apps/web-wallet/app/root.tsx
+++ b/apps/web-wallet/app/root.tsx
@@ -38,6 +38,7 @@ import type { Route } from './+types/root';
 import { LoadingScreen } from './features/loading/LoadingScreen';
 import { NotFoundError } from './features/shared/error';
 import { getQueryClient } from './features/shared/query-client';
+import { SdkProvider } from './features/shared/sdk-provider';
 import { useDehydratedState } from './hooks/use-dehydrated-state';
 import { sanitizeUrl } from './tracing-utils';
 
@@ -207,12 +208,14 @@ export default function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <HydrationBoundary state={dehydratedState}>
-        <Suspense fallback={<LoadingScreen />}>
-          <Outlet />
-        </Suspense>
-        <ReactQueryDevtools initialIsOpen={false} />
-      </HydrationBoundary>
+      <SdkProvider>
+        <HydrationBoundary state={dehydratedState}>
+          <Suspense fallback={<LoadingScreen />}>
+            <Outlet />
+          </Suspense>
+          <ReactQueryDevtools initialIsOpen={false} />
+        </HydrationBoundary>
+      </SdkProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/web-wallet/package.json
+++ b/apps/web-wallet/package.json
@@ -22,6 +22,7 @@
     "@agicash/db-types": "workspace:*",
     "@agicash/lib": "workspace:*",
     "@agicash/wallet-sdk": "workspace:*",
+    "@agicash/react-wallet-sdk": "workspace:*",
     "@agicash/opensecret": "catalog:",
     "@agicash/qr-scanner": "0.1.2",
     "@cashu/cashu-ts": "3.6.1",

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@agicash/lib": "workspace:*",
         "@agicash/opensecret": "catalog:",
         "@agicash/qr-scanner": "0.1.2",
+        "@agicash/react-wallet-sdk": "workspace:*",
         "@agicash/wallet-sdk": "workspace:*",
         "@cashu/cashu-ts": "3.6.1",
         "@noble/ciphers": "1.3.0",


### PR DESCRIPTION
First sub-PR of the web-wallet migration onto the reactive SDK. It makes `@agicash/wallet-sdk` **available** to the app via its React provider and **flips nothing**: no read hooks migrated, no data pre-warm, and the web keeps running its own TanStack caches + Supabase realtime + task-processor. The SDK is instantiated and provided, but unused. The app should behave identically.

Stacked on the cashu-split branch (`sdk-reactive/lib-extract-cashu`, #1143).

## What's here
- **Deps:** add `@agicash/react-wallet-sdk` (`workspace:*`) to `apps/web-wallet` (`@agicash/wallet-sdk` was already a dep).
- **Sdk singleton** (`app/features/shared/sdk.ts`): mirrors the existing `browserQueryClient` pattern. `Sdk.create` is async and the `App` root is sync (and runs during SSR), so the singleton is a **memoised promise** built **client-side**. `SdkConfig` is assembled from the same `VITE_*` credentials the app already reads — OpenSecret (`entry.client.tsx`), Supabase (`agicash-db/database.client.ts`), Breez (`features/shared/spark.ts`) — with a `localStorage` `StorageAdapter` and `window.location.host` as the LN-address domain.
- **Async-in-sync-root wiring:** `entry.client.tsx` eagerly kicks off `getSdk()` (fire-and-forget, rejection swallowed) so the promise is already settling before hydration. A small SSR-safe `SdkProvider` (`app/features/shared/sdk-provider.tsx`) renders children as a pass-through on the server (`isServer`) and, on the client, unwraps the singleton with React 19's `use(getSdk())` then mounts `AgicashProvider`. Because `Sdk.create` does no I/O, the promise settles in a microtask, so `use` resolves before paint and never blocks the app. `SdkProvider` wraps the tree **inside** the existing `QueryClientProvider` (the app keeps its own `QueryClient`).
- **Smoke test** (`sdk-provider.test.tsx`): `SdkProvider` is an inert SSR pass-through; `AgicashProvider` resolves the supplied `Sdk` via `useSdk`.

## Transition coexistence — what `Sdk.create` connects
**Nothing, at the network level.** Verified each connection-bearing internal:
- `OpenSecretClient` ctor → only the module-global `configure()` (no I/O).
- Supabase client → `createClient()` only; its realtime channel subscribes lazily and is **only** triggered by `RealtimeHub.subscribe()`, which runs **only** from `BackgroundProcessor.start()`.
- `RealtimeHub` / `LeaderElection` / `BackgroundProcessor` / `SparkBalanceTracker` / `Orchestrator` → inert constructors; all subscriptions / polling / Breez listeners start via `start()` / `subscribe()` / `track()`.
- Spark/Breez wallets connect lazily via the live-handle resolver, only when an account handle is first resolved (a read path PR8a never triggers).

PR8a does **not** call `sdk.background.start()` and migrates **no reads**, so the SDK coexists with the web's existing background processing with **no doubled Supabase realtime channel, no second Breez connection, no extra mint WS**. (`background.start()` is deferred to a later sub-PR.)

## Checks (local, full repo)
- `biome format` + `biome lint`: clean (2 pre-existing warnings in `vite-env.d.ts`, untouched).
- `bun --filter='*' run typecheck`: all 6 packages exit 0.
- `bun --filter='*' run test`: lib 14 / wallet-sdk 485 / react-wallet-sdk 5 / web-wallet 59 (incl. 2 new) — all green.
- `bun run build`: client + server + prerender succeed (prerender exercises the `SdkProvider` SSR pass-through).

Do not merge — first of the sub-PR sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)