### PR TITLE
feat(web): migrate transaction reads to the SDK (PR8c)

### DIFF
--- a/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
@@ -1,3 +1,5 @@
+import type { Money } from '@agicash/lib';
+import { useSdk } from '@agicash/react-wallet-sdk';
 import {
   HttpResponseError,
   MintOperationError,
@@ -22,7 +24,6 @@ import {
   sumProofs,
   useOnMeltQuoteStateChange,
 } from '~/lib/cashu';
-import type { Money } from '@agicash/lib';
 import {
   type LongTimeout,
   clearLongTimeout,
@@ -39,7 +40,6 @@ import {
 import type { AgicashDbCashuReceiveQuote } from '../agicash-db/database';
 import { getInitializedCashuWallet } from '../shared/cashu';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
-import { useTransactionsCache } from '../transactions/transaction-hooks';
 import { useUser } from '../user/user-hooks';
 import type { CashuReceiveQuote } from './cashu-receive-quote';
 import { useCashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
@@ -583,7 +583,7 @@ export function useProcessCashuReceiveQuoteTasks() {
     useGetCashuAccountByMintUrlAndCurrency();
   const pendingQuotesCache = usePendingCashuReceiveQuotesCache();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
-  const transactionsCache = useTransactionsCache();
+  const sdk = useSdk();
   const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
@@ -603,11 +603,12 @@ export function useProcessCashuReceiveQuoteTasks() {
         // Updating the quote cache triggers navigation to the transaction details page.
         // Completing the quote also completes the transaction and if navigation to transaction
         // page happens before transaction udpated realtime notification is processed, the
-        // transaction would be stale in the cache with the DRAFT state. We are invalidating the
-        // transaction cache here so that it starts refetching the transaction as soon as possible
+        // transaction would be stale in the cache with the DRAFT state. We refetch the SDK
+        // transaction read here so that it starts refetching the transaction as soon as possible
         // without relying on realtime notification which might be delayed when reconnecting due to
         // the app being in background.
-        transactionsCache.invalidateTransaction(data.quote.transactionId);
+        void sdk.transactions.get(data.quote.transactionId).refetch();
+        void sdk.transactions.list().refetch();
         cashuReceiveQuoteCache.updateIfExists(data.quote);
         pendingQuotesCache.update(data.quote);
       }

--- a/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
@@ -1,4 +1,6 @@
 import type { Payment } from '@agicash/breez-sdk-spark';
+import type { Money } from '@agicash/lib';
+import { useSdk } from '@agicash/react-wallet-sdk';
 import { MintOperationError, NetworkError } from '@cashu/cashu-ts';
 import {
   type QueryClient,
@@ -14,7 +16,6 @@ import {
   sumProofs,
   useOnMeltQuoteStateChange,
 } from '~/lib/cashu';
-import type { Money } from '@agicash/lib';
 import { useLatest } from '~/lib/use-latest';
 import type { SparkAccount } from '../accounts/account';
 import {
@@ -26,7 +27,6 @@ import type { AgicashDbSparkReceiveQuote } from '../agicash-db/database';
 import { getInitializedCashuWallet } from '../shared/cashu';
 import { sparkDebugLog } from '../shared/spark';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
-import { useTransactionsCache } from '../transactions/transaction-hooks';
 import { useUser } from '../user/user-hooks';
 import type { SparkReceiveQuote } from './spark-receive-quote';
 import { getLightningQuote } from './spark-receive-quote-core';
@@ -461,7 +461,7 @@ export function useProcessSparkReceiveQuoteTasks() {
     useGetCashuAccountByMintUrlAndCurrency();
   const pendingQuotesCache = usePendingSparkReceiveQuotesCache();
   const sparkReceiveQuoteCache = useSparkReceiveQuoteCache();
-  const transactionsCache = useTransactionsCache();
+  const sdk = useSdk();
   const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
@@ -497,11 +497,12 @@ export function useProcessSparkReceiveQuoteTasks() {
         // Updating the quote cache triggers navigation to the transaction details page.
         // Completing the quote also completes the transaction and if navigation to transaction
         // page happens before transaction updated realtime notification is processed, the
-        // transaction would be stale in the cache with the DRAFT state. We are invalidating the
-        // transaction cache here so that it starts refetching the transaction as soon as possible
+        // transaction would be stale in the cache with the DRAFT state. We refetch the SDK
+        // transaction read here so that it starts refetching the transaction as soon as possible
         // without relying on realtime notification which might be delayed when reconnecting due to
         // the app being in background.
-        transactionsCache.invalidateTransaction(updatedQuote.transactionId);
+        void sdk.transactions.get(updatedQuote.transactionId).refetch();
+        void sdk.transactions.list().refetch();
         sparkReceiveQuoteCache.updateIfExists(updatedQuote);
         pendingQuotesCache.remove(updatedQuote);
       }

--- a/apps/web-wallet/app/features/transactions/transaction-additional-details.tsx
+++ b/apps/web-wallet/app/features/transactions/transaction-additional-details.tsx
@@ -205,7 +205,7 @@ const getDetails = (transaction: Transaction, account: CashuAccount) => {
 export function TransactionAdditionalDetails({
   transactionId,
 }: { transactionId: string }) {
-  const { data: transaction } = useTransaction(transactionId);
+  const transaction = useTransaction(transactionId);
   const account = useAccountOrNull(transaction.accountId);
 
   if (!account) {

--- a/apps/web-wallet/app/features/transactions/transaction-hooks.ts
+++ b/apps/web-wallet/app/features/transactions/transaction-hooks.ts
@@ -1,217 +1,71 @@
-import {
-  type InfiniteData,
-  type QueryClient,
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from '@tanstack/react-query';
-import { useMemo } from 'react';
-import type { AgicashDbTransaction } from '~/features/agicash-db/database';
+import { useSdk } from '@agicash/react-wallet-sdk';
+import { useQ } from '@agicash/react-wallet-sdk';
+import type { TransactionCursor } from '@agicash/wallet-sdk';
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { useLatest } from '~/lib/use-latest';
 import { useGetCashuAccount } from '../accounts/account-hooks';
 import { useCashuSendSwapRepository } from '../send/cashu-send-swap-repository';
 import { useCashuSendSwapService } from '../send/cashu-send-swap-service';
 import { NotFoundError } from '../shared/error';
-import { useUser } from '../user/user-hooks';
 import type { Transaction } from './transaction';
-import {
-  type Cursor,
-  useTransactionRepository,
-} from './transaction-repository';
 
-/**
- * Cache that manages transaction data and acknowledgment counts.
- */
-class TransactionsCache {
-  public static Key = 'transactions';
-  public static AllTransactionsKey = 'all-transactions';
-  public static UnacknowledgedCountKey = 'unacknowledged-transactions-count';
+export function useTransaction(id: string): Transaction {
+  const sdk = useSdk();
+  const transaction = useQ(sdk.transactions.get(id));
 
-  constructor(private readonly queryClient: QueryClient) {}
-
-  /**
-   * Adds a new transaction or updates an existing transaction in the individual transaction cache.
-   * Only updates when the incoming version is higher than the cached version, to avoid
-   * overwriting newer data with older in case of out-of-order events.
-   * @param transaction - The transaction to add or update.
-   */
-  upsert(transaction: Transaction) {
-    this.queryClient.setQueryData<Transaction>(
-      [TransactionsCache.Key, transaction.id],
-      (curr) =>
-        !curr || transaction.version > curr.version ? transaction : undefined,
-    );
+  if (!transaction) {
+    throw new NotFoundError(`Transaction not found for id: ${id}`);
   }
 
-  /**
-   * Invalidates all transaction caches.
-   */
-  invalidate() {
-    return Promise.all([
-      this.queryClient.invalidateQueries({
-        queryKey: [TransactionsCache.Key],
-      }),
-      this.queryClient.invalidateQueries({
-        queryKey: [TransactionsCache.AllTransactionsKey],
-      }),
-      this.queryClient.invalidateQueries({
-        queryKey: [TransactionsCache.UnacknowledgedCountKey],
-      }),
-    ]);
-  }
-
-  /**
-   * Invalidates a single transaction query by ID.
-   */
-  invalidateTransaction(transactionId: string) {
-    return this.queryClient.invalidateQueries({
-      queryKey: [TransactionsCache.Key, transactionId],
-    });
-  }
-
-  /**
-   * Invalidates the unacknowledged count query.
-   */
-  invalidateUnacknowledgedCount() {
-    return this.queryClient.invalidateQueries({
-      queryKey: [TransactionsCache.UnacknowledgedCountKey],
-    });
-  }
+  return transaction as unknown as Transaction;
 }
 
-export function useTransactionsCache() {
-  const queryClient = useQueryClient();
-  return useMemo(() => new TransactionsCache(queryClient), [queryClient]);
-}
+const ALL_TRANSACTIONS_KEY = 'all-transactions';
 
-export function useTransaction(id: string) {
-  const transactionRepository = useTransactionRepository();
-
-  return useSuspenseQuery({
-    queryKey: [TransactionsCache.Key, id],
-    queryFn: async () => {
-      const transaction = await transactionRepository.get(id);
-
-      if (!transaction) {
-        throw new NotFoundError(`Transaction not found for id: ${id}`);
-      }
-
-      return transaction;
-    },
-    retry: (failureCount, error) => {
-      if (error instanceof NotFoundError) {
-        return false;
-      }
-      return failureCount <= 3;
-    },
-    staleTime: Number.POSITIVE_INFINITY,
-    refetchOnWindowFocus: 'always',
-    refetchOnReconnect: 'always',
-  });
-}
-
-const PAGE_SIZE = 25;
+type TransactionsPage = {
+  transactions: Transaction[];
+  nextCursor: TransactionCursor | null;
+};
 
 export function useTransactions(accountId?: string) {
-  const userId = useUser((user) => user.id);
-  const transactionRepository = useTransactionRepository();
-  const transactionsCache = useTransactionsCache();
+  const sdk = useSdk();
 
-  const result = useInfiniteQuery({
-    queryKey: [TransactionsCache.AllTransactionsKey, accountId],
-    initialPageParam: null,
-    queryFn: async ({ pageParam }: { pageParam: Cursor | null }) => {
-      const result = await transactionRepository.list({
-        userId,
-        cursor: pageParam,
-        pageSize: PAGE_SIZE,
-        accountId,
-      });
-
-      for (const transaction of result.transactions) {
-        transactionsCache.upsert(transaction);
-      }
-
-      return {
-        transactions: result.transactions,
-        nextCursor:
-          result.transactions.length === PAGE_SIZE ? result.nextCursor : null,
-      };
-    },
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  return useInfiniteQuery({
+    queryKey: [ALL_TRANSACTIONS_KEY, accountId],
+    initialPageParam: undefined as TransactionCursor | undefined,
+    queryFn: ({ pageParam }: { pageParam: TransactionCursor | undefined }) =>
+      // The SDK and web `Transaction` types are structurally equivalent at
+      // runtime; the web's zod-narrowed union is just stricter on `details`.
+      sdk.transactions
+        .list({ accountId, cursor: pageParam ?? undefined })
+        .toPromise() as Promise<TransactionsPage>,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     refetchOnWindowFocus: 'always',
     refetchOnReconnect: 'always',
     retry: 1,
   });
-
-  return result;
 }
 
 export function useHasTransactionsPendingAck() {
-  const transactionRepository = useTransactionRepository();
-  const userId = useUser((user) => user.id);
-
-  const result = useQuery({
-    queryKey: [TransactionsCache.UnacknowledgedCountKey],
-    queryFn: () =>
-      transactionRepository.countTransactionsPendingAck({ userId }),
-    select: (data) => data > 0,
-    staleTime: Number.POSITIVE_INFINITY,
-    refetchOnWindowFocus: 'always',
-    refetchOnReconnect: 'always',
-    retry: 1,
-  });
-
-  return result.data ?? false;
+  const sdk = useSdk();
+  const count = useQ(sdk.transactions.countPendingAck());
+  return count > 0;
 }
 
-const acknowledgeTransactionInHistoryCache = (
-  queryClient: QueryClient,
-  transaction: Transaction,
-) => {
-  // Update all transaction query caches (both unified and account-specific)
-  const queries = queryClient.getQueriesData<
-    InfiniteData<{
-      transactions: Transaction[];
-      nextCursor: Cursor | null;
-    }>
-  >({ queryKey: [TransactionsCache.AllTransactionsKey] });
-
-  queries.forEach(([queryKey, data]) => {
-    if (!data) return;
-
-    queryClient.setQueryData(queryKey, {
-      ...data,
-      pages: data.pages.map((page) => ({
-        ...page,
-        transactions: page.transactions.map((tx) =>
-          tx.id === transaction.id && tx.acknowledgmentStatus === 'pending'
-            ? { ...tx, acknowledgmentStatus: 'acknowledged' }
-            : tx,
-        ),
-      })),
-    });
-  });
-};
-
 export function useAcknowledgeTransaction() {
-  const transactionRepository = useTransactionRepository();
-  const userId = useUser((user) => user.id);
-  const queryClient = useQueryClient();
-  const transactionsCache = useTransactionsCache();
+  const sdk = useSdk();
 
   return useMutation({
     mutationFn: async ({ transaction }: { transaction: Transaction }) => {
-      await transactionRepository.acknowledgeTransaction({
-        userId,
-        transactionId: transaction.id,
-      });
+      await sdk.transactions.acknowledge(
+        transaction as unknown as Parameters<
+          typeof sdk.transactions.acknowledge
+        >[0],
+      );
     },
-    onSuccess: (_, { transaction }) => {
-      acknowledgeTransactionInHistoryCache(queryClient, transaction);
-      transactionsCache.invalidateUnacknowledgedCount();
+    onSuccess: () => {
+      void sdk.transactions.list().refetch();
+      void sdk.transactions.countPendingAck().refetch();
     },
     retry: 1,
   });
@@ -271,44 +125,4 @@ export function useReverseTransaction({
       onErrorRef.current?.(error);
     },
   });
-}
-
-/**
- * Hook that returns a transaction change handler.
- */
-export function useTransactionChangeHandlers() {
-  const transactionRepository = useTransactionRepository();
-  const transactionsCache = useTransactionsCache();
-
-  return [
-    {
-      event: 'TRANSACTION_CREATED',
-      handleEvent: async (payload: AgicashDbTransaction) => {
-        const transaction = await transactionRepository.toTransaction(payload);
-        transactionsCache.upsert(transaction);
-
-        if (transaction.acknowledgmentStatus === 'pending') {
-          transactionsCache.invalidateUnacknowledgedCount();
-        }
-      },
-    },
-    {
-      event: 'TRANSACTION_UPDATED',
-      handleEvent: async (
-        payload: AgicashDbTransaction & {
-          previous_acknowledgment_status: Transaction['acknowledgmentStatus'];
-        },
-      ) => {
-        const transaction = await transactionRepository.toTransaction(payload);
-        transactionsCache.upsert(transaction);
-
-        if (
-          payload.previous_acknowledgment_status !==
-          transaction.acknowledgmentStatus
-        ) {
-          transactionsCache.invalidateUnacknowledgedCount();
-        }
-      },
-    },
-  ];
 }

--- a/apps/web-wallet/app/features/wallet/use-track-wallet-changes.ts
+++ b/apps/web-wallet/app/features/wallet/use-track-wallet-changes.ts
@@ -33,10 +33,6 @@ import {
   useSparkSendQuoteChangeHandlers,
   useUnresolvedSparkSendQuotesCache,
 } from '../send/spark-send-quote-hooks';
-import {
-  useTransactionChangeHandlers,
-  useTransactionsCache,
-} from '../transactions/transaction-hooks';
 import { useUser } from '../user/user-hooks';
 
 type DatabaseChangeHandler = {
@@ -84,7 +80,6 @@ function useTrackDatabaseChanges({ handlers, onConnected }: Props) {
 
 export const useTrackWalletChanges = () => {
   const sdk = useSdk();
-  const transactionChangeHandlers = useTransactionChangeHandlers();
   const cashuReceiveQuoteChangeHandlers = useCashuReceiveQuoteChangeHandlers();
   const cashuReceiveSwapChangeHandlers = useCashuReceiveSwapChangeHandlers();
   const cashuSendQuoteChangeHandlers = useCashuSendQuoteChangeHandlers();
@@ -93,7 +88,6 @@ export const useTrackWalletChanges = () => {
   const sparkReceiveQuoteChangeHandlers = useSparkReceiveQuoteChangeHandlers();
   const sparkSendQuoteChangeHandlers = useSparkSendQuoteChangeHandlers();
 
-  const transactionsCache = useTransactionsCache();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
   const pendingCashuReceiveQuotesCache = usePendingCashuReceiveQuotesCache();
   const pendingCashuReceiveSwapsCache = usePendingCashuReceiveSwapsCache();
@@ -133,6 +127,27 @@ export const useTrackWalletChanges = () => {
     },
   ];
 
+  // Transaction change handlers: refetch the SDK's reactive transaction reads so
+  // useQ(sdk.transactions.list()) / useQ(sdk.transactions.countPendingAck())
+  // subscribers see the new data. SDK background (PR8d) will own this long-term;
+  // for PR8c we drive it off the same web Supabase realtime channel.
+  const transactionChangeHandlers: DatabaseChangeHandler[] = [
+    {
+      event: 'TRANSACTION_CREATED',
+      handleEvent: () => {
+        void sdk.transactions.list().refetch();
+        void sdk.transactions.countPendingAck().refetch();
+      },
+    },
+    {
+      event: 'TRANSACTION_UPDATED',
+      handleEvent: () => {
+        void sdk.transactions.list().refetch();
+        void sdk.transactions.countPendingAck().refetch();
+      },
+    },
+  ];
+
   useTrackDatabaseChanges({
     handlers: [
       ...accountChangeHandlers,
@@ -150,8 +165,9 @@ export const useTrackWalletChanges = () => {
       // Refetch SDK reactive reads on reconnect to catch any missed updates.
       void sdk.accounts.list().refetch();
       void sdk.user.getCurrentUser().refetch();
+      void sdk.transactions.list().refetch();
+      void sdk.transactions.countPendingAck().refetch();
       // Invalidate the web TanStack caches for the other features.
-      transactionsCache.invalidate();
       cashuReceiveQuoteCache.invalidate();
       pendingCashuReceiveQuotesCache.invalidate();
       pendingCashuReceiveSwapsCache.invalidate();

--- a/apps/web-wallet/app/routes/_protected.transactions.$transactionId_.tsx
+++ b/apps/web-wallet/app/routes/_protected.transactions.$transactionId_.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/_protected.transactions.$transactionId_';
 export default function TransactionDetailsPage({
   params: { transactionId },
 }: Route.ComponentProps) {
-  const { data: transaction } = useTransaction(transactionId);
+  const transaction = useTransaction(transactionId);
   const { redirectTo } = useRedirectTo('/');
 
   return (


### PR DESCRIPTION
## What

Third slice of the reactive-SDK web migration (after PR8a provider wiring and PR8b accounts + user). Migrates the web wallet's **transaction reads** off its own TanStack Query `TransactionsCache` onto the SDK's reactive hooks (`useQ(sdk.transactions.*)`), following the pattern PR8b established in `account-hooks.ts`.

## Read-flip + Cache deletion (`transaction-hooks.ts`)

- `useTransaction(id)` → `useQ(sdk.transactions.get(id))`, returning the `Transaction` directly (throws `NotFoundError` on null, preserving the not-found UX).
- `useHasTransactionsPendingAck()` → `useQ(sdk.transactions.countPendingAck()) > 0`.
- `useAcknowledgeTransaction()` → mutation body calls `sdk.transactions.acknowledge(tx)`; `onSuccess` refetches `sdk.transactions.list()` + `countPendingAck()`.
- `useTransactions(accountId)` stays a **thin web `useInfiniteQuery`** that pages through the SDK: `queryFn: ({ pageParam }) => sdk.transactions.list({ accountId, cursor: pageParam ?? undefined }).toPromise()`, `getNextPageParam: (last) => last.nextCursor ?? undefined`, `initialPageParam: undefined`. This preserves infinite-scroll without an SDK infinite read.
- **Deleted** the `TransactionsCache` class, `useTransactionsCache`, and `useTransactionChangeHandlers`.

A small `as Promise<TransactionsPage>` cast bridges the SDK `Transaction` type to the web's zod-narrowed `Transaction` union (structurally equivalent at runtime; the web type is just stricter on `details`) so the out-of-scope `transaction-list.tsx` consumer keeps type-checking — same boundary-cast approach PR8b used.

## Detail-read call sites

- `transaction-additional-details.tsx` and `routes/_protected.transactions.$transactionId_.tsx` now consume the value-returning `useTransaction` directly (dropped the `{ data }` destructure).

## The 3 former `TransactionsCache` writers, rewired to refresh the SDK

- `use-track-wallet-changes.ts`: replaced the deleted `useTransactionChangeHandlers` with inline `TRANSACTION_CREATED` / `TRANSACTION_UPDATED` handlers that `void sdk.transactions.list().refetch()` + `countPendingAck().refetch()` (mirroring the existing account/user handlers); dropped the `transactionsCache.invalidate()` from `onConnected` in favour of the SDK refetches.
- `receive/cashu-receive-quote-hooks.ts` and `receive/spark-receive-quote-hooks.ts`: in the quote-complete `onSuccess`, replaced `transactionsCache.invalidateTransaction(txId)` with `void sdk.transactions.get(txId).refetch()` + `void sdk.transactions.list().refetch()` — the faithful 1:1 mirror that keeps the just-completed transaction detail page fresh.

## Deliberately out of scope (left for later slices)

- The **quote reads** in the two receive-quote hook files (only their `TransactionsCache`-write lines changed here) → **PR8e**.
- The wholesale delete of `use-track-wallet-changes.ts` → **PR8d**.
- SDK-owned realtime invalidation (this slice drives refetches off the existing web Supabase realtime channel) → **PR8d**.
- The now-unused web `transaction-repository.ts` is **kept** (its delete isn't in this slice's scope).

## Verification

- `bun run check:all` (typecheck across all 6 packages + `biome lint` + `biome format`) → green (only 2 pre-existing `ImportMetaEnv` lint warnings, present on the base branch).
- `bun run test` → 563 pass / 0 fail (lib 14, wallet-sdk 485, react-wallet-sdk 5, web-wallet 59).

## Notes

One minor implementation decision worth flagging: for the two receive-quote completion handlers, the brief's blanket guidance was `list().refetch()`, but the line being replaced was `invalidateTransaction(txId)` whose documented purpose is refreshing the **transaction detail page** after completion. `list().refetch()` alone would not refresh `sdk.transactions.get(txId)`, so I used `get(txId).refetch()` + `list().refetch()` to faithfully preserve that behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)