### PR TITLE
refactor(wallet-sdk): internal-hatch cleanup chunks 0-2 — curated reads + sdk.transfer

### DIFF
--- a/apps/web-wallet/app/features/accounts/account-hooks.ts
+++ b/apps/web-wallet/app/features/accounts/account-hooks.ts
@@ -21,18 +21,6 @@ import { getSdk } from '../shared/sdk';
 import { useUser } from '../user/user-hooks';
 
 /**
- * Hook that provides the accounts cache.
- *
- * Transitional (sdk.accounts.internal): only for the web-owned tracking and
- * task-processing hooks until they move into the SDK (the MCP phase). App/UI
- * code must use the curated sdk.accounts methods.
- * @returns The accounts cache.
- */
-export function useAccountsCache() {
-  return getSdk().accounts.internal.cache;
-}
-
-/**
  * Filter options for `useAccounts` hook.
  * Results are sorted by creation date (oldest first).
  */
@@ -233,11 +221,9 @@ export function useGetAccount<T extends keyof AccountTypeMap>(
 ): (id: string) => AccountTypeMap[T];
 export function useGetAccount(type?: undefined): (id: string) => Account;
 export function useGetAccount(type?: keyof AccountTypeMap) {
-  const accountsCache = useAccountsCache();
-
   return useCallback(
     (id: string) => {
-      const account = accountsCache.get(id);
+      const account = getSdk().accounts.getCached(id);
       if (!account) {
         throw new Error(`Account not found for id: ${id}`);
       }
@@ -246,7 +232,7 @@ export function useGetAccount(type?: keyof AccountTypeMap) {
       }
       return account;
     },
-    [accountsCache, type],
+    [type],
   );
 }
 
