### PR TITLE
refactor(web): decouple repositories and services from QueryClient

### DIFF
--- a/apps/web-wallet/app/features/accounts/account-hooks.ts
+++ b/apps/web-wallet/app/features/accounts/account-hooks.ts
@@ -468,8 +468,7 @@ export function useAccountOrDefault(accountId: string | null) {
 export function useAddCashuAccount() {
   const userId = useUser((x) => x.id);
   const accountCache = useAccountsCache();
-  const queryClient = useQueryClient();
-  const accountService = useAccountService(queryClient);
+  const accountService = useAccountService();
 
   const { mutateAsync } = useMutation({
     mutationFn: async (

--- a/apps/web-wallet/app/features/accounts/account-repository.ts
+++ b/apps/web-wallet/app/features/accounts/account-repository.ts
@@ -1,6 +1,6 @@
 import { ProofSchema, normalizeMintUrl } from '@agicash/cashu';
 import type { Currency } from '@agicash/money';
-import { type QueryClient, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
 import { z } from 'zod/mini';
 import {
@@ -49,7 +49,6 @@ export class AccountRepository {
   constructor(
     private readonly db: AgicashDb,
     private readonly encryption: Encryption,
-    private readonly queryClient: QueryClient,
     private readonly getCashuWalletSeed: () => Promise<Uint8Array>,
     private readonly getSparkWalletMnemonic: () => Promise<string>,
     private readonly sparkStorageDir: string,
@@ -232,7 +231,6 @@ export class AccountRepository {
   ) {
     const seed = await this.getCashuWalletSeed();
     return getInitializedCashuWallet({
-      queryClient: this.queryClient,
       mintUrl,
       currency,
       bip39seed: seed ?? undefined,
@@ -242,12 +240,7 @@ export class AccountRepository {
 
   private async getInitializedSparkWallet(network: SparkNetwork) {
     const mnemonic = await this.getSparkWalletMnemonic();
-    return getInitializedSparkWallet(
-      this.queryClient,
-      mnemonic,
-      network,
-      this.sparkStorageDir,
-    );
+    return getInitializedSparkWallet(mnemonic, network, this.sparkStorageDir);
   }
 
   private async decryptCashuProofs(
@@ -296,7 +289,6 @@ export function useAccountRepository() {
   return new AccountRepository(
     agicashDbClient,
     encryption,
-    queryClient,
     getCashuWalletSeed,
     getSparkWalletMnemonic,
     './.spark-data',

--- a/apps/web-wallet/app/features/accounts/account-service.ts
+++ b/apps/web-wallet/app/features/accounts/account-service.ts
@@ -3,9 +3,8 @@ import {
   findFirstActiveKeyset,
   getKeysetExpiry,
 } from '@agicash/cashu';
-import type { QueryClient } from '@tanstack/react-query';
+import { Mint } from '@cashu/cashu-ts';
 import type { DistributedOmit } from 'type-fest';
-import { allMintKeysetsQueryOptions } from '~/features/shared/cashu';
 import type { CashuAccount } from './account';
 import {
   type AccountRepository,
@@ -13,10 +12,7 @@ import {
 } from './account-repository';
 
 export class AccountService {
-  constructor(
-    private readonly accountRepository: AccountRepository,
-    private readonly queryClient: QueryClient,
-  ) {}
+  constructor(private readonly accountRepository: AccountRepository) {}
 
   async addCashuAccount({
     userId,
@@ -41,9 +37,7 @@ export class AccountService {
 
     let expiresAt: string | null = null;
     if (account.purpose === 'offer') {
-      const { keysets } = await this.queryClient.fetchQuery(
-        allMintKeysetsQueryOptions(account.mintUrl),
-      );
+      const { keysets } = await new Mint(account.mintUrl).getKeySets();
       const activeKeyset = findFirstActiveKeyset(keysets, account.currency);
       if (activeKeyset) {
         expiresAt = getKeysetExpiry(activeKeyset)?.toISOString() ?? null;
@@ -60,7 +54,7 @@ export class AccountService {
   }
 }
 
-export function useAccountService(queryClient: QueryClient) {
+export function useAccountService() {
   const accountRepository = useAccountRepository();
-  return new AccountService(accountRepository, queryClient);
+  return new AccountService(accountRepository);
 }

--- a/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/cashu-receive-quote-hooks.ts
@@ -584,7 +584,6 @@ export function useProcessCashuReceiveQuoteTasks() {
   const pendingQuotesCache = usePendingCashuReceiveQuotesCache();
   const cashuReceiveQuoteCache = useCashuReceiveQuoteCache();
   const transactionsCache = useTransactionsCache();
-  const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
     mutationFn: async (quoteId: string) => {
@@ -682,7 +681,6 @@ export function useProcessCashuReceiveQuoteTasks() {
         sourceWallet = sourceAccount.wallet;
       } else {
         const { wallet, isOnline } = await getInitializedCashuWallet({
-          queryClient,
           mintUrl: sourceMintUrl,
           currency: quote.tokenReceiveData.tokenAmount.currency,
         });

--- a/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
+++ b/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
@@ -1,15 +1,12 @@
 import type { Payment } from '@agicash/breez-sdk-spark';
 import type { Token } from '@cashu/cashu-ts';
 import * as Sentry from '@sentry/react-router';
-import type { QueryClient } from '@tanstack/react-query';
-import { getExchangeRate } from '~/hooks/use-exchange-rate';
+import { ExchangeRateService } from '~/lib/exchange-rate/exchange-rate-service';
 import type { Account, CashuAccount, SparkAccount } from '../accounts/account';
-import { AccountsCache, accountsQueryOptions } from '../accounts/account-hooks';
 import type { AccountRepository } from '../accounts/account-repository';
 import type { AccountService } from '../accounts/account-service';
 import { DomainError } from '../shared/error';
 import type { User } from '../user/user';
-import { UserCache } from '../user/user-hooks';
 import { UserService } from '../user/user-service';
 import type { CashuReceiveQuoteService } from './cashu-receive-quote-service';
 import type { CashuReceiveSwap } from './cashu-receive-swap';
@@ -27,14 +24,21 @@ type ClaimTokenResult =
   | {
       success: true;
       destinationAccount: Pick<Account, 'id' | 'purpose'>;
+      /**
+       * Accounts created or updated while claiming, for the caller to write into
+       * its cache (the service no longer owns one).
+       */
+      changedAccounts: Account[];
+      /**
+       * The updated user when the claim changed the default account, else null,
+       * for the caller to write into its cache.
+       */
+      updatedUser: User | null;
     }
   | { success: false; message: string };
 
 export class ClaimCashuTokenService {
-  private readonly accountsCache: AccountsCache;
-
   constructor(
-    private readonly queryClient: QueryClient,
     private readonly accountRepository: AccountRepository,
     private readonly accountService: AccountService,
     private readonly receiveSwapService: CashuReceiveSwapService,
@@ -43,9 +47,7 @@ export class ClaimCashuTokenService {
     private readonly receiveCashuTokenService: ReceiveCashuTokenService,
     private readonly receiveCashuTokenQuoteService: ReceiveCashuTokenQuoteService,
     private readonly userService: UserService,
-  ) {
-    this.accountsCache = new AccountsCache(queryClient);
-  }
+  ) {}
 
   /**
    * Claims the cashu token for the user.
@@ -86,12 +88,10 @@ export class ClaimCashuTokenService {
     token: Token,
     claimTo: 'cashu' | 'spark',
   ): Promise<ClaimTokenResult> {
-    const accounts = await this.queryClient.fetchQuery(
-      accountsQueryOptions({
-        userId: user.id,
-        accountRepository: this.accountRepository,
-      }),
-    );
+    const changedAccounts = new Map<string, Account>();
+    let updatedUser: User | null = null;
+
+    const accounts = await this.accountRepository.getAllActive(user.id);
     const extendedAccounts = UserService.getExtendedAccounts(user, accounts);
     const preferredReceiveAccountId =
       claimTo === 'spark'
@@ -122,7 +122,7 @@ export class ClaimCashuTokenService {
         userId: user.id,
         account: receiveAccount,
       });
-      this.accountsCache.upsert(addedAccount);
+      changedAccounts.set(addedAccount.id, addedAccount);
       receiveAccount = { ...receiveAccount, ...addedAccount };
     }
 
@@ -135,7 +135,7 @@ export class ClaimCashuTokenService {
       // when home page loads might not show the correct currency.
       const result = await this.trySetDefaultAccount(user, receiveAccount);
       if (result.success) {
-        this.queryClient.setQueryData([UserCache.Key], result.user);
+        updatedUser = result.user;
       }
     }
 
@@ -150,7 +150,7 @@ export class ClaimCashuTokenService {
         token,
         account: receiveAccount as CashuAccount,
       });
-      this.accountsCache.upsert(account);
+      changedAccounts.set(account.id, account);
 
       // We want to fail the entire claim flow if completing the swap fails only if the swap is in failed state (non
       // recoverable error). Otherwise, the background processing can pick it up and retry when the app loads. If the
@@ -159,7 +159,7 @@ export class ClaimCashuTokenService {
       // handle the failed swap.
       const result = await this.tryCompleteSwap(account, swap);
       if (result.success) {
-        this.accountsCache.upsert(result.account);
+        changedAccounts.set(result.account.id, result.account);
       } else if (result.swap?.state === 'FAILED') {
         return {
           success: false,
@@ -167,8 +167,7 @@ export class ClaimCashuTokenService {
         };
       }
     } else {
-      const exchangeRate = await getExchangeRate(
-        this.queryClient,
+      const exchangeRate = await new ExchangeRateService().getRate(
         `${sourceAccount.currency}-${receiveAccount.currency}`,
       );
       const quotes =
@@ -200,7 +199,7 @@ export class ClaimCashuTokenService {
       // complete it, the app already has a way to handle the failed receive.
       const result = await this.tryCompleteReceive(quotes);
       if (result.success && result.account) {
-        this.accountsCache.upsert(result.account);
+        changedAccounts.set(result.account.id, result.account);
       }
     }
 
@@ -210,6 +209,8 @@ export class ClaimCashuTokenService {
         id: receiveAccount.id,
         purpose: receiveAccount.purpose,
       },
+      changedAccounts: [...changedAccounts.values()],
+      updatedUser,
     };
   }
 

--- a/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
+++ b/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
@@ -48,6 +48,7 @@ export class ClaimCashuTokenService {
    * @param user - The user to claim the token for.
    * @param token - The token to claim.
    * @param claimTo - Whether to claim the token to a cashu or spark account.
+   * @param accounts - The user's accounts used to resolve the token's source and possible destination accounts.
    * @returns The result of the claim.
    */
   async claimToken(

--- a/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
+++ b/apps/web-wallet/app/features/receive/claim-cashu-token-service.ts
@@ -1,9 +1,8 @@
 import type { Payment } from '@agicash/breez-sdk-spark';
 import type { Token } from '@cashu/cashu-ts';
 import * as Sentry from '@sentry/react-router';
-import { ExchangeRateService } from '~/lib/exchange-rate/exchange-rate-service';
+import type { Ticker } from '~/lib/exchange-rate';
 import type { Account, CashuAccount, SparkAccount } from '../accounts/account';
-import type { AccountRepository } from '../accounts/account-repository';
 import type { AccountService } from '../accounts/account-service';
 import { DomainError } from '../shared/error';
 import type { User } from '../user/user';
@@ -23,30 +22,22 @@ import type { SparkReceiveQuoteService } from './spark-receive-quote-service';
 type ClaimTokenResult =
   | {
       success: true;
-      destinationAccount: Pick<Account, 'id' | 'purpose'>;
-      /**
-       * Accounts created or updated while claiming, for the caller to write into
-       * its cache (the service no longer owns one).
-       */
+      /** The account the token was claimed into. */
+      receiveAccount: Account;
+      /** Accounts created or updated while claiming, for the caller to write into its cache. */
       changedAccounts: Account[];
-      /**
-       * The updated user when the claim changed the default account, else null,
-       * for the caller to write into its cache.
-       */
-      updatedUser: User | null;
     }
   | { success: false; message: string };
 
 export class ClaimCashuTokenService {
   constructor(
-    private readonly accountRepository: AccountRepository,
     private readonly accountService: AccountService,
     private readonly receiveSwapService: CashuReceiveSwapService,
     private readonly cashuReceiveQuoteService: CashuReceiveQuoteService,
     private readonly sparkReceiveQuoteService: SparkReceiveQuoteService,
     private readonly receiveCashuTokenService: ReceiveCashuTokenService,
     private readonly receiveCashuTokenQuoteService: ReceiveCashuTokenQuoteService,
-    private readonly userService: UserService,
+    private readonly getExchangeRate: (ticker: Ticker) => Promise<string>,
   ) {}
 
   /**
@@ -63,9 +54,10 @@ export class ClaimCashuTokenService {
     user: User,
     token: Token,
     claimTo: 'cashu' | 'spark',
+    accounts: Account[],
   ): Promise<ClaimTokenResult> {
     try {
-      return await this.handleClaim(user, token, claimTo);
+      return await this.handleClaim(user, token, claimTo, accounts);
     } catch (error) {
       if (error instanceof DomainError) {
         return {
@@ -87,11 +79,10 @@ export class ClaimCashuTokenService {
     user: User,
     token: Token,
     claimTo: 'cashu' | 'spark',
+    accounts: Account[],
   ): Promise<ClaimTokenResult> {
-    const changedAccounts = new Map<string, Account>();
-    let updatedUser: User | null = null;
+    const changedAccounts: Account[] = [];
 
-    const accounts = await this.accountRepository.getAllActive(user.id);
     const extendedAccounts = UserService.getExtendedAccounts(user, accounts);
     const preferredReceiveAccountId =
       claimTo === 'spark'
@@ -122,21 +113,8 @@ export class ClaimCashuTokenService {
         userId: user.id,
         account: receiveAccount,
       });
-      changedAccounts.set(addedAccount.id, addedAccount);
+      changedAccounts.push(addedAccount);
       receiveAccount = { ...receiveAccount, ...addedAccount };
-    }
-
-    if (
-      receiveAccount.currency !== user.defaultCurrency ||
-      !UserService.isDefaultAccount(user, receiveAccount)
-    ) {
-      // We don't want to fail the entire claim flow if setting the default account fails because it's not
-      // critical and the user can still claim the token, it just won't be as nice UX because the balance
-      // when home page loads might not show the correct currency.
-      const result = await this.trySetDefaultAccount(user, receiveAccount);
-      if (result.success) {
-        updatedUser = result.user;
-      }
     }
 
     const isSameAccountClaim = isClaimingToSameCashuAccount(
@@ -150,7 +128,7 @@ export class ClaimCashuTokenService {
         token,
         account: receiveAccount as CashuAccount,
       });
-      changedAccounts.set(account.id, account);
+      changedAccounts.push(account);
 
       // We want to fail the entire claim flow if completing the swap fails only if the swap is in failed state (non
       // recoverable error). Otherwise, the background processing can pick it up and retry when the app loads. If the
@@ -159,7 +137,7 @@ export class ClaimCashuTokenService {
       // handle the failed swap.
       const result = await this.tryCompleteSwap(account, swap);
       if (result.success) {
-        changedAccounts.set(result.account.id, result.account);
+        changedAccounts.push(result.account);
       } else if (result.swap?.state === 'FAILED') {
         return {
           success: false,
@@ -167,7 +145,7 @@ export class ClaimCashuTokenService {
         };
       }
     } else {
-      const exchangeRate = await new ExchangeRateService().getRate(
+      const exchangeRate = await this.getExchangeRate(
         `${sourceAccount.currency}-${receiveAccount.currency}`,
       );
       const quotes =
@@ -199,41 +177,15 @@ export class ClaimCashuTokenService {
       // complete it, the app already has a way to handle the failed receive.
       const result = await this.tryCompleteReceive(quotes);
       if (result.success && result.account) {
-        changedAccounts.set(result.account.id, result.account);
+        changedAccounts.push(result.account);
       }
     }
 
     return {
       success: true,
-      destinationAccount: {
-        id: receiveAccount.id,
-        purpose: receiveAccount.purpose,
-      },
-      changedAccounts: [...changedAccounts.values()],
-      updatedUser,
+      receiveAccount,
+      changedAccounts,
     };
-  }
-
-  private async trySetDefaultAccount(
-    user: User,
-    account: Account,
-  ): Promise<{ success: true; user: User } | { success: false }> {
-    try {
-      const updatedUser = await this.userService.setDefaultAccount(
-        user,
-        account,
-        {
-          setDefaultCurrency: true,
-        },
-      );
-      return { success: true, user: updatedUser };
-    } catch (error) {
-      console.error('Failed to set default account while claiming the token', {
-        cause: error,
-        accountId: account.id,
-      });
-      return { success: false };
-    }
   }
 
   private async tryCompleteSwap(

--- a/apps/web-wallet/app/features/receive/lightning-address-service.ts
+++ b/apps/web-wallet/app/features/receive/lightning-address-service.ts
@@ -9,7 +9,6 @@ import { Money } from '@agicash/money';
 import { sha256 } from '@noble/hashes/sha2';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { base64url } from '@scure/base';
-import type { QueryClient } from '@tanstack/react-query';
 import { z } from 'zod/mini';
 import { ExchangeRateService } from '~/lib/exchange-rate/exchange-rate-service';
 import { measureOperation } from '~/lib/performance';
@@ -19,7 +18,7 @@ import {
 } from '~/lib/xchacha20poly1305';
 import type { AgicashDb } from '../agicash-db/database';
 import { NotFoundError } from '../shared/error';
-import { sparkWalletQueryOptions } from '../shared/spark';
+import { getSparkWallet } from '../shared/spark';
 import {
   ReadUserDefaultAccountRepository,
   ReadUserRepository,
@@ -67,7 +66,6 @@ export class LightningAddressService {
   private minSendable: Money<'BTC'>;
   private maxSendable: Money<'BTC'>;
   private exchangeRateService: ExchangeRateService;
-  private queryClient: QueryClient;
   /**
    * A client can flag that they will not validate the invoice amount.
    * This is useful for agicash <-> agicash payments so that the receiver can receive into their default currency
@@ -78,12 +76,10 @@ export class LightningAddressService {
   constructor(
     request: Request,
     db: AgicashDb,
-    queryClient: QueryClient,
     options?: {
       bypassAmountValidation?: boolean;
     },
   ) {
-    this.queryClient = queryClient;
     this.exchangeRateService = new ExchangeRateService();
     this.db = db;
     this.userRepository = new ReadUserRepository(db);
@@ -167,7 +163,6 @@ export class LightningAddressService {
 
       const userDefaultAccountRepository = new ReadUserDefaultAccountRepository(
         this.db,
-        this.queryClient,
         getSparkWalletMnemonic,
         '/tmp/.spark-data',
       );
@@ -321,13 +316,11 @@ export class LightningAddressService {
   private async handleSparkLnurlpVerify(
     receiveRequestId: string,
   ): Promise<LNURLVerifyResult> {
-    const wallet = await this.queryClient.fetchQuery(
-      sparkWalletQueryOptions({
-        network: 'MAINNET',
-        mnemonic: sparkMnemonic,
-        storageDir: '/tmp/.spark-data',
-      }),
-    );
+    const wallet = await getSparkWallet({
+      network: 'MAINNET',
+      mnemonic: sparkMnemonic,
+      storageDir: '/tmp/.spark-data',
+    });
 
     const receiveRequest = await measureOperation(
       'BreezSdk.getLightningReceiveRequest',

--- a/apps/web-wallet/app/features/receive/receive-cashu-token-service.ts
+++ b/apps/web-wallet/app/features/receive/receive-cashu-token-service.ts
@@ -7,7 +7,6 @@ import {
 } from '@agicash/cashu';
 import type { Currency } from '@agicash/money';
 import type { Token } from '@cashu/cashu-ts';
-import { type QueryClient, useQueryClient } from '@tanstack/react-query';
 import {
   type ExtendedAccount,
   type ExtendedCashuAccount,
@@ -25,8 +24,6 @@ import type {
 } from './receive-cashu-token-models';
 
 export class ReceiveCashuTokenService {
-  constructor(private readonly queryClient: QueryClient) {}
-
   /**
    * Builds a cashu account object for a given mint and currency.
    * This account is not stored in the database, and has placeholder values for the id and createdAt.
@@ -39,7 +36,6 @@ export class ReceiveCashuTokenService {
     currency: Currency,
   ): Promise<CashuAccountWithTokenFlags> {
     const { wallet, isOnline } = await getInitializedCashuWallet({
-      queryClient: this.queryClient,
       mintUrl,
       currency,
     });
@@ -237,6 +233,5 @@ export class ReceiveCashuTokenService {
 }
 
 export function useReceiveCashuTokenService() {
-  const queryClient = useQueryClient();
-  return new ReceiveCashuTokenService(queryClient);
+  return new ReceiveCashuTokenService();
 }

--- a/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
+++ b/apps/web-wallet/app/features/receive/spark-receive-quote-hooks.ts
@@ -462,7 +462,6 @@ export function useProcessSparkReceiveQuoteTasks() {
   const pendingQuotesCache = usePendingSparkReceiveQuotesCache();
   const sparkReceiveQuoteCache = useSparkReceiveQuoteCache();
   const transactionsCache = useTransactionsCache();
-  const queryClient = useQueryClient();
 
   const { mutate: completeReceiveQuote } = useMutation({
     mutationFn: async ({
@@ -576,7 +575,6 @@ export function useProcessSparkReceiveQuoteTasks() {
         sourceWallet = sourceAccount.wallet;
       } else {
         const { wallet, isOnline } = await getInitializedCashuWallet({
-          queryClient,
           mintUrl: sourceMintUrl,
           currency: quote.tokenReceiveData.tokenAmount.currency,
         });

--- a/apps/web-wallet/app/features/shared/cashu.ts
+++ b/apps/web-wallet/app/features/shared/cashu.ts
@@ -183,11 +183,6 @@ export const allMintKeysetsQueryKey = (mintUrl: string) => [
   'all-mint-keysets',
   mintUrl,
 ];
-export const mintKeysQueryKey = (mintUrl: string, keysetId?: string) => [
-  'mint-keys',
-  mintUrl,
-  keysetId,
-];
 
 /**
  * Get the mint info.
@@ -238,37 +233,19 @@ export async function decodeCashuToken(content: string): Promise<Token | null> {
 }
 
 /**
- * Get the mints public keys.
- *
- * @param mintUrl
- * @param keysetId Optional param to get the keys for a specific keyset. If not specified, the
- *   keys from all active keysets are fetched.
- * @returns An object with an array of the fetched keysets.
- */
-export const mintKeysQueryOptions = (mintUrl: string, keysetId?: string) =>
-  queryOptions({
-    queryKey: mintKeysQueryKey(mintUrl, keysetId),
-    queryFn: async () => new Mint(mintUrl).getKeys(keysetId),
-    staleTime: 1000 * 60 * 60, // 1 hour
-  });
-
-/**
  * Initializes a Cashu wallet with offline handling.
  * If the mint is offline or times out, returns a minimal wallet with isOnline: false.
- * @param queryClient - The query client to use for fetching mint data.
  * @param mintUrl - The mint URL.
  * @param currency - The currency.
  * @param bip39seed - Optional BIP39 seed for wallet initialization.
  * @returns The wallet and online status.
  */
 export async function getInitializedCashuWallet({
-  queryClient,
   mintUrl,
   currency,
   bip39seed,
   authProvider,
 }: {
-  queryClient: QueryClient;
   mintUrl: string;
   currency: Currency;
   bip39seed?: Uint8Array;
@@ -282,23 +259,15 @@ export async function getInitializedCashuWallet({
       let mintActiveKeys: GetKeysResponse;
 
       try {
+        const mint = new Mint(mintUrl);
         [mintInfo, allMintKeysets, mintActiveKeys] = await Promise.race([
           Promise.all([
-            queryClient.fetchQuery(mintInfoQueryOptions(mintUrl)),
-            queryClient.fetchQuery(allMintKeysetsQueryOptions(mintUrl)),
-            queryClient.fetchQuery(mintKeysQueryOptions(mintUrl)),
+            mint.getInfo().then((info) => new ExtendedMintInfo(info)),
+            mint.getKeySets(),
+            mint.getKeys(),
           ]),
           new Promise<never>((_, reject) => {
             setTimeout(() => {
-              queryClient.cancelQueries({
-                queryKey: mintInfoQueryKey(mintUrl),
-              });
-              queryClient.cancelQueries({
-                queryKey: allMintKeysetsQueryKey(mintUrl),
-              });
-              queryClient.cancelQueries({
-                queryKey: mintKeysQueryKey(mintUrl),
-              });
               reject(new NetworkError('Mint request timed out'));
             }, 10_000);
           }),

--- a/apps/web-wallet/app/features/shared/spark.ts
+++ b/apps/web-wallet/app/features/shared/spark.ts
@@ -86,54 +86,74 @@ export const sparkIdentityPublicKeyQueryOptions = ({
     },
   });
 
-export const sparkWalletQueryOptions = ({
+const sparkWalletPromises = new Map<string, Promise<BreezSdk>>();
+
+/**
+ * Returns the process-wide Breez wallet for a mnemonic, connecting on first
+ * request and memoizing the connection. A Breez `connect()` opens a stateful
+ * session, so it must run at most once per mnemonic/network/storageDir —
+ * re-connecting would leak duplicate sessions. A failed connect is evicted so
+ * the next call retries.
+ */
+export function getSparkWallet({
   network,
   mnemonic,
   storageDir,
-}: { network: SparkNetwork; mnemonic: string; storageDir: string }) =>
-  queryOptions({
-    queryKey: ['spark-wallet', computeSHA256(mnemonic), network, storageDir],
-    queryFn: async () => {
-      const breezNetwork = network.toLowerCase() as 'mainnet' | 'regtest';
+}: {
+  network: SparkNetwork;
+  mnemonic: string;
+  storageDir: string;
+}): Promise<BreezSdk> {
+  const key = `${computeSHA256(mnemonic)}:${network}:${storageDir}`;
+  const existing = sparkWalletPromises.get(key);
+  if (existing) return existing;
 
-      tryInitLogging();
-
-      const sdk = await measureOperation(
-        'BreezSdk.connect',
-        () =>
-          connect({
-            config: {
-              ...defaultConfig(breezNetwork),
-              apiKey,
-              lnurlDomain: undefined, // Disables Breez's built-in lightning address recovery — we use our own ln address system
-              privateEnabledDefault: true,
-              optimizationConfig: {
-                autoEnabled: true,
-                multiplicity: 2,
-              },
-            },
-            seed: { type: 'mnemonic', mnemonic },
-            storageDir,
-          }),
-        { 'spark.network': network },
-      );
-
-      return sdk;
-    },
-    staleTime: Number.POSITIVE_INFINITY,
-    gcTime: Number.POSITIVE_INFINITY,
+  const breezNetwork = network.toLowerCase() as 'mainnet' | 'regtest';
+  tryInitLogging();
+  const walletPromise = measureOperation(
+    'BreezSdk.connect',
+    () =>
+      connect({
+        config: {
+          ...defaultConfig(breezNetwork),
+          apiKey,
+          lnurlDomain: undefined, // Disables Breez's built-in lightning address recovery — we use our own ln address system
+          privateEnabledDefault: true,
+          optimizationConfig: {
+            autoEnabled: true,
+            multiplicity: 2,
+          },
+        },
+        seed: { type: 'mnemonic', mnemonic },
+        storageDir,
+      }),
+    { 'spark.network': network },
+  );
+  sparkWalletPromises.set(key, walletPromise);
+  void walletPromise.catch(() => {
+    if (sparkWalletPromises.get(key) === walletPromise) {
+      sparkWalletPromises.delete(key);
+    }
   });
+  return walletPromise;
+}
+
+/**
+ * Drops all memoized Breez wallet connections so a subsequent session
+ * reconnects fresh. Called on sign-out (mirrors the old `queryClient.clear()`).
+ */
+export function clearSparkWallets(): void {
+  sparkWalletPromises.clear();
+}
 
 /**
  * Initializes a Spark wallet with offline handling.
  * If Spark is offline or times out, returns a minimal wallet with isOnline: false.
- * @param queryClient - The query client to use for async queries and caching.
  * @param mnemonic - The Spark wallet mnemonic.
  * @param network - The Spark network that the wallet is on.
  * @returns The wallet, balance and online status.
  */
 export async function getInitializedSparkWallet(
-  queryClient: QueryClient,
   mnemonic: string,
   network: SparkNetwork,
   storageDir: string,
@@ -146,9 +166,7 @@ export async function getInitializedSparkWallet(
     'getInitializedSparkWallet',
     async () => {
       try {
-        const wallet = await queryClient.fetchQuery(
-          sparkWalletQueryOptions({ network, mnemonic, storageDir }),
-        );
+        const wallet = await getSparkWallet({ network, mnemonic, storageDir });
         const info = await measureOperation('BreezSdk.getInfo', () =>
           wallet.getInfo({}),
         );

--- a/apps/web-wallet/app/features/shared/spark.ts
+++ b/apps/web-wallet/app/features/shared/spark.ts
@@ -130,10 +130,8 @@ export function getSparkWallet({
     { 'spark.network': network },
   );
   sparkWalletPromises.set(key, walletPromise);
-  void walletPromise.catch(() => {
-    if (sparkWalletPromises.get(key) === walletPromise) {
-      sparkWalletPromises.delete(key);
-    }
+  walletPromise.catch(() => {
+    sparkWalletPromises.delete(key);
   });
   return walletPromise;
 }

--- a/apps/web-wallet/app/features/user/auth.ts
+++ b/apps/web-wallet/app/features/user/auth.ts
@@ -21,6 +21,7 @@ import { jwtDecode } from 'jwt-decode';
 import { useCallback, useState } from 'react';
 import { useNavigate, useRevalidator } from 'react-router';
 import { getQueryClient } from '~/features/shared/query-client';
+import { clearSparkWallets } from '~/features/shared/spark';
 import { useLongTimeout } from '~/hooks/use-long-timeout';
 import { generateRandomPassword } from '~/lib/password-generator';
 import { guestAccountStorage } from './guest-account-storage';
@@ -217,6 +218,9 @@ export const useAuthActions = (): AuthActions => {
       await refreshSession(options.redirectTo);
       Sentry.setUser(null);
       queryClient.clear();
+      // The spark wallet connection memo is framework-free (not in the query
+      // cache), so clear it alongside so a next session reconnects fresh.
+      clearSparkWallets();
     },
     [refreshSession, queryClient],
   );

--- a/apps/web-wallet/app/features/user/user-repository.ts
+++ b/apps/web-wallet/app/features/user/user-repository.ts
@@ -1,6 +1,5 @@
 import { normalizeMintUrl } from '@agicash/cashu';
 import type { Currency } from '@agicash/money';
-import type { QueryClient } from '@tanstack/react-query';
 import type { DistributedOmit } from 'type-fest';
 import type { z } from 'zod/mini';
 import type { Account, RedactedAccount } from '../accounts/account';
@@ -206,7 +205,6 @@ export class WriteUserRepository {
 export class ReadUserDefaultAccountRepository {
   constructor(
     private readonly db: AgicashDb,
-    private readonly queryClient: QueryClient,
     private readonly getSparkWalletMnemonic: () => Promise<string>,
     private readonly sparkStorageDir: string,
   ) {}
@@ -268,7 +266,6 @@ export class ReadUserDefaultAccountRepository {
       const details = data.details;
 
       const { wallet, isOnline } = await getInitializedCashuWallet({
-        queryClient: this.queryClient,
         mintUrl: details.mint_url,
         currency: data.currency,
         authProvider: getMintAuthProvider(data.purpose),
@@ -304,12 +301,7 @@ export class ReadUserDefaultAccountRepository {
 
   private async getInitializedSparkWallet(network: SparkNetwork) {
     const mnemonic = await this.getSparkWalletMnemonic();
-    return getInitializedSparkWallet(
-      this.queryClient,
-      mnemonic,
-      network,
-      this.sparkStorageDir,
-    );
+    return getInitializedSparkWallet(mnemonic, network, this.sparkStorageDir);
   }
 }
 

--- a/apps/web-wallet/app/routes/[.]well-known.lnurlp.$username.ts
+++ b/apps/web-wallet/app/routes/[.]well-known.lnurlp.$username.ts
@@ -5,15 +5,12 @@
 
 import { agicashDbServer } from '~/features/agicash-db/database.server';
 import { LightningAddressService } from '~/features/receive/lightning-address-service';
-import { getQueryClient } from '~/features/shared/query-client';
 import type { Route } from './+types/[.]well-known.lnurlp.$username';
 
 export async function loader({ request, params }: Route.LoaderArgs) {
-  const queryClient = getQueryClient();
   const lightningAddressService = new LightningAddressService(
     request,
     agicashDbServer,
-    queryClient,
   );
 
   const response = await lightningAddressService.handleLud16Request(

--- a/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
+++ b/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
@@ -44,7 +44,7 @@ import { toast } from '~/hooks/use-toast';
 import type { Route } from './+types/_protected.receive.cashu_.token';
 import { ReceiveCashuTokenSkeleton } from './receive-cashu-token-skeleton';
 
-const getClaimCashuTokenService = async () => {
+const getServices = async () => {
   const queryClient = getQueryClient();
   const [encryptionPrivateKey, encryptionPublicKey] = await Promise.all([
     queryClient.ensureQueryData(encryptionPrivateKeyQueryOptions()),
@@ -111,7 +111,7 @@ const getClaimCashuTokenService = async () => {
  * right balance on the home page. Best-effort: never fails the claim. Web-only
  * UX, so it lives here rather than in the claim service.
  */
-async function setReceiveAccountAsDefault(
+async function trySetReceiveAccountAsDefault(
   userService: UserService,
   queryClient: QueryClient,
   user: User,
@@ -171,7 +171,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   if (claimTo) {
     const user = getUserFromCacheOrThrow();
     const { claimCashuTokenService, accountRepository, userService } =
-      await getClaimCashuTokenService();
+      await getServices();
     const queryClient = getQueryClient();
     const accounts = await queryClient.fetchQuery(
       accountsQueryOptions({ userId: user.id, accountRepository }),
@@ -191,7 +191,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
       for (const account of result.changedAccounts) {
         accountsCache.upsert(account);
       }
-      await setReceiveAccountAsDefault(
+      await trySetReceiveAccountAsDefault(
         userService,
         queryClient,
         user,

--- a/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
+++ b/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
@@ -1,8 +1,13 @@
 import { validateCashuToken } from '@agicash/cashu';
+import type { QueryClient } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { redirect } from 'react-router';
 import { Page } from '~/components/page';
-import { AccountsCache } from '~/features/accounts/account-hooks';
+import type { Account } from '~/features/accounts/account';
+import {
+  AccountsCache,
+  accountsQueryOptions,
+} from '~/features/accounts/account-hooks';
 import { AccountRepository } from '~/features/accounts/account-repository';
 import { AccountService } from '~/features/accounts/account-service';
 import { agicashDbClient } from '~/features/agicash-db/database.client';
@@ -30,9 +35,11 @@ import {
 } from '~/features/shared/encryption';
 import { getQueryClient } from '~/features/shared/query-client';
 import { sparkMnemonicQueryOptions } from '~/features/shared/spark';
+import type { User } from '~/features/user/user';
 import { UserCache, getUserFromCacheOrThrow } from '~/features/user/user-hooks';
 import { WriteUserRepository } from '~/features/user/user-repository';
 import { UserService } from '~/features/user/user-service';
+import { getExchangeRate } from '~/hooks/use-exchange-rate';
 import { toast } from '~/hooks/use-toast';
 import type { Route } from './+types/_protected.receive.cashu_.token';
 import { ReceiveCashuTokenSkeleton } from './receive-cashu-token-skeleton';
@@ -85,17 +92,49 @@ const getClaimCashuTokenService = async () => {
   );
   const userService = new UserService(userRepository);
 
-  return new ClaimCashuTokenService(
-    accountRepository,
+  const claimCashuTokenService = new ClaimCashuTokenService(
     accountService,
     receiveSwapService,
     cashuReceiveQuoteService,
     sparkReceiveQuoteService,
     receiveCashuTokenService,
     receiveCashuTokenQuoteService,
-    userService,
+    (ticker) => getExchangeRate(queryClient, ticker),
   );
+
+  return { claimCashuTokenService, accountRepository, userService };
 };
+
+/**
+ * Sets the just-received account as the user's default when it isn't already —
+ * a UI nicety so a first-time user receiving to a non-default account sees the
+ * right balance on the home page. Best-effort: never fails the claim. Web-only
+ * UX, so it lives here rather than in the claim service.
+ */
+async function setReceiveAccountAsDefault(
+  userService: UserService,
+  queryClient: QueryClient,
+  user: User,
+  account: Account,
+): Promise<void> {
+  if (
+    account.currency === user.defaultCurrency &&
+    UserService.isDefaultAccount(user, account)
+  ) {
+    return;
+  }
+  try {
+    const updatedUser = await userService.setDefaultAccount(user, account, {
+      setDefaultCurrency: true,
+    });
+    new UserCache(queryClient).set(updatedUser);
+  } catch (error) {
+    console.error('Failed to set default account while claiming the token', {
+      cause: error,
+      accountId: account.id,
+    });
+  }
+}
 
 const getClaimTo = (
   searchParams: URLSearchParams,
@@ -131,26 +170,33 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
 
   if (claimTo) {
     const user = getUserFromCacheOrThrow();
-    const claimCashuTokenService = await getClaimCashuTokenService();
+    const { claimCashuTokenService, accountRepository, userService } =
+      await getClaimCashuTokenService();
+    const queryClient = getQueryClient();
+    const accounts = await queryClient.fetchQuery(
+      accountsQueryOptions({ userId: user.id, accountRepository }),
+    );
 
     const result = await claimCashuTokenService.claimToken(
       user,
       token,
       claimTo,
+      accounts,
     );
 
     if (result.success) {
-      // The claim service no longer writes to the cache directly; apply its
-      // account/user changes here so the destination screen renders them
-      // immediately after the redirect.
-      const queryClient = getQueryClient();
+      // Apply the claim's account changes to the cache so the destination
+      // screen renders them immediately after the redirect.
       const accountsCache = new AccountsCache(queryClient);
       for (const account of result.changedAccounts) {
         accountsCache.upsert(account);
       }
-      if (result.updatedUser) {
-        new UserCache(queryClient).set(result.updatedUser);
-      }
+      await setReceiveAccountAsDefault(
+        userService,
+        queryClient,
+        user,
+        result.receiveAccount,
+      );
     } else {
       toast({
         title: 'Failed to claim the token',
@@ -166,9 +212,9 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
     if (
       !explicitRedirectTo &&
       result.success &&
-      result.destinationAccount.purpose === 'gift-card'
+      result.receiveAccount.purpose === 'gift-card'
     ) {
-      redirectTo = `/gift-cards/${result.destinationAccount.id}`;
+      redirectTo = `/gift-cards/${result.receiveAccount.id}`;
     }
 
     throw redirect(redirectTo);

--- a/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
+++ b/apps/web-wallet/app/routes/_protected.receive.cashu_.token.tsx
@@ -2,6 +2,7 @@ import { validateCashuToken } from '@agicash/cashu';
 import { Suspense } from 'react';
 import { redirect } from 'react-router';
 import { Page } from '~/components/page';
+import { AccountsCache } from '~/features/accounts/account-hooks';
 import { AccountRepository } from '~/features/accounts/account-repository';
 import { AccountService } from '~/features/accounts/account-service';
 import { agicashDbClient } from '~/features/agicash-db/database.client';
@@ -29,7 +30,7 @@ import {
 } from '~/features/shared/encryption';
 import { getQueryClient } from '~/features/shared/query-client';
 import { sparkMnemonicQueryOptions } from '~/features/shared/spark';
-import { getUserFromCacheOrThrow } from '~/features/user/user-hooks';
+import { UserCache, getUserFromCacheOrThrow } from '~/features/user/user-hooks';
 import { WriteUserRepository } from '~/features/user/user-repository';
 import { UserService } from '~/features/user/user-service';
 import { toast } from '~/hooks/use-toast';
@@ -49,12 +50,11 @@ const getClaimCashuTokenService = async () => {
   const accountRepository = new AccountRepository(
     agicashDbClient,
     encryption,
-    queryClient,
     getCashuWalletSeed,
     getSparkWalletMnemonic,
     './.spark-data',
   );
-  const accountService = new AccountService(accountRepository, queryClient);
+  const accountService = new AccountService(accountRepository);
   const receiveSwapRepository = new CashuReceiveSwapRepository(
     agicashDbClient,
     encryption,
@@ -74,7 +74,7 @@ const getClaimCashuTokenService = async () => {
   const sparkReceiveQuoteService = new SparkReceiveQuoteService(
     new SparkReceiveQuoteRepository(agicashDbClient, encryption),
   );
-  const receiveCashuTokenService = new ReceiveCashuTokenService(queryClient);
+  const receiveCashuTokenService = new ReceiveCashuTokenService();
   const receiveCashuTokenQuoteService = new ReceiveCashuTokenQuoteService(
     cashuReceiveQuoteService,
     sparkReceiveQuoteService,
@@ -86,7 +86,6 @@ const getClaimCashuTokenService = async () => {
   const userService = new UserService(userRepository);
 
   return new ClaimCashuTokenService(
-    queryClient,
     accountRepository,
     accountService,
     receiveSwapService,
@@ -139,7 +138,20 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
       token,
       claimTo,
     );
-    if (!result.success) {
+
+    if (result.success) {
+      // The claim service no longer writes to the cache directly; apply its
+      // account/user changes here so the destination screen renders them
+      // immediately after the redirect.
+      const queryClient = getQueryClient();
+      const accountsCache = new AccountsCache(queryClient);
+      for (const account of result.changedAccounts) {
+        accountsCache.upsert(account);
+      }
+      if (result.updatedUser) {
+        new UserCache(queryClient).set(result.updatedUser);
+      }
+    } else {
       toast({
         title: 'Failed to claim the token',
         description: result.message,

--- a/apps/web-wallet/app/routes/_protected.tsx
+++ b/apps/web-wallet/app/routes/_protected.tsx
@@ -113,7 +113,6 @@ const ensureUserData = async (
     const accountRepository = new AccountRepository(
       agicashDbClient,
       encryption,
-      queryClient,
       getCashuWalletSeed,
       getSparkWalletMnemonic,
       './.spark-data',

--- a/apps/web-wallet/app/routes/api.lnurlp.callback.$userId.ts
+++ b/apps/web-wallet/app/routes/api.lnurlp.callback.$userId.ts
@@ -6,7 +6,6 @@
 import { Money } from '@agicash/money';
 import { agicashDbServer } from '~/features/agicash-db/database.server';
 import { LightningAddressService } from '~/features/receive/lightning-address-service';
-import { getQueryClient } from '~/features/shared/query-client';
 import type { Route } from './+types/api.lnurlp.callback.$userId';
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -36,11 +35,9 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const bypassAmountValidation =
     url.searchParams.get('bypassAmountValidation') === 'true';
 
-  const queryClient = getQueryClient();
   const lightningAddressService = new LightningAddressService(
     request,
     agicashDbServer,
-    queryClient,
     { bypassAmountValidation },
   );
 

--- a/apps/web-wallet/app/routes/api.lnurlp.verify.$encryptedQuoteData.ts
+++ b/apps/web-wallet/app/routes/api.lnurlp.verify.$encryptedQuoteData.ts
@@ -5,17 +5,14 @@
 
 import { agicashDbServer } from '~/features/agicash-db/database.server';
 import { LightningAddressService } from '~/features/receive/lightning-address-service';
-import { getQueryClient } from '~/features/shared/query-client';
 import type { Route } from './+types/api.lnurlp.verify.$encryptedQuoteData';
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const { encryptedQuoteData } = params;
 
-  const queryClient = getQueryClient();
   const lightningAddressService = new LightningAddressService(
     request,
     agicashDbServer,
-    queryClient,
   );
 
   const response =


### PR DESCRIPTION
Repositories and services no longer take a TanStack QueryClient; they run their underlying async actions directly and return Promises. This is a prerequisite for the stateless @agicash/wallet-sdk extraction, where the SDK holds no read cache and the web keeps TanStack Query.

The Breez wallet connection is the one piece that must still be held: connect() opens a stateful, resource-owning session (disconnect/free, event listeners, background loops, a storageDir DB), so there must be exactly one instance per wallet, not a fresh one per account load. It moves to a process-wide singleton (getSparkWallet, keyed by mnemonic/network/storageDir), cleared on signOut alongside queryClient.clear().

Everything else is a plain read fetched directly:
- Mint metadata (info/keysets/keys): getInitializedCashuWallet and account-service call the mint over HTTP directly (idempotent, nothing to leak). The web's mint *QueryOptions are untouched and still cache those reads for the settings form / token decode.
- Accounts / exchange rate: claim-cashu-token-service reads via accountRepository.getAllActive and ExchangeRateService directly.

claim-cashu-token-service no longer writes to the cache either: it returns the changed accounts + updated user, and the token route's clientLoader applies them.

Behavior note: the account-load path (getInitializedCashuWallet via toAccount) no longer shares the QueryClient mint cache, so it refetches mint metadata on each load; only the web's own mint reads stay cached. typecheck + biome clean; web/bolt11/ecies/cashu unit tests pass.