### PR TITLE
feat(web): migrate contact reads to the SDK (PR8c-contacts)

### DIFF
--- a/apps/web-wallet/app/features/contacts/contact-hooks.ts
+++ b/apps/web-wallet/app/features/contacts/contact-hooks.ts
@@ -1,126 +1,55 @@
-import {
-  type QueryClient,
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from '@tanstack/react-query';
-import { useMemo } from 'react';
-import useLocationData from '~/hooks/use-location';
-import type { AgicashDbContact } from '../agicash-db/database';
-import { useUser } from '../user/user-hooks';
+import { useQ, useSdk } from '@agicash/react-wallet-sdk';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import type { Contact } from './contact';
-import { ContactRepository, useContactRepository } from './contact-repository';
-export class ContactsCache {
-  public static Key = 'contacts';
-
-  constructor(private readonly queryClient: QueryClient) {}
-
-  /**
-   * Adds a contact to the cache.
-   * @param contact - The contact to add.
-   */
-  add(contact: Contact) {
-    this.queryClient.setQueryData<Contact[]>([ContactsCache.Key], (curr) => [
-      ...(curr ?? []),
-      contact,
-    ]);
-  }
-
-  /**
-   * Gets all contacts in the cache for the current user.
-   * @returns The list of contacts.
-   */
-  getAll() {
-    return this.queryClient.getQueryData<Contact[]>([ContactsCache.Key]);
-  }
-
-  /**
-   * Get a contact by id.
-   * @param id - The id of the contact.
-   * @returns The contact or null if the contact is not found.
-   */
-  get(id: string) {
-    const contacts = this.getAll();
-    return contacts?.find((x) => x.id === id) ?? null;
-  }
-
-  /**
-   * Removes a contact from the cache.
-   * @param contactId - The id of the contact to remove.
-   */
-  remove(contactId: string) {
-    this.queryClient.setQueryData<Contact[]>(
-      [ContactsCache.Key],
-      (curr) => curr?.filter((x) => x.id !== contactId) ?? [],
-    );
-  }
-
-  /**
-   * Invalidates the contacts cache.
-   */
-  invalidate() {
-    return this.queryClient.invalidateQueries({
-      queryKey: [ContactsCache.Key],
-    });
-  }
-}
-
-export function useContactsCache() {
-  const queryClient = useQueryClient();
-  return useMemo(() => new ContactsCache(queryClient), [queryClient]);
-}
 
 /**
- * Hook for listing contacts for the current user with optional filtering
+ * Hook for listing contacts for the current user with optional filtering.
+ *
+ * Returns the array directly (suspends while loading).
  */
-export function useContacts(select?: (contacts: Contact[]) => Contact[]) {
-  const userId = useUser((user) => user.id);
-  const contactRepository = useContactRepository();
-
-  const { data: contacts } = useSuspenseQuery({
-    queryKey: [ContactsCache.Key],
-    queryFn: async () => contactRepository.getAll(userId),
-    staleTime: Number.POSITIVE_INFINITY,
-    refetchOnWindowFocus: 'always',
-    refetchOnReconnect: 'always',
-    select,
-  });
-
-  return contacts;
+export function useContacts(
+  select?: (contacts: Contact[]) => Contact[],
+): Contact[] {
+  const sdk = useSdk();
+  // The SDK and web `Contact` types are structurally equivalent at runtime; the
+  // web's is a zod-narrowed mirror of the SDK's plain type.
+  const contacts = useQ(sdk.contacts.list()) as unknown as Contact[];
+  return select ? select(contacts) : contacts;
 }
 
-export function useContact(contactId: string) {
-  const contacts = useContacts();
-  const contact = contacts.find((contact) => contact.id === contactId);
-  if (!contact) {
-    return null;
-  }
-  return contact;
+export function useContact(contactId: string): Contact | null {
+  const sdk = useSdk();
+  const contact = useQ(sdk.contacts.get(contactId));
+  return contact as unknown as Contact | null;
 }
 
 export function useCreateContact() {
-  const userId = useUser((user) => user.id);
-  const contactRepository = useContactRepository();
+  const sdk = useSdk();
 
   const { mutateAsync: createContact } = useMutation({
     mutationKey: ['create-contact'],
     mutationFn: ({ username }: { username: string }) =>
-      contactRepository.create({
-        ownerId: userId,
-        username,
-      }),
+      sdk.contacts.add({ username }),
+    onSuccess: () => {
+      void sdk.contacts.list().refetch();
+    },
   });
 
   return createContact;
 }
 
 export function useDeleteContact() {
-  const contactRepository = useContactRepository();
+  const sdk = useSdk();
 
   const { mutateAsync: deleteContact } = useMutation({
     mutationKey: ['delete-contact'],
-    mutationFn: (contactId: string) => contactRepository.delete(contactId),
+    mutationFn: (contact: Contact) =>
+      sdk.contacts.remove(
+        contact as unknown as Parameters<typeof sdk.contacts.remove>[0],
+      ),
+    onSuccess: () => {
+      void sdk.contacts.list().refetch();
+    },
   });
 
   return deleteContact;
@@ -131,38 +60,13 @@ export function useDeleteContact() {
  * @return the query response containing any user profiles that match the query
  */
 export function useFindContactCandidates(query: string) {
-  const contactRepository = useContactRepository();
-  const userId = useUser((user) => user.id);
+  const sdk = useSdk();
 
   return useQuery({
     queryKey: ['search-user-profiles', query],
-    queryFn: async () => contactRepository.findContactCandidates(query, userId),
+    queryFn: () => sdk.contacts.search({ query }),
     initialData: [],
     initialDataUpdatedAt: () => Date.now() - 1000 * 6,
     staleTime: 1000 * 5,
   });
-}
-
-/**
- * Hook that returns a contact change handler.
- */
-export function useContactChangeHandlers() {
-  const contactsCache = useContactsCache();
-  const { domain } = useLocationData();
-
-  return [
-    {
-      event: 'CONTACT_CREATED',
-      handleEvent: async (payload: AgicashDbContact) => {
-        const contact = ContactRepository.toContact(payload, domain);
-        contactsCache.add(contact);
-      },
-    },
-    {
-      event: 'CONTACT_DELETED',
-      handleEvent: async (payload: AgicashDbContact) => {
-        contactsCache.remove(payload.id);
-      },
-    },
-  ];
 }

--- a/apps/web-wallet/app/features/settings/contact.tsx
+++ b/apps/web-wallet/app/features/settings/contact.tsx
@@ -26,7 +26,7 @@ export function SingleContact({ contact }: { contact: Contact }) {
 
   const handleDelete = async () => {
     try {
-      await deleteContact(contact.id);
+      await deleteContact(contact);
       toast({
         title: 'Contact deleted',
         description: contact?.username,

--- a/apps/web-wallet/app/features/wallet/use-track-wallet-changes.ts
+++ b/apps/web-wallet/app/features/wallet/use-track-wallet-changes.ts
@@ -3,10 +3,6 @@ import { agicashRealtimeClient } from '~/features/agicash-db/database.client';
 import { useSupabaseRealtime } from '~/lib/supabase';
 import { useLatest } from '~/lib/use-latest';
 import {
-  useContactChangeHandlers,
-  useContactsCache,
-} from '../contacts/contact-hooks';
-import {
   useCashuReceiveQuoteCache,
   useCashuReceiveQuoteChangeHandlers,
   usePendingCashuReceiveQuotesCache,
@@ -84,7 +80,6 @@ export const useTrackWalletChanges = () => {
   const cashuReceiveSwapChangeHandlers = useCashuReceiveSwapChangeHandlers();
   const cashuSendQuoteChangeHandlers = useCashuSendQuoteChangeHandlers();
   const cashuSendSwapChangeHandlers = useCashuSendSwapChangeHandlers();
-  const contactChangeHandlers = useContactChangeHandlers();
   const sparkReceiveQuoteChangeHandlers = useSparkReceiveQuoteChangeHandlers();
   const sparkSendQuoteChangeHandlers = useSparkSendQuoteChangeHandlers();
 
@@ -94,7 +89,6 @@ export const useTrackWalletChanges = () => {
   const unresolvedCashuSendQuotesCache = useUnresolvedCashuSendQuotesCache();
   const cashuSendSwapCache = useCashuSendSwapCache();
   const unresolvedCashuSendSwapsCache = useUnresolvedCashuSendSwapsCache();
-  const contactsCache = useContactsCache();
   const sparkReceiveQuoteCache = useSparkReceiveQuoteCache();
   const pendingSparkReceiveQuotesCache = usePendingSparkReceiveQuotesCache();
   const unresolvedSparkSendQuotesCache = useUnresolvedSparkSendQuotesCache();
@@ -148,6 +142,25 @@ export const useTrackWalletChanges = () => {
     },
   ];
 
+  // Contact change handlers: refetch the SDK's reactive contact reads so
+  // useQ(sdk.contacts.list()) subscribers see the new data. SDK background
+  // (PR8d) will own this long-term; for PR8c-contacts we drive it off the same
+  // web Supabase realtime channel.
+  const contactChangeHandlers: DatabaseChangeHandler[] = [
+    {
+      event: 'CONTACT_CREATED',
+      handleEvent: () => {
+        void sdk.contacts.list().refetch();
+      },
+    },
+    {
+      event: 'CONTACT_DELETED',
+      handleEvent: () => {
+        void sdk.contacts.list().refetch();
+      },
+    },
+  ];
+
   useTrackDatabaseChanges({
     handlers: [
       ...accountChangeHandlers,
@@ -167,6 +180,7 @@ export const useTrackWalletChanges = () => {
       void sdk.user.getCurrentUser().refetch();
       void sdk.transactions.list().refetch();
       void sdk.transactions.countPendingAck().refetch();
+      void sdk.contacts.list().refetch();
       // Invalidate the web TanStack caches for the other features.
       cashuReceiveQuoteCache.invalidate();
       pendingCashuReceiveQuotesCache.invalidate();
@@ -174,7 +188,6 @@ export const useTrackWalletChanges = () => {
       unresolvedCashuSendQuotesCache.invalidate();
       cashuSendSwapCache.invalidate();
       unresolvedCashuSendSwapsCache.invalidate();
-      contactsCache.invalidate();
       sparkReceiveQuoteCache.invalidate();
       pendingSparkReceiveQuotesCache.invalidate();
       unresolvedSparkSendQuotesCache.invalidate();


### PR DESCRIPTION
Migrates the web app's **contacts** reads off its own TanStack Query `ContactsCache` and onto the SDK's reactive hooks (`@agicash/wallet-sdk` contacts domain). Continues the PR8a/8b/8c pattern (providers, accounts+user, transactions).

## What changed

**`apps/web-wallet/app/features/contacts/contact-hooks.ts`** — the read-flip + cache deletion:
- Deleted the `ContactsCache` class, `useContactsCache`, and `useContactChangeHandlers` (the web cache + its realtime add/remove handlers — now owned by the SDK).
- `useContacts(select?)` → `useQ(sdk.contacts.list())`, applies the optional `select`, returns the `Contact[]` directly (suspends while loading; same value-returning shape as PR8b `useAccounts`).
- `useContact(contactId)` → `useQ(sdk.contacts.get(contactId))`, returns `Contact | null` directly (preserves the existing null-on-not-found behavior — the contact route redirects on null).
- `useCreateContact()` → mutation wrapping `sdk.contacts.add({ username })`; `onSuccess` refetches `sdk.contacts.list()`.
- `useDeleteContact()` → mutation wrapping `sdk.contacts.remove(contact)` (the SDK takes the **full contact object**, not the id); `onSuccess` refetches `sdk.contacts.list()`.
- `useFindContactCandidates(query)` → kept as a thin `useQuery` (search is a one-shot fetch); its `queryFn` now calls `sdk.contacts.search({ query })`, which returns a `Promise` directly — **no `.toPromise()`**. Preserved the existing `['search-user-profiles', query]` key + `initialData`/`staleTime` options.

**`apps/web-wallet/app/features/wallet/use-track-wallet-changes.ts`** — change-handler rewire (file kept; wholesale delete is PR8d):
- Dropped the `useContactChangeHandlers` + `useContactsCache` usage.
- Added an inline `contactChangeHandlers` block (mirroring the PR8c `transactionChangeHandlers`) for the existing `CONTACT_CREATED` / `CONTACT_DELETED` realtime events — each refetches `sdk.contacts.list()`.
- `onConnected` now refetches `sdk.contacts.list()` (replacing the removed `contactsCache.invalidate()`).

**`apps/web-wallet/app/features/settings/contact.tsx`** — consumer adjust: `useDeleteContact` now takes the full contact, so `handleDelete` passes `contact` instead of `contact.id`.

The other consumers (`contacts-list.tsx`, the `$contactId` route, `add-contact-drawer.tsx`) needed **no read-shape change** — `useContacts`/`useContact` were already value-returning, and `useFindContactCandidates` stays a `useQuery` returning `{ data }`.

The SDK and web `Contact`/`UserProfile` types are structurally identical (the web's `Contact` is a zod-narrowed mirror), so the SDK→web boundary uses the same `as unknown as` cast PR8b/8c used.

## Verification
- `bun run check:all` clean (typecheck + biome lint + biome format; all 6 packages exit 0).
- `bun run test` green: web-wallet 59, wallet-sdk 485 (incl. the contacts background-processor + event-forwarder tests), react-wallet-sdk 5, lib 14 — 0 failures.

## Left for PR8d
- Delete `use-track-wallet-changes.ts` wholesale once the SDK background/realtime owns all change propagation.
- Retire the now-unused web `contact-repository.ts` (`useContactRepository` no longer has callers in the contacts feature) once nothing else references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