@@ -263,19 +249,17 @@ export function useGetCashuAccount() {
  * @returns A function that takes a mint URL and currency and returns the matching cashu account or null.
  */
 export function useGetCashuAccountByMintUrlAndCurrency() {
-  const accountsCache = useAccountsCache();
-
   return useCallback(
     (mintUrl: string, currency: Currency) =>
-      accountsCache
-        .getAll()
-        ?.find(
+      getSdk()
+        .accounts.listCached()
+        .find(
           (a): a is CashuAccount =>
             a.type === 'cashu' &&
             a.mintUrl === mintUrl &&
             a.currency === currency,
         ) ?? null,
-    [accountsCache],
+    [],
   );
 }
 
@@ -366,15 +350,10 @@ export function useBalance(currency: Currency) {
  * Hook that returns a selector function to filter out items with offline accounts.
  */
 export function useSelectItemsWithOnlineAccount() {
-  const accountsCache = useAccountsCache();
-
-  return useCallback(
-    <T extends { accountId: string }>(items: T[]): T[] => {
-      return items.filter((item) => {
-        const account = accountsCache.get(item.accountId);
-        return account?.isOnline;
-      });
-    },
-    [accountsCache],
-  );
+  return useCallback(<T extends { accountId: string }>(items: T[]): T[] => {
+    return items.filter((item) => {
+      const account = getSdk().accounts.getCached(item.accountId);
+      return account?.isOnline;
+    });
+  }, []);
 }

--- a/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
@@ -39,7 +39,6 @@ import {
   useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import { getSdk } from '../shared/sdk';
-import { useTransactionsCache } from '../transactions/transaction-hooks';
 
 type CreateProps = {
   account: CashuAccount;
@@ -422,7 +421,6 @@ export function useProcessCashuReceiveQuoteTasks() {
     useGetCashuAccountByMintUrlAndCurrency();
   const pendingQuotesCache = usePendingCashuReceiveQuotesCache();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
-  const transactionsCache = useTransactionsCache();
   const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
@@ -446,7 +444,7 @@ export function useProcessCashuReceiveQuoteTasks() {
         // transaction cache here so that it starts refetching the transaction as soon as possible
         // without relying on realtime notification which might be delayed when reconnecting due to
         // the app being in background.
-        transactionsCache.invalidateTransaction(data.quote.transactionId);
+        getSdk().transactions.invalidate(data.quote.transactionId);
         cashuReceiveQuoteCache.updateIfExists(data.quote);
         pendingQuotesCache.update(data.quote);
       }

--- a/apps/web-wallet/app/features/receive/receive-cashu-token-hooks.ts
+++ b/apps/web-wallet/app/features/receive/receive-cashu-token-hooks.ts
@@ -24,7 +24,6 @@ import {
   toAccountSelectorOption,
 } from '../accounts/account-selector';
 import { getSdk } from '../shared/sdk';
-import { useUser } from '../user/user-hooks';
 
 type UseGetClaimableTokenProps = {
   token: Token;
@@ -52,23 +51,8 @@ export function useCashuTokenSourceAccountQuery(
   token: Token,
   existingAccounts: ExtendedAccount[] = [],
 ) {
-  const tokenCurrency = tokenToMoney(token).currency;
-  const receiveCashuTokenService =
-    getSdk().receive.internal.receiveCashuTokenService;
-
   return useSuspenseQuery({
-    queryKey: [
-      'token-source-account',
-      token.mint,
-      tokenCurrency,
-      existingAccounts.map((a) => a.id).sort(),
-    ],
-    queryFn: async () =>
-      receiveCashuTokenService.getSourceAndDestinationAccounts(
-        token,
-        existingAccounts,
-      ),
-    staleTime: 3 * 60 * 1000,
+    ...getSdk().receive.tokenReceiveAccountsOptions(token, existingAccounts),
     retry: 1,
   });
 }
@@ -253,10 +237,7 @@ type CreateCrossAccountReceiveQuotesProps = {
  * The actual melting of proofs should be done by the caller.
  */
 export function useCreateCrossAccountReceiveQuotes() {
-  const userId = useUser((user) => user.id);
   const getExchangeRate = useGetExchangeRate();
-  const receiveCashuTokenQuoteService =
-    getSdk().receive.internal.receiveCashuTokenQuoteService;
 
   return useMutation({
     mutationFn: async ({
@@ -270,15 +251,12 @@ export function useCreateCrossAccountReceiveQuotes() {
         `${tokenCurrency}-${accountCurrency}`,
       );
 
-      return await receiveCashuTokenQuoteService.createCrossAccountReceiveQuotes(
-        {
-          userId,
-          token,
-          sourceAccount,
-          destinationAccount,
-          exchangeRate,
-        },
-      );
+      return await getSdk().receive.createCrossAccountReceiveQuotes({
+        token,
+        sourceAccount,
+        destinationAccount,
+        exchangeRate,
+      });
     },
     retry: (failureCount, error) => {
       if (error instanceof DomainError) {
@@ -290,13 +268,10 @@ export function useCreateCrossAccountReceiveQuotes() {
 }
 
 function useBuildCashuAccountPlaceholder(mintUrl: string, currency: Currency) {
-  const receiveCashuTokenService =
-    getSdk().receive.internal.receiveCashuTokenService;
-
   const { data } = useSuspenseQuery({
     queryKey: ['build-cashu-account-for-mint', mintUrl, currency],
-    queryFn: async () =>
-      receiveCashuTokenService.buildAccountForMint(mintUrl, currency),
+    queryFn: () =>
+      getSdk().receive.buildCashuAccountPlaceholder(mintUrl, currency),
     staleTime: 0,
     gcTime: 0,
     retry: 1,

--- a/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
@@ -22,7 +22,6 @@ import {
   useSelectItemsWithOnlineAccount,
 } from '../accounts/account-hooks';
 import { getSdk } from '../shared/sdk';
-import { useTransactionsCache } from '../transactions/transaction-hooks';
 
 /**
  * Transitional (sdk.receive.internal): only for the web-owned realtime wiring
@@ -302,7 +301,6 @@ export function useProcessSparkReceiveQuoteTasks() {
     useGetCashuAccountByMintUrlAndCurrency();
   const pendingQuotesCache = usePendingSparkReceiveQuotesCache();
   const sparkReceiveQuoteCache = useSparkReceiveQuoteCache();
-  const transactionsCache = useTransactionsCache();
   const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
@@ -342,7 +340,7 @@ export function useProcessSparkReceiveQuoteTasks() {
         // transaction cache here so that it starts refetching the transaction as soon as possible
         // without relying on realtime notification which might be delayed when reconnecting due to
         // the app being in background.
-        transactionsCache.invalidateTransaction(updatedQuote.transactionId);
+        getSdk().transactions.invalidate(updatedQuote.transactionId);
         sparkReceiveQuoteCache.updateIfExists(updatedQuote);
         pendingQuotesCache.remove(updatedQuote);
       }

--- a/apps/web-wallet/app/features/transactions/transaction-additional-details.tsx
+++ b/apps/web-wallet/app/features/transactions/transaction-additional-details.tsx
@@ -65,12 +65,12 @@ function LightningSendDetails({
   account,
   transaction,
 }: { account: CashuAccount; transaction: Transaction }) {
-  const repository = getSdk().send.internal.cashuSendQuoteRepository;
+  const options = getSdk().send.quoteByTransactionIdOptions(transaction.id);
 
   const { data: sendQuote } = useSuspenseQuery({
-    queryKey: ['transaction-details', transaction.id],
+    ...options,
     queryFn: async () => {
-      const quote = await repository.getByTransactionId(transaction.id);
+      const quote = await options.queryFn();
       if (!quote) {
         throw new Error('No send quote found for transaction');
       }
@@ -93,12 +93,12 @@ function LightningSendDetails({
 function LightningReceiveDetails({
   transaction,
 }: { transaction: Transaction }) {
-  const repository = getSdk().receive.internal.cashuReceiveQuoteRepository;
+  const options = getSdk().receive.quoteByTransactionIdOptions(transaction.id);
 
   const { data } = useSuspenseQuery({
-    queryKey: ['transaction-details', transaction.id],
+    ...options,
     queryFn: async () => {
-      const quote = await repository.getByTransactionId(transaction.id);
+      const quote = await options.queryFn();
       if (!quote) {
         throw new Error('No receive quote found for transaction');
       }
@@ -113,12 +113,12 @@ function CashuTokenSendDetails({
   account,
   transaction,
 }: { account: CashuAccount; transaction: Transaction }) {
-  const repository = getSdk().send.internal.cashuSendSwapRepository;
+  const options = getSdk().send.swapByTransactionIdOptions(transaction.id);
 
   const { data: swap } = useSuspenseQuery({
-    queryKey: ['transaction-details', transaction.id],
+    ...options,
     queryFn: async () => {
-      const swap = await repository.getByTransactionId(transaction.id);
+      const swap = await options.queryFn();
       if (!swap) {
         throw new Error('No send swap found for transaction');
       }
@@ -148,12 +148,12 @@ function CashuTokenReceiveDetails({
   account,
   transaction,
 }: { account: CashuAccount; transaction: Transaction }) {
-  const repository = getSdk().receive.internal.cashuReceiveSwapRepository;
+  const options = getSdk().receive.swapByTransactionIdOptions(transaction.id);
 
   const { data: swap } = useSuspenseQuery({
-    queryKey: ['transaction-details', transaction.id],
+    ...options,
     queryFn: async () => {
-      const swap = await repository.getByTransactionId(transaction.id);
+      const swap = await options.queryFn();
       if (!swap) {
         throw new Error('No receive swap found for transaction');
       }

--- a/apps/web-wallet/app/features/transactions/transaction-hooks.ts
+++ b/apps/web-wallet/app/features/transactions/transaction-hooks.ts
@@ -13,17 +13,6 @@ import { useLatest } from '~/lib/use-latest';
 
 export { isTransactionReversable };
 
-/**
- * Hook that provides the transactions cache.
- *
- * Transitional (sdk.transactions.internal): only for the not-yet-migrated
- * receive/send domain code and the web-owned realtime infrastructure.
- * App/UI code must use the curated sdk.transactions methods.
- */
-export function useTransactionsCache() {
-  return getSdk().transactions.internal.cache;
-}
-
 export function useTransaction(id: string) {
   return useSuspenseQuery({
     ...getSdk().transactions.queryOptions(id),

--- a/apps/web-wallet/app/features/transfer/transfer-confirmation.tsx
+++ b/apps/web-wallet/app/features/transfer/transfer-confirmation.tsx
@@ -1,5 +1,6 @@
 import { getDefaultUnit } from '@agicash/wallet-sdk/currencies';
 import { DomainError } from '@agicash/wallet-sdk/error';
+import type { TransferQuote } from '@agicash/wallet-sdk/transfer/transfer-service';
 import { MoneyDisplay } from '~/components/money-display';
 import {
   PageBackButton,
@@ -15,7 +16,6 @@ import { useBuildLinkWithSearchParams } from '~/hooks/use-search-params-link';
 import { useToast } from '~/hooks/use-toast';
 import { useNavigateWithViewTransition } from '~/lib/transitions';
 import { useInitiateTransfer } from './transfer-hooks';
-import type { TransferQuote } from './transfer-service';
 
 type Props = {
   quote: TransferQuote;

--- a/apps/web-wallet/app/features/transfer/transfer-hooks.ts
+++ b/apps/web-wallet/app/features/transfer/transfer-hooks.ts
@@ -1,14 +1,11 @@
 import type { Money } from '@agicash/utils/money';
 import type { Account } from '@agicash/wallet-sdk/accounts/account';
 import { ConcurrencyError, DomainError } from '@agicash/wallet-sdk/error';
+import type { TransferQuote } from '@agicash/wallet-sdk/transfer/transfer-service';
 import { useMutation } from '@tanstack/react-query';
-import { useUser } from '../user/user-hooks';
-import type { TransferQuote } from './transfer-service';
-import { useTransferService } from './transfer-service';
+import { getSdk } from '../shared/sdk';
 
 export function useGetTransferQuote() {
-  const transferService = useTransferService();
-
   return useMutation({
     mutationFn: ({
       sourceAccount,
@@ -19,7 +16,7 @@ export function useGetTransferQuote() {
       destinationAccount: Account;
       amount: Money;
     }) => {
-      return transferService.getTransferQuote({
+      return getSdk().transfer.getTransferQuote({
         sourceAccount,
         destinationAccount,
         amount,
@@ -36,12 +33,9 @@ export function useGetTransferQuote() {
 }
 
 export function useInitiateTransfer() {
-  const userId = useUser((user) => user.id);
-  const transferService = useTransferService();
-
   return useMutation({
     mutationFn: ({ quote }: { quote: TransferQuote }) => {
-      return transferService.initiateTransfer({ userId, quote });
+      return getSdk().transfer.initiateTransfer({ quote });
     },
     retry: (failureCount, error) => {
       if (error instanceof ConcurrencyError) {

--- a/apps/web-wallet/app/features/transfer/transfer-store.ts
+++ b/apps/web-wallet/app/features/transfer/transfer-store.ts
@@ -1,7 +1,7 @@
 import type { Currency, Money } from '@agicash/utils/money';
 import type { Account } from '@agicash/wallet-sdk/accounts/account';
+import type { TransferQuote } from '@agicash/wallet-sdk/transfer/transfer-service';
 import { create } from 'zustand';
-import type { TransferQuote } from './transfer-service';
 
 type TransferQuoteResult =
   | { success: true; quote: TransferQuote }

--- a/packages/wallet-sdk/package.json
+++ b/packages/wallet-sdk/package.json
@@ -38,7 +38,8 @@
     "./supabase-session": "./src/supabase-session.ts",
     "./task-processing-lock-repository": "./src/task-processing-lock-repository.ts",
     "./transactions/transaction": "./src/transactions/transaction.ts",
-    "./transactions/transaction-enums": "./src/transactions/transaction-enums.ts"
+    "./transactions/transaction-enums": "./src/transactions/transaction-enums.ts",
+    "./transfer/transfer-service": "./src/transfer/transfer-service.ts"
   },
   "scripts": {
     "typecheck": "tsc",

--- a/packages/wallet-sdk/src/accounts/accounts-api.ts
+++ b/packages/wallet-sdk/src/accounts/accounts-api.ts
@@ -47,17 +47,6 @@ export type AccountsApi = {
    * @returns a cleanup function removing the listeners.
    */
   trackSparkBalances: (accounts: SparkAccount[]) => () => void;
-  /**
-   * Transitional escape hatch — NOT part of the public surface. Only for (a)
-   * not-yet-migrated SDK collaborators still composed in web feature code
-   * (receive/send repositories and services) and (b) the web-owned
-   * realtime + spark-balance infrastructure until the SDK owns realtime.
-   * App/UI code must use the curated methods above. Shrinks each phase and is
-   * removed once the remaining domains and the realtime hub move into the SDK.
-   */
-  internal: {
-    cache: AccountsCache;
-  };
 };
 
 export type AccountsApiDeps = {
@@ -171,9 +160,6 @@ export function createAccountsApi(deps: AccountsApiDeps): {
             });
         }
       };
-    },
-    internal: {
-      cache,
     },
   };
 

--- a/packages/wallet-sdk/src/accounts/accounts-api.ts
+++ b/packages/wallet-sdk/src/accounts/accounts-api.ts
@@ -56,8 +56,6 @@ export type AccountsApi = {
    * removed once the remaining domains and the realtime hub move into the SDK.
    */
   internal: {
-    repository: AccountRepository;
-    service: AccountService;
     cache: AccountsCache;
   };
 };
@@ -175,8 +173,6 @@ export function createAccountsApi(deps: AccountsApiDeps): {
       };
     },
     internal: {
-      repository,
-      service,
       cache,
     },
   };

--- a/packages/wallet-sdk/src/receive/receive-api.test.ts
+++ b/packages/wallet-sdk/src/receive/receive-api.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import type { MintValidator } from '@agicash/cashu';
+import type { AgicashDb } from '@agicash/db-types';
+import { QueryClient } from '@tanstack/query-core';
+import type { AccountRepository } from '../accounts/account-repository';
+import type { AccountService } from '../accounts/account-service';
+import type { Encryption } from '../encryption';
+import type { UserService } from '../user/user-service';
+import type { CashuReceiveQuote } from './cashu-receive-quote';
+import { CashuReceiveQuoteRepository } from './cashu-receive-quote-repository';
+import type { CashuReceiveSwap } from './cashu-receive-swap';
+import { CashuReceiveSwapRepository } from './cashu-receive-swap-repository';
+import { type ReceiveApi, createReceiveApi } from './receive-api';
+
+const makeApi = (): ReceiveApi =>
+  createReceiveApi({
+    queryClient: new QueryClient(),
+    db: {} as AgicashDb,
+    encryption: {} as Encryption,
+    getCurrentUserId: () => {
+      throw new Error('not expected to be called');
+    },
+    getCurrentUser: () => {
+      throw new Error('not expected to be called');
+    },
+    accountRepository: {} as AccountRepository,
+    accountService: {} as AccountService,
+    userService: {} as UserService,
+    cashuMintValidator: {} as MintValidator,
+  }).api;
+
+const restores: Array<() => void> = [];
+afterEach(() => {
+  for (const restore of restores.splice(0)) restore();
+});
+
+describe('receive-api quoteByTransactionIdOptions', () => {
+  it('keys on the transaction id and delegates the queryFn to the repository', async () => {
+    const quote = { id: 'q1' } as unknown as CashuReceiveQuote;
+    const get = spyOn(
+      CashuReceiveQuoteRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(quote);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().quoteByTransactionIdOptions('tx-1');
+
+    expect(options.queryKey).toEqual(['transaction-details', 'tx-1']);
+    expect(await options.queryFn()).toBe(quote);
+    expect(get).toHaveBeenCalledWith('tx-1');
+  });
+
+  it('resolves null when the repository has no quote for the transaction', async () => {
+    const get = spyOn(
+      CashuReceiveQuoteRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(null);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().quoteByTransactionIdOptions('tx-missing');
+
+    expect(await options.queryFn()).toBeNull();
+  });
+});
+
+describe('receive-api swapByTransactionIdOptions', () => {
+  it('keys on the transaction id and delegates the queryFn to the repository', async () => {
+    const swap = { id: 's1' } as unknown as CashuReceiveSwap;
+    const get = spyOn(
+      CashuReceiveSwapRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(swap);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().swapByTransactionIdOptions('tx-2');
+
+    expect(options.queryKey).toEqual(['transaction-details', 'tx-2']);
+    expect(await options.queryFn()).toBe(swap);
+    expect(get).toHaveBeenCalledWith('tx-2');
+  });
+
+  it('resolves null when the repository has no swap for the transaction', async () => {
+    const get = spyOn(
+      CashuReceiveSwapRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(null);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().swapByTransactionIdOptions('tx-missing');
+
+    expect(await options.queryFn()).toBeNull();
+  });
+});

--- a/packages/wallet-sdk/src/receive/receive-api.ts
+++ b/packages/wallet-sdk/src/receive/receive-api.ts
@@ -234,6 +234,10 @@ export function createReceiveApi(deps: ReceiveApiDeps): {
   api: ReceiveApi;
   /** Shared with the send api: send swap reversal claims back through it. */
   cashuReceiveSwapService: CashuReceiveSwapService;
+  /** Shared with the transfer api: it persists the transfer's receive quote. */
+  cashuReceiveQuoteService: CashuReceiveQuoteService;
+  /** Shared with the transfer api: it persists the transfer's receive quote. */
+  sparkReceiveQuoteService: SparkReceiveQuoteService;
   caches: { invalidate: () => unknown }[];
   changeHandlers: DatabaseChangeHandler[];
 } {
@@ -446,6 +450,8 @@ export function createReceiveApi(deps: ReceiveApiDeps): {
   return {
     api,
     cashuReceiveSwapService,
+    cashuReceiveQuoteService,
+    sparkReceiveQuoteService,
     caches: [
       cashuReceiveQuoteCache,
       pendingCashuReceiveQuotesCache,

--- a/packages/wallet-sdk/src/receive/receive-api.ts
+++ b/packages/wallet-sdk/src/receive/receive-api.ts
@@ -1,12 +1,16 @@
 import type { MintValidator } from '@agicash/cashu';
 import type { AgicashDb } from '@agicash/db-types';
-import type { Money } from '@agicash/utils/money';
+import type { Currency, Money } from '@agicash/utils/money';
 import type { Token } from '@cashu/cashu-ts';
 import type { QueryClient } from '@tanstack/query-core';
-import type { CashuAccount, SparkAccount } from '../accounts/account';
+import type {
+  CashuAccount,
+  ExtendedAccount,
+  SparkAccount,
+} from '../accounts/account';
 import type { AccountRepository } from '../accounts/account-repository';
 import type { AccountService } from '../accounts/account-service';
-import { getCashuCryptography } from '../cashu';
+import { getCashuCryptography, tokenToMoney } from '../cashu';
 import type { Encryption } from '../encryption';
 import type { DatabaseChangeHandler } from '../realtime/realtime-api';
 import type { TransactionPurpose } from '../transactions/transaction-enums';
@@ -31,7 +35,10 @@ import {
   ClaimCashuTokenService,
   type ClaimTokenResult,
 } from './claim-cashu-token-service';
-import { ReceiveCashuTokenQuoteService } from './receive-cashu-token-quote-service';
+import {
+  type CrossAccountReceiveQuotesResult,
+  ReceiveCashuTokenQuoteService,
+} from './receive-cashu-token-quote-service';
 import { ReceiveCashuTokenService } from './receive-cashu-token-service';
 import type { SparkReceiveQuote } from './spark-receive-quote';
 import {
@@ -127,19 +134,73 @@ export type ReceiveApi = {
     staleTime: number;
   };
   /**
+   * Query config for the cashu receive quote backing a transaction (consume
+   * with useSuspenseQuery). The queryFn resolves null when no such quote
+   * exists; throw-on-missing is caller policy.
+   */
+  quoteByTransactionIdOptions: (transactionId: string) => {
+    queryKey: string[];
+    queryFn: () => Promise<CashuReceiveQuote | null>;
+  };
+  /**
+   * Query config for the cashu receive swap backing a transaction (consume
+   * with useSuspenseQuery). The queryFn resolves null when no such swap
+   * exists; throw-on-missing is caller policy.
+   */
+  swapByTransactionIdOptions: (transactionId: string) => {
+    queryKey: string[];
+    queryFn: () => Promise<CashuReceiveSwap | null>;
+  };
+  /**
+   * Query config for resolving the source and possible destination accounts
+   * for receiving a cashu token. Unknown mints are fetched and validated into
+   * a placeholder source account. Pass the user's existing accounts to fold
+   * them into the destinations.
+   */
+  tokenReceiveAccountsOptions: (
+    token: Token,
+    existingAccounts?: ExtendedAccount[],
+  ) => {
+    queryKey: (string | string[])[];
+    queryFn: () => ReturnType<
+      ReceiveCashuTokenService['getSourceAndDestinationAccounts']
+    >;
+    staleTime: number;
+  };
+  /**
+   * Builds a (non-persisted) placeholder cashu account for the mint and
+   * currency, fetching and validating the mint. Use when receiving a token
+   * from a mint the user has no account for.
+   */
+  buildCashuAccountPlaceholder: (
+    mintUrl: string,
+    currency: Currency,
+  ) => ReturnType<ReceiveCashuTokenService['buildAccountForMint']>;
+  /**
+   * Creates the receive quotes (and, for cashu destinations, the melt quote)
+   * needed to claim a cashu token into a different mint or currency account
+   * for the current user. The caller performs the actual proof melt. The
+   * pending/active quote state is recorded by the receive-quote realtime
+   * broadcasts, not here.
+   */
+  createCrossAccountReceiveQuotes: (
+    params: Omit<
+      Parameters<
+        ReceiveCashuTokenQuoteService['createCrossAccountReceiveQuotes']
+      >[0],
+      'userId'
+    >,
+  ) => Promise<CrossAccountReceiveQuotesResult>;
+  /**
    * Transitional escape hatch — NOT part of the public surface. Only for the
    * web-owned tracking/task-processing hooks and realtime wiring until the
    * background task processing moves into the SDK (the MCP phase). App/UI
    * code must use the curated methods above.
    */
   internal: {
-    cashuReceiveQuoteRepository: CashuReceiveQuoteRepository;
-    cashuReceiveSwapRepository: CashuReceiveSwapRepository;
     cashuReceiveQuoteService: CashuReceiveQuoteService;
     cashuReceiveSwapService: CashuReceiveSwapService;
     sparkReceiveQuoteService: SparkReceiveQuoteService;
-    receiveCashuTokenService: ReceiveCashuTokenService;
-    receiveCashuTokenQuoteService: ReceiveCashuTokenQuoteService;
     cashuReceiveQuoteCache: CashuReceiveQuoteCache;
     pendingCashuReceiveQuotesCache: PendingCashuReceiveQuotesCache;
     sparkReceiveQuoteCache: SparkReceiveQuoteCache;
@@ -339,14 +400,41 @@ export function createReceiveApi(deps: ReceiveApiDeps): {
       queryFn: () => cashuReceiveSwapRepository.getPending(getCurrentUserId()),
       staleTime: Number.POSITIVE_INFINITY,
     }),
+    quoteByTransactionIdOptions: (transactionId) => ({
+      queryKey: ['transaction-details', transactionId],
+      queryFn: () =>
+        cashuReceiveQuoteRepository.getByTransactionId(transactionId),
+    }),
+    swapByTransactionIdOptions: (transactionId) => ({
+      queryKey: ['transaction-details', transactionId],
+      queryFn: () =>
+        cashuReceiveSwapRepository.getByTransactionId(transactionId),
+    }),
+    tokenReceiveAccountsOptions: (token, existingAccounts = []) => ({
+      queryKey: [
+        'token-source-account',
+        token.mint,
+        tokenToMoney(token).currency,
+        existingAccounts.map((account) => account.id).sort(),
+      ],
+      queryFn: () =>
+        receiveCashuTokenService.getSourceAndDestinationAccounts(
+          token,
+          existingAccounts,
+        ),
+      staleTime: 3 * 60 * 1000,
+    }),
+    buildCashuAccountPlaceholder: (mintUrl, currency) =>
+      receiveCashuTokenService.buildAccountForMint(mintUrl, currency),
+    createCrossAccountReceiveQuotes: (params) =>
+      receiveCashuTokenQuoteService.createCrossAccountReceiveQuotes({
+        userId: getCurrentUserId(),
+        ...params,
+      }),
     internal: {
-      cashuReceiveQuoteRepository,
-      cashuReceiveSwapRepository,
       cashuReceiveQuoteService,
       cashuReceiveSwapService,
       sparkReceiveQuoteService,
-      receiveCashuTokenService,
-      receiveCashuTokenQuoteService,
       cashuReceiveQuoteCache,
       pendingCashuReceiveQuotesCache,
       sparkReceiveQuoteCache,

--- a/packages/wallet-sdk/src/receive/receive-api.ts
+++ b/packages/wallet-sdk/src/receive/receive-api.ts
@@ -129,13 +129,12 @@ export type ReceiveApi = {
   /**
    * Transitional escape hatch — NOT part of the public surface. Only for the
    * web-owned tracking/task-processing hooks and realtime wiring until the
-   * SDK owns the realtime hub and background processing (Phase 8). App/UI
+   * background task processing moves into the SDK (the MCP phase). App/UI
    * code must use the curated methods above.
    */
   internal: {
     cashuReceiveQuoteRepository: CashuReceiveQuoteRepository;
     cashuReceiveSwapRepository: CashuReceiveSwapRepository;
-    sparkReceiveQuoteRepository: SparkReceiveQuoteRepository;
     cashuReceiveQuoteService: CashuReceiveQuoteService;
     cashuReceiveSwapService: CashuReceiveSwapService;
     sparkReceiveQuoteService: SparkReceiveQuoteService;
@@ -343,7 +342,6 @@ export function createReceiveApi(deps: ReceiveApiDeps): {
     internal: {
       cashuReceiveQuoteRepository,
       cashuReceiveSwapRepository,
-      sparkReceiveQuoteRepository,
       cashuReceiveQuoteService,
       cashuReceiveSwapService,
       sparkReceiveQuoteService,

--- a/packages/wallet-sdk/src/sdk.ts
+++ b/packages/wallet-sdk/src/sdk.ts
@@ -17,6 +17,7 @@ import {
   type TransactionsApi,
   createTransactionsApi,
 } from './transactions/transactions-api';
+import { type TransferApi, createTransferApi } from './transfer/transfer-api';
 import { type UserApi, createUserApi } from './user/user-api';
 
 export type { AccountsApi } from './accounts/accounts-api';
@@ -26,6 +27,7 @@ export type { RealtimeApi } from './realtime/realtime-api';
 export type { ReceiveApi } from './receive/receive-api';
 export type { SendApi } from './send/send-api';
 export type { TransactionsApi } from './transactions/transactions-api';
+export type { TransferApi } from './transfer/transfer-api';
 export type { UserApi } from './user/user-api';
 
 export type WalletSdkConfig = {
@@ -113,6 +115,7 @@ export class WalletSdk {
   readonly contacts: ContactsApi;
   readonly receive: ReceiveApi;
   readonly send: SendApi;
+  readonly transfer: TransferApi;
   readonly realtime: RealtimeApi;
 
   constructor(config: WalletSdkConfig) {
@@ -194,6 +197,15 @@ export class WalletSdk {
       cashuReceiveSwapService: receive.cashuReceiveSwapService,
     });
     this.send = send.api;
+
+    const transfer = createTransferApi({
+      getCurrentUserId,
+      cashuReceiveQuoteService: receive.cashuReceiveQuoteService,
+      sparkReceiveQuoteService: receive.sparkReceiveQuoteService,
+      cashuSendQuoteService: send.cashuSendQuoteService,
+      sparkSendQuoteService: send.sparkSendQuoteService,
+    });
+    this.transfer = transfer.api;
 
     const invalidateOnReconnect = [
       accounts.cache,

--- a/packages/wallet-sdk/src/send/send-api.test.ts
+++ b/packages/wallet-sdk/src/send/send-api.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import type { AgicashDb } from '@agicash/db-types';
+import { QueryClient } from '@tanstack/query-core';
+import type { AccountsCache } from '../accounts/accounts-cache';
+import type { Encryption } from '../encryption';
+import type { CashuReceiveSwapService } from '../receive/cashu-receive-swap-service';
+import type { CashuSendQuote } from './cashu-send-quote';
+import { CashuSendQuoteRepository } from './cashu-send-quote-repository';
+import type { CashuSendSwap } from './cashu-send-swap';
+import { CashuSendSwapRepository } from './cashu-send-swap-repository';
+import { type SendApi, createSendApi } from './send-api';
+
+const makeApi = (): SendApi =>
+  createSendApi({
+    queryClient: new QueryClient(),
+    db: {} as AgicashDb,
+    encryption: {} as Encryption,
+    getCurrentUserId: () => {
+      throw new Error('not expected to be called');
+    },
+    accountsCache: {} as AccountsCache,
+    cashuReceiveSwapService: {} as CashuReceiveSwapService,
+  }).api;
+
+const restores: Array<() => void> = [];
+afterEach(() => {
+  for (const restore of restores.splice(0)) restore();
+});
+
+describe('send-api quoteByTransactionIdOptions', () => {
+  it('keys on the transaction id and delegates the queryFn to the repository', async () => {
+    const quote = { id: 'q1' } as unknown as CashuSendQuote;
+    const get = spyOn(
+      CashuSendQuoteRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(quote);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().quoteByTransactionIdOptions('tx-1');
+
+    expect(options.queryKey).toEqual(['transaction-details', 'tx-1']);
+    expect(await options.queryFn()).toBe(quote);
+    expect(get).toHaveBeenCalledWith('tx-1');
+  });
+
+  it('resolves null when the repository has no quote for the transaction', async () => {
+    const get = spyOn(
+      CashuSendQuoteRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(null);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().quoteByTransactionIdOptions('tx-missing');
+
+    expect(await options.queryFn()).toBeNull();
+  });
+});
+
+describe('send-api swapByTransactionIdOptions', () => {
+  it('keys on the transaction id and delegates the queryFn to the repository', async () => {
+    const swap = { id: 's1' } as unknown as CashuSendSwap;
+    const get = spyOn(
+      CashuSendSwapRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(swap);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().swapByTransactionIdOptions('tx-2');
+
+    expect(options.queryKey).toEqual(['transaction-details', 'tx-2']);
+    expect(await options.queryFn()).toBe(swap);
+    expect(get).toHaveBeenCalledWith('tx-2');
+  });
+
+  it('resolves null when the repository has no swap for the transaction', async () => {
+    const get = spyOn(
+      CashuSendSwapRepository.prototype,
+      'getByTransactionId',
+    ).mockResolvedValue(null);
+    restores.push(() => get.mockRestore());
+
+    const options = makeApi().swapByTransactionIdOptions('tx-missing');
+
+    expect(await options.queryFn()).toBeNull();
+  });
+});

--- a/packages/wallet-sdk/src/send/send-api.ts
+++ b/packages/wallet-sdk/src/send/send-api.ts
@@ -147,13 +147,12 @@ export type SendApi = {
   /**
    * Transitional escape hatch — NOT part of the public surface. Only for the
    * web-owned tracking/task-processing hooks and realtime wiring until the
-   * SDK owns the realtime hub and background processing (Phase 8). App/UI
+   * background task processing moves into the SDK (the MCP phase). App/UI
    * code must use the curated methods above.
    */
   internal: {
     cashuSendQuoteRepository: CashuSendQuoteRepository;
     cashuSendSwapRepository: CashuSendSwapRepository;
-    sparkSendQuoteRepository: SparkSendQuoteRepository;
     cashuSendQuoteService: CashuSendQuoteService;
     cashuSendSwapService: CashuSendSwapService;
     sparkSendQuoteService: SparkSendQuoteService;
@@ -341,7 +340,6 @@ export function createSendApi(deps: SendApiDeps): {
     internal: {
       cashuSendQuoteRepository,
       cashuSendSwapRepository,
-      sparkSendQuoteRepository,
       cashuSendQuoteService,
       cashuSendSwapService,
       sparkSendQuoteService,

--- a/packages/wallet-sdk/src/send/send-api.ts
+++ b/packages/wallet-sdk/src/send/send-api.ts
@@ -196,6 +196,10 @@ export type SendApiDeps = {
 
 export function createSendApi(deps: SendApiDeps): {
   api: SendApi;
+  /** Shared with the transfer api: it persists the transfer's send quote. */
+  cashuSendQuoteService: CashuSendQuoteService;
+  /** Shared with the transfer api: it persists the transfer's send quote. */
+  sparkSendQuoteService: SparkSendQuoteService;
   caches: { invalidate: () => unknown }[];
   changeHandlers: DatabaseChangeHandler[];
 } {
@@ -374,6 +378,8 @@ export function createSendApi(deps: SendApiDeps): {
 
   return {
     api,
+    cashuSendQuoteService,
+    sparkSendQuoteService,
     caches: [
       unresolvedCashuSendQuotesCache,
       cashuSendSwapCache,

--- a/packages/wallet-sdk/src/send/send-api.ts
+++ b/packages/wallet-sdk/src/send/send-api.ts
@@ -145,14 +145,30 @@ export type SendApi = {
     staleTime: number;
   };
   /**
+   * Query config for the cashu send quote backing a transaction (consume with
+   * useSuspenseQuery). The queryFn resolves null when no such quote exists;
+   * throw-on-missing is caller policy.
+   */
+  quoteByTransactionIdOptions: (transactionId: string) => {
+    queryKey: string[];
+    queryFn: () => Promise<CashuSendQuote | null>;
+  };
+  /**
+   * Query config for the cashu send swap backing a transaction (consume with
+   * useSuspenseQuery). The queryFn resolves null when no such swap exists;
+   * throw-on-missing is caller policy.
+   */
+  swapByTransactionIdOptions: (transactionId: string) => {
+    queryKey: string[];
+    queryFn: () => Promise<CashuSendSwap | null>;
+  };
+  /**
    * Transitional escape hatch — NOT part of the public surface. Only for the
    * web-owned tracking/task-processing hooks and realtime wiring until the
    * background task processing moves into the SDK (the MCP phase). App/UI
    * code must use the curated methods above.
    */
   internal: {
-    cashuSendQuoteRepository: CashuSendQuoteRepository;
-    cashuSendSwapRepository: CashuSendSwapRepository;
     cashuSendQuoteService: CashuSendQuoteService;
     cashuSendSwapService: CashuSendSwapService;
     sparkSendQuoteService: SparkSendQuoteService;
@@ -337,9 +353,15 @@ export function createSendApi(deps: SendApiDeps): {
       queryFn: () => cashuSendSwapRepository.getUnresolved(getCurrentUserId()),
       staleTime: Number.POSITIVE_INFINITY,
     }),
+    quoteByTransactionIdOptions: (transactionId) => ({
+      queryKey: ['transaction-details', transactionId],
+      queryFn: () => cashuSendQuoteRepository.getByTransactionId(transactionId),
+    }),
+    swapByTransactionIdOptions: (transactionId) => ({
+      queryKey: ['transaction-details', transactionId],
+      queryFn: () => cashuSendSwapRepository.getByTransactionId(transactionId),
+    }),
     internal: {
-      cashuSendQuoteRepository,
-      cashuSendSwapRepository,
       cashuSendQuoteService,
       cashuSendSwapService,
       sparkSendQuoteService,

--- a/packages/wallet-sdk/src/transactions/transactions-api.test.ts
+++ b/packages/wallet-sdk/src/transactions/transactions-api.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, spyOn } from 'bun:test';
+import type { AgicashDb } from '@agicash/db-types';
+import { QueryClient } from '@tanstack/query-core';
+import type { Encryption } from '../encryption';
+import { createTransactionsApi } from './transactions-api';
+import { TransactionsCache } from './transactions-cache';
+
+const makeApi = (queryClient: QueryClient) =>
+  createTransactionsApi({
+    queryClient,
+    db: {} as AgicashDb,
+    encryption: {} as Encryption,
+    getCurrentUserId: () => {
+      throw new Error('not expected to be called');
+    },
+  }).api;
+
+describe('transactions-api invalidate', () => {
+  it('invalidates the single-transaction query for the given id', () => {
+    const queryClient = new QueryClient();
+    const invalidate = spyOn(
+      queryClient,
+      'invalidateQueries',
+    ).mockResolvedValue(undefined);
+
+    makeApi(queryClient).invalidate('tx-1');
+
+    expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [TransactionsCache.Key, 'tx-1'],
+    });
+  });
+});

--- a/packages/wallet-sdk/src/transactions/transactions-api.ts
+++ b/packages/wallet-sdk/src/transactions/transactions-api.ts
@@ -61,7 +61,6 @@ export type TransactionsApi = {
    * methods above.
    */
   internal: {
-    repository: TransactionRepository;
     cache: TransactionsCache;
   };
 };
@@ -148,7 +147,6 @@ export function createTransactionsApi(deps: TransactionsApiDeps): {
       cache.invalidateUnacknowledgedCount();
     },
     internal: {
-      repository,
       cache,
     },
   };

--- a/packages/wallet-sdk/src/transactions/transactions-api.ts
+++ b/packages/wallet-sdk/src/transactions/transactions-api.ts
@@ -54,15 +54,11 @@ export type TransactionsApi = {
    */
   acknowledge: (transaction: Transaction) => Promise<void>;
   /**
-   * Transitional escape hatch — NOT part of the public surface. Only for (a)
-   * not-yet-migrated SDK collaborators still composed in web feature code
-   * (the receive/send services) and (b) the web-owned realtime infrastructure
-   * until the SDK owns the realtime hub. App/UI code must use the curated
-   * methods above.
+   * Invalidates the single-transaction query so it refetches. Call after a
+   * state change the realtime broadcast may deliver late (e.g. right before
+   * navigating to the transaction details page).
    */
-  internal: {
-    cache: TransactionsCache;
-  };
+  invalidate: (transactionId: string) => Promise<void>;
 };
 
 export type TransactionsApiDeps = {
@@ -146,9 +142,8 @@ export function createTransactionsApi(deps: TransactionsApiDeps): {
       cache.acknowledgeInHistory(transaction);
       cache.invalidateUnacknowledgedCount();
     },
-    internal: {
-      cache,
-    },
+    invalidate: (transactionId: string) =>
+      cache.invalidateTransaction(transactionId),
   };
 
   return {

--- a/packages/wallet-sdk/src/transfer/transfer-api.test.ts
+++ b/packages/wallet-sdk/src/transfer/transfer-api.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { Money } from '@agicash/utils/money';
+import type { CashuAccount } from '../accounts/account';
+import type { CashuReceiveQuote } from '../receive/cashu-receive-quote';
+import type { CashuReceiveQuoteService } from '../receive/cashu-receive-quote-service';
+import type { SparkReceiveQuoteService } from '../receive/spark-receive-quote-service';
+import type { CashuSendQuoteService } from '../send/cashu-send-quote-service';
+import type { SparkSendQuoteService } from '../send/spark-send-quote-service';
+import { createTransferApi } from './transfer-api';
+import type { TransferQuote } from './transfer-service';
+
+const cashuAccount = {
+  id: 'acc-1',
+  type: 'cashu',
+  name: 'Cashu',
+} as unknown as CashuAccount;
+
+const sats = (amount: number) =>
+  new Money({ amount, currency: 'BTC', unit: 'sat' });
+
+const quote = {
+  amount: sats(1000),
+  amountToReceive: sats(1000),
+  totalFees: Money.zero('BTC'),
+  totalCost: sats(1000),
+  receive: {
+    account: cashuAccount,
+    fee: Money.zero('BTC'),
+    lightningQuote: { mintQuote: { request: 'lnbc-receive' } },
+  },
+  send: {
+    account: cashuAccount,
+    lightningQuote: {
+      paymentRequest: 'lnbc-send',
+      amountRequested: sats(1000),
+      amountRequestedInBtc: sats(1000),
+      meltQuote: { quote: 'melt-1' },
+    },
+  },
+} as unknown as TransferQuote;
+
+describe('createTransferApi initiateTransfer identity', () => {
+  it('derives the user id from getCurrentUserId, not the caller', async () => {
+    const receiveQuote = {
+      id: 'rq-1',
+      transactionId: 'receive-tx',
+    } as unknown as CashuReceiveQuote;
+    const createReceiveQuote = mock(async () => receiveQuote);
+    const createSendQuote = mock(async () => ({ transactionId: 'send-tx' }));
+
+    const { api } = createTransferApi({
+      getCurrentUserId: () => 'derived-user',
+      cashuReceiveQuoteService: {
+        createReceiveQuote,
+        fail: mock(async (): Promise<void> => undefined),
+      } as unknown as CashuReceiveQuoteService,
+      sparkReceiveQuoteService: {} as SparkReceiveQuoteService,
+      cashuSendQuoteService: {
+        createSendQuote,
+      } as unknown as CashuSendQuoteService,
+      sparkSendQuoteService: {} as SparkSendQuoteService,
+    });
+
+    const result = await api.initiateTransfer({ quote });
+
+    expect(result).toEqual({
+      transferId: expect.any(String),
+      receiveTransactionId: 'receive-tx',
+      sendTransactionId: 'send-tx',
+    });
+    expect(createReceiveQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'derived-user' }),
+    );
+    expect(createSendQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'derived-user' }),
+    );
+  });
+});

--- a/packages/wallet-sdk/src/transfer/transfer-api.ts
+++ b/packages/wallet-sdk/src/transfer/transfer-api.ts
@@ -1,0 +1,73 @@
+import type { Money } from '@agicash/utils/money';
+import type { Account } from '../accounts/account';
+import type { CashuReceiveQuoteService } from '../receive/cashu-receive-quote-service';
+import type { SparkReceiveQuoteService } from '../receive/spark-receive-quote-service';
+import type { CashuSendQuoteService } from '../send/cashu-send-quote-service';
+import type { SparkSendQuoteService } from '../send/spark-send-quote-service';
+import { type TransferQuote, TransferService } from './transfer-service';
+
+export type TransferApi = {
+  /**
+   * Gets a transfer quote for moving the amount from the source account to the
+   * destination account. Only fetches the lightning quotes; nothing is
+   * persisted.
+   * @throws DomainError when the source cannot send or the destination cannot
+   * receive Lightning payments.
+   */
+  getTransferQuote: (params: {
+    sourceAccount: Account;
+    destinationAccount: Account;
+    amount: Money;
+  }) => Promise<TransferQuote>;
+  /**
+   * Initiates a transfer for the current user by persisting the receive and
+   * send quotes (the background task processor picks up the send quote). If the
+   * send quote fails to persist the receive quote is failed (best-effort
+   * cleanup).
+   * @throws when the receive or send quote fails to persist.
+   */
+  initiateTransfer: (params: { quote: TransferQuote }) => Promise<{
+    transferId: string;
+    receiveTransactionId: string;
+    sendTransactionId: string;
+  }>;
+};
+
+export type TransferApiDeps = {
+  /**
+   * Resolves the current user's id from the SDK's user state.
+   * @throws if no user is loaded yet.
+   */
+  getCurrentUserId: () => string;
+  cashuReceiveQuoteService: CashuReceiveQuoteService;
+  sparkReceiveQuoteService: SparkReceiveQuoteService;
+  cashuSendQuoteService: CashuSendQuoteService;
+  sparkSendQuoteService: SparkSendQuoteService;
+};
+
+export function createTransferApi(deps: TransferApiDeps): {
+  api: TransferApi;
+} {
+  const {
+    getCurrentUserId,
+    cashuReceiveQuoteService,
+    sparkReceiveQuoteService,
+    cashuSendQuoteService,
+    sparkSendQuoteService,
+  } = deps;
+
+  const transferService = new TransferService(
+    cashuReceiveQuoteService,
+    sparkReceiveQuoteService,
+    cashuSendQuoteService,
+    sparkSendQuoteService,
+  );
+
+  const api: TransferApi = {
+    getTransferQuote: (params) => transferService.getTransferQuote(params),
+    initiateTransfer: ({ quote }) =>
+      transferService.initiateTransfer({ userId: getCurrentUserId(), quote }),
+  };
+
+  return { api };
+}

--- a/packages/wallet-sdk/src/transfer/transfer-service.test.ts
+++ b/packages/wallet-sdk/src/transfer/transfer-service.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { Money } from '@agicash/utils/money';
+import type { CashuAccount } from '../accounts/account';
+import type { CashuReceiveQuote } from '../receive/cashu-receive-quote';
+import type { CashuReceiveQuoteService } from '../receive/cashu-receive-quote-service';
+import type { SparkReceiveQuoteService } from '../receive/spark-receive-quote-service';
+import type { CashuSendQuoteService } from '../send/cashu-send-quote-service';
+import type { SparkSendQuoteService } from '../send/spark-send-quote-service';
+import { type TransferQuote, TransferService } from './transfer-service';
+
+const cashuAccount = {
+  id: 'acc-1',
+  type: 'cashu',
+  name: 'Cashu',
+} as unknown as CashuAccount;
+
+const sats = (amount: number) =>
+  new Money({ amount, currency: 'BTC', unit: 'sat' });
+
+// Only the fields initiateTransfer's cashu path reads (persistSendQuote +
+// persistReceiveQuote); getTransferQuote is not exercised here.
+const baseQuote = (): TransferQuote =>
+  ({
+    amount: sats(1000),
+    amountToReceive: sats(1000),
+    totalFees: Money.zero('BTC'),
+    totalCost: sats(1000),
+    receive: {
+      account: cashuAccount,
+      fee: Money.zero('BTC'),
+      lightningQuote: { mintQuote: { request: 'lnbc-receive' } },
+    },
+    send: {
+      account: cashuAccount,
+      lightningQuote: {
+        paymentRequest: 'lnbc-send',
+        amountRequested: sats(1000),
+        amountRequestedInBtc: sats(1000),
+        meltQuote: { quote: 'melt-1' },
+      },
+    },
+  }) as unknown as TransferQuote;
+
+describe('TransferService.initiateTransfer fail-cleanup', () => {
+  it('fails the receive quote and rethrows when the send quote creation throws', async () => {
+    const receiveQuote = {
+      id: 'rq-1',
+      transactionId: 'rx-1',
+    } as unknown as CashuReceiveQuote;
+    const sendError = new Error('send quote create failed');
+
+    const createReceiveQuote = mock(async () => receiveQuote);
+    const fail = mock(async (): Promise<void> => undefined);
+    const createSendQuote = mock(async () => {
+      throw sendError;
+    });
+
+    const service = new TransferService(
+      {
+        createReceiveQuote,
+        fail,
+      } as unknown as CashuReceiveQuoteService,
+      {} as SparkReceiveQuoteService,
+      { createSendQuote } as unknown as CashuSendQuoteService,
+      {} as SparkSendQuoteService,
+    );
+
+    await expect(
+      service.initiateTransfer({ userId: 'user-1', quote: baseQuote() }),
+    ).rejects.toBe(sendError);
+
+    expect(createReceiveQuote).toHaveBeenCalledTimes(1);
+    expect(createSendQuote).toHaveBeenCalledTimes(1);
+    expect(fail).toHaveBeenCalledTimes(1);
+    expect(fail).toHaveBeenCalledWith(
+      receiveQuote,
+      'Transfer initiation failed',
+    );
+  });
+
+  it('swallows a cleanup failure and still rethrows the original send error', async () => {
+    const receiveQuote = {
+      id: 'rq-2',
+      transactionId: 'rx-2',
+    } as unknown as CashuReceiveQuote;
+    const sendError = new Error('send quote create failed');
+
+    const createReceiveQuote = mock(async () => receiveQuote);
+    const fail = mock(async () => {
+      throw new Error('cleanup also failed');
+    });
+    const createSendQuote = mock(async () => {
+      throw sendError;
+    });
+
+    const service = new TransferService(
+      {
+        createReceiveQuote,
+        fail,
+      } as unknown as CashuReceiveQuoteService,
+      {} as SparkReceiveQuoteService,
+      { createSendQuote } as unknown as CashuSendQuoteService,
+      {} as SparkSendQuoteService,
+    );
+
+    await expect(
+      service.initiateTransfer({ userId: 'user-2', quote: baseQuote() }),
+    ).rejects.toBe(sendError);
+    expect(fail).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TransferService.initiateTransfer happy path', () => {
+  it('returns the transfer id and both transaction ids when both quotes persist', async () => {
+    const receiveQuote = {
+      id: 'rq-3',
+      transactionId: 'receive-tx',
+    } as unknown as CashuReceiveQuote;
+
+    const createReceiveQuote = mock(async () => receiveQuote);
+    const fail = mock(async (): Promise<void> => undefined);
+    const createSendQuote = mock(async () => ({ transactionId: 'send-tx' }));
+
+    const service = new TransferService(
+      {
+        createReceiveQuote,
+        fail,
+      } as unknown as CashuReceiveQuoteService,
+      {} as SparkReceiveQuoteService,
+      { createSendQuote } as unknown as CashuSendQuoteService,
+      {} as SparkSendQuoteService,
+    );
+
+    const result = await service.initiateTransfer({
+      userId: 'user-3',
+      quote: baseQuote(),
+    });
+
+    expect(result.receiveTransactionId).toBe('receive-tx');
+    expect(result.sendTransactionId).toBe('send-tx');
+    expect(typeof result.transferId).toBe('string');
+    expect(result.transferId.length).toBeGreaterThan(0);
+    expect(fail).not.toHaveBeenCalled();
+  });
+});

--- a/packages/wallet-sdk/src/transfer/transfer-service.ts
+++ b/packages/wallet-sdk/src/transfer/transfer-service.ts
@@ -1,32 +1,25 @@
 import { Money } from '@agicash/utils/money';
-import type {
-  Account,
-  CashuAccount,
-  SparkAccount,
-} from '@agicash/wallet-sdk/accounts/account';
+import type { Account, CashuAccount, SparkAccount } from '../accounts/account';
 import {
   canReceiveFromLightning,
   canSendToLightning,
-} from '@agicash/wallet-sdk/accounts/account';
-import type { CashuReceiveQuote } from '@agicash/wallet-sdk/receive/cashu-receive-quote';
-import type { CashuReceiveLightningQuote } from '@agicash/wallet-sdk/receive/cashu-receive-quote-core';
-import type { CashuReceiveQuoteService } from '@agicash/wallet-sdk/receive/cashu-receive-quote-service';
-import type { SparkReceiveQuote } from '@agicash/wallet-sdk/receive/spark-receive-quote';
-import { getLightningQuote as getSparkLightningQuote } from '@agicash/wallet-sdk/receive/spark-receive-quote-core';
-import type { SparkReceiveLightningQuote } from '@agicash/wallet-sdk/receive/spark-receive-quote-core';
-import type { SparkReceiveQuoteService } from '@agicash/wallet-sdk/receive/spark-receive-quote-service';
+} from '../accounts/account';
+import { DomainError } from '../error';
+import type { CashuReceiveQuote } from '../receive/cashu-receive-quote';
+import type { CashuReceiveLightningQuote } from '../receive/cashu-receive-quote-core';
+import type { CashuReceiveQuoteService } from '../receive/cashu-receive-quote-service';
+import type { SparkReceiveQuote } from '../receive/spark-receive-quote';
+import { getLightningQuote as getSparkLightningQuote } from '../receive/spark-receive-quote-core';
+import type { SparkReceiveLightningQuote } from '../receive/spark-receive-quote-core';
+import type { SparkReceiveQuoteService } from '../receive/spark-receive-quote-service';
 import type {
   CashuLightningQuote,
   CashuSendQuoteService,
-} from '@agicash/wallet-sdk/send/cashu-send-quote-service';
-
+} from '../send/cashu-send-quote-service';
 import type {
   SparkLightningQuote,
   SparkSendQuoteService,
-} from '@agicash/wallet-sdk/send/spark-send-quote-service';
-
-import { DomainError } from '@agicash/wallet-sdk/error';
-import { getSdk } from '../shared/sdk';
+} from '../send/spark-send-quote-service';
 
 export type TransferReceiveSide =
   | {
@@ -278,19 +271,4 @@ export class TransferService {
       transferId,
     });
   }
-}
-
-export function useTransferService() {
-  const cashuReceiveQuoteService =
-    getSdk().receive.internal.cashuReceiveQuoteService;
-  const sparkReceiveQuoteService =
-    getSdk().receive.internal.sparkReceiveQuoteService;
-  const cashuSendQuoteService = getSdk().send.internal.cashuSendQuoteService;
-  const sparkSendQuoteService = getSdk().send.internal.sparkSendQuoteService;
-  return new TransferService(
-    cashuReceiveQuoteService,
-    sparkReceiveQuoteService,
-    cashuSendQuoteService,
-    sparkSendQuoteService,
-  );
 }


### PR DESCRIPTION
Chunks 0-2 of the `sdk.*.internal` escape-hatch elimination plan (agreed in Discord), stacked on #1150. Review per-commit; each commit passed the extraction's gates independently.

## What this does

Web `.internal.` sites: **29 → 16**. Tests: **168 → 181** (wallet-sdk 40 → 53). Typecheck 6/6, biome clean, framework-free grep clean (1 comment hit, pre-existing).

**Commit 1 — chunk 0, free deletions.** Removes the five internal members with zero web consumers (`accounts.internal.{repository,service}`, `receive.internal.sparkReceiveQuoteRepository`, `send.internal.sparkSendQuoteRepository`, `transactions.internal.repository`) — exposure only, the instances stay wired inside the SDK. Also fixes the two stale "(Phase 8)" JSDocs in receive-api/send-api.

**Commit 2 — chunk 1, curated reads (kills 9 sites).** New curated surface:
- `sdk.send.quoteByTransactionIdOptions / swapByTransactionIdOptions`, `sdk.receive.quoteByTransactionIdOptions / swapByTransactionIdOptions` — the four transaction-details panels stop reaching into repositories. Same queryKey (`['transaction-details', id]`), same data; suspense/retry stay web-side.
- `sdk.receive.tokenReceiveAccountsOptions` (queryKey/staleTime byte-identical to the old hook), `sdk.receive.buildCashuAccountPlaceholder`, `sdk.receive.createCrossAccountReceiveQuotes` (writes NO cache — the old hook had no onSuccess write; realtime is the single write path. `userId` derived from SDK state).
- `sdk.transactions.invalidate(transactionId)` (returns the `invalidateQueries` promise, matching `sdk.auth.invalidate`; call sites are fire-and-forget as before).
- account-hooks rewired onto existing `getCached`/`listCached` (no new surface needed).
- Freed internal members deleted; `accounts.internal` and `transactions.internal` blocks became empty and were removed entirely. `useAccountsCache` / `useTransactionsCache` deleted.

**Commit 3 — chunk 2, `sdk.transfer` (kills 4 sites).** `TransferService` moves into the SDK byte-identical (verified by body diff: zero hunks outside the import block and the dropped `useTransferService` tail — the `initiateTransfer` fail-cleanup path is untouched). New `transfer/transfer-api.ts` per the file-per-domain pattern; the root wires the four quote services through extended factory returns (never through `internal`). **Named behavior change:** curated `initiateTransfer` derives `userId` via the root's `getCurrentUserId` thunk instead of taking it from the caller (the 3.6/3.7 precedent; the only caller passed the current user's id, so behavior is equivalent). Web `transfer-hooks.ts` becomes thin bindings keeping retry policy; old web `transfer-service.ts` deleted. +1 exports entry (`./transfer/transfer-service`) for the web's `TransferQuote` type imports.

## Verification

Built and adversarially verified (independent pass refuting each claim against the diff): TransferService byte-identity, queryKey/staleTime/retry parity on every rewired site, the no-cache-write precondition on the cross-account path, identity-derivation equivalence (complete caller graph), zero-consumer safety of every deleted member, and the gate numbers above. New tests are real: the fail-cleanup test fails if the cleanup call is removed; the api tests run the real options closures against spied repository prototypes.

## Reviewer notes (non-blocking)

- The `./transfer/transfer-service` exports entry exposes the class while web only imports the `TransferQuote` type — consistent with the existing `*-service` export convention, but a future types-only split could tighten this across all such entries.
- The fail-cleanup test locks the cashu branch; the spark branch is byte-identical-moved but not test-locked.
- `bun run test` prints an intentional "Failed to fetch rates" fixture stack from `exchange-rate-service.test.ts` — pre-existing, the test passes.
- Two JSDocs with the older "until the SDK owns the realtime hub" phrasing remain (contacts-api, user-api) — same staleness family as the two fixed here; left for the closeout chunk.

## What is deliberately NOT here

The remaining 16 sites are the tracking + background task-processing machinery (chunks 3-4: the `sdk.tasks` engine — design doc comes for review before any code) and the `window.agicashRealtime` debug handle (closeout chunk, to be dev-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
